### PR TITLE
Suspend/coroutine data access + async r2dbc backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - name: Install libpq + libsqlite3 (for the Kotlin/Native cinterops)
         run: sudo apt-get update && sudo apt-get install -y libpq-dev libsqlite3-dev
@@ -37,13 +37,14 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      # JVM unit + integration tests. The integration tests use Testcontainers,
-      # which needs Docker (available on ubuntu-latest runners).
+      # JVM unit tests. korm-sqlite runs against an in-memory database (no Docker); it covers
+      # both the blocking and the suspend (offload) paths.
       - name: JVM tests
-        run: ./gradlew :korm-core:jvmTest --console=plain
+        run: ./gradlew :korm-core:jvmTest :korm-sqlite:jvmTest --console=plain
 
       # Native (libpq) tests against the Postgres service above. The host native test task
       # on a Linux runner is linuxX64Test (the modules now declare real native targets).
+      # korm-sqlite's native tests use an in-memory database (no Postgres needed).
       - name: Native tests
         env:
           KORM_DB_HOST: localhost
@@ -51,7 +52,7 @@ jobs:
           KORM_DB_NAME: postgres
           KORM_DB_USER: postgres
           KORM_DB_PASSWORD: password
-        run: ./gradlew :korm-core:linuxX64Test :korm-postgres:linuxX64Test --console=plain
+        run: ./gradlew :korm-core:linuxX64Test :korm-postgres:linuxX64Test :korm-sqlite:linuxX64Test --console=plain
 
       # The ktor integration libraries are libraries (no native exe link), so assemble
       # builds their JVM + native artifacts to verify they compile on every target.
@@ -67,11 +68,18 @@ jobs:
           :samples:sharding:jvmTest :samples:sharding:nativeTest
           --console=plain
 
+      # Async r2dbc backend (JVM-only) — end-to-end tests spin up their own Postgres via
+      # Testcontainers.
+      - name: r2dbc tests (Testcontainers, JVM)
+        run: ./gradlew :korm-r2dbc:jvmTest --console=plain
+
       # Postgres samples — JVM end-to-end tests spin up their own Postgres via Testcontainers.
+      # samples:r2dbc is the async variant of ktor-di.
       - name: Postgres sample tests (Testcontainers, JVM)
         run: >-
           ./gradlew
           :samples:ktor-di:jvmTest :samples:ktor-koin:jvmTest :samples:sqlite-cache:jvmTest
+          :samples:r2dbc:jvmTest
           --console=plain
 
       - name: Upload test reports
@@ -91,11 +99,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -119,11 +127,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - name: Install libpq (for the Kotlin/Native libpq cinterop)
         run: brew install libpq

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ val publishableModules = setOf(
     "korm-postgres",
     "korm-jdbc",
     "korm-sqlite",
+    "korm-r2dbc",
     "korm-ktor",
     "korm-ktor-di",
     "korm-ktor-koin",

--- a/korm-core/build.gradle.kts
+++ b/korm-core/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 
     jvm {
         testRuns["test"].executionTask.configure {

--- a/korm-core/src/commonMain/kotlin/ConnectionPool.kt
+++ b/korm-core/src/commonMain/kotlin/ConnectionPool.kt
@@ -1,0 +1,81 @@
+package io.github.knyazevs.korm
+
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+
+/**
+ * One pinned connection borrowed from a [ConnectionPool]: the per-connection
+ * [executor] plus the transaction primitives. The blocking [runPinned] and the
+ * suspend [runConnection] drive these the same way; only how they're scheduled
+ * differs.
+ */
+interface PinnedConnection {
+    val executor: SqlExecutor
+    fun begin()
+    fun commit()
+    fun rollback()
+    /** Returns the connection to the pool (and restores any per-borrow state). */
+    fun release()
+}
+
+/**
+ * The pooling seam shared by a backend's blocking [Database] and suspend
+ * [io.github.knyazevs.korm.database.SuspendDatabase]: ONE pool serves both paths
+ * (decision: no second suspend-only pool). A backend implements [acquire]; if its
+ * pool can hand out a connection without blocking (e.g. a Channel-based native pool),
+ * it overrides [acquireSuspending] for that free path — otherwise the default just
+ * offloads the blocking [acquire] to the IO dispatcher.
+ */
+interface ConnectionPool {
+    /** Borrows a connection, blocking until one is free. */
+    fun acquire(): PinnedConnection
+
+    /** Borrows a connection, suspending until one is free. */
+    suspend fun acquireSuspending(): PinnedConnection = withContext(ioDispatcher) { acquire() }
+}
+
+/**
+ * Blocking pinned-connection run: borrow, BEGIN/COMMIT/ROLLBACK around [block] when
+ * [transactional], always release. Backs [Database.usePinned].
+ */
+fun <R> ConnectionPool.runPinned(transactional: Boolean, block: (SqlExecutor) -> R): R {
+    val conn = acquire()
+    try {
+        if (!transactional) return block(conn.executor)
+        conn.begin()
+        return try {
+            block(conn.executor).also { conn.commit() }
+        } catch (e: Throwable) {
+            runCatching { conn.rollback() }
+            throw e
+        }
+    } finally {
+        conn.release()
+    }
+}
+
+/**
+ * Suspend pinned-connection run (offload strategy B): borrow without blocking, run
+ * the block via a [SuspendExecutorAdapter] that offloads each blocking driver call to
+ * [ioDispatcher]; BEGIN/COMMIT/ROLLBACK and release are offloaded too. Operations run
+ * sequentially, so the connection is never used concurrently. Cleanup runs under
+ * [NonCancellable] so a cancelled block still rolls back and releases. Backs
+ * [io.github.knyazevs.korm.database.SuspendDatabase.useConnection] for blocking drivers;
+ * a truly async backend (r2dbc) implements useConnection itself instead.
+ */
+suspend fun <R> ConnectionPool.runConnection(transactional: Boolean, block: suspend (SuspendSqlExecutor) -> R): R {
+    val conn = acquireSuspending()
+    try {
+        val exec = SuspendExecutorAdapter(conn.executor, ioDispatcher)
+        if (!transactional) return block(exec)
+        withContext(ioDispatcher) { conn.begin() }
+        return try {
+            block(exec).also { withContext(ioDispatcher) { conn.commit() } }
+        } catch (e: Throwable) {
+            withContext(NonCancellable + ioDispatcher) { runCatching { conn.rollback() } }
+            throw e
+        }
+    } finally {
+        withContext(NonCancellable + ioDispatcher) { conn.release() }
+    }
+}

--- a/korm-core/src/commonMain/kotlin/Join.kt
+++ b/korm-core/src/commonMain/kotlin/Join.kt
@@ -144,10 +144,15 @@ internal fun Table<*, *>.qualifiedName(dialect: Dialect): String {
 internal fun Join<*>.allColumns(): List<Column<*, *, *>> =
     tables.flatMap { it.getFieldDisplayNames().values }
 
-// Builds and runs the SELECT, reading each field positionally (columns are emitted
-// qualified, e.g. "users"."id", so colliding names don't clash).
-internal fun runSelect(exec: SqlExecutor, join: Join<*>, fields: List<Selectable<*>>): List<ResultRow> {
-    val builder = ParamBuilder(exec.dialect, exec.typeMapper, qualifyColumns = true)
+// Builds the SELECT SQL + params (columns are emitted qualified, e.g. "users"."id",
+// so colliding names don't clash). Pure — no I/O; the runners below execute it.
+private fun buildSelect(
+    join: Join<*>,
+    fields: List<Selectable<*>>,
+    dialect: Dialect,
+    typeMapper: TypeMapper,
+): Pair<String, Map<String, Any?>> {
+    val builder = ParamBuilder(dialect, typeMapper, qualifyColumns = true)
     val selectList = fields.joinToString(", ") { it.toSql(builder) }
     val from = StringBuilder(join.base.qualifiedName(builder.dialect))
     for (clause in join.clauses) {
@@ -158,8 +163,19 @@ internal fun runSelect(exec: SqlExecutor, join: Join<*>, fields: List<Selectable
     val groupBy = if (join.groupByCols.isEmpty()) ""
         else " GROUP BY ${join.groupByCols.joinToString(", ") { it.toSql(builder) }}"
     val having = join.havingExpr?.let { " HAVING ${it.toSql(builder)}" }.orEmpty()
-    val sql = "SELECT $distinct$selectList FROM $from$where$groupBy$having"
-    return exec.execute(sql, builder.params) { rs ->
-        ResultRow(fields.withIndex().associate { (i, f) -> fieldKey(f) to f.read(rs, i, exec.typeMapper) })
-    }
+    return "SELECT $distinct$selectList FROM $from$where$groupBy$having" to builder.params
+}
+
+// Reads each field positionally into a ResultRow.
+private fun mapRow(fields: List<Selectable<*>>, rs: ResultSet, typeMapper: TypeMapper): ResultRow =
+    ResultRow(fields.withIndex().associate { (i, f) -> fieldKey(f) to f.read(rs, i, typeMapper) })
+
+internal fun runSelect(exec: SqlExecutor, join: Join<*>, fields: List<Selectable<*>>): List<ResultRow> {
+    val (sql, params) = buildSelect(join, fields, exec.dialect, exec.typeMapper)
+    return exec.execute(sql, params) { rs -> mapRow(fields, rs, exec.typeMapper) }
+}
+
+internal suspend fun runSelect(exec: SuspendSqlExecutor, join: Join<*>, fields: List<Selectable<*>>): List<ResultRow> {
+    val (sql, params) = buildSelect(join, fields, exec.dialect, exec.typeMapper)
+    return exec.execute(sql, params) { rs -> mapRow(fields, rs, exec.typeMapper) }
 }

--- a/korm-core/src/commonMain/kotlin/Scope.kt
+++ b/korm-core/src/commonMain/kotlin/Scope.kt
@@ -2,7 +2,6 @@ package io.github.knyazevs.korm
 
 import io.github.knyazevs.korm.database.Database
 import io.github.knyazevs.korm.resultset.ResultSet
-import kotlinx.coroutines.withContext
 
 /**
  * The receiver inside a [transaction] / [autocommit] block. It pins one connection
@@ -40,11 +39,11 @@ class Scope<G : Catalog> internal constructor(private val exec: SqlExecutor) {
 
     /** Creates this table from its column definitions (`CREATE TABLE [IF NOT EXISTS]`). */
     fun <T : Entity> Table<G, T>.createTable(ifNotExists: Boolean = true) =
-        exec.executeUpdate(createTableSql(exec, ifNotExists))
+        exec.executeUpdate(createTableSql(exec.dialect, ifNotExists))
 
     /** Drops this table (`DROP TABLE [IF EXISTS]`). */
     fun <T : Entity> Table<G, T>.dropTable(ifExists: Boolean = true) =
-        exec.executeUpdate(dropTableSql(exec, ifExists))
+        exec.executeUpdate(dropTableSql(exec.dialect, ifExists))
 
     /** Runs the query, selecting the given fields (or all columns if none are given). */
     fun Join<G>.select(vararg fields: Selectable<*>): List<ResultRow> =
@@ -115,16 +114,3 @@ fun <G : Catalog, R> Database<G>.transaction(block: Scope<G>.() -> R): R =
  */
 fun <G : Catalog, R> Database<G>.autocommit(block: Scope<G>.() -> R): R =
     usePinned(transactional = false) { Scope<G>(it).block() }
-
-/**
- * Coroutine-friendly [transaction]: the blocking transaction runs on [Dispatchers.IO]
- * so the calling coroutine suspends instead of blocking its thread (e.g. a ktor worker).
- * The drivers are blocking, so this offloads work rather than doing async I/O; [block]
- * runs entirely on one IO thread for the transaction's duration.
- */
-suspend fun <G : Catalog, R> Database<G>.suspendTransaction(block: Scope<G>.() -> R): R =
-    withContext(ioDispatcher) { transaction(block) }
-
-/** Coroutine-friendly [autocommit]; see [suspendTransaction]. */
-suspend fun <G : Catalog, R> Database<G>.suspendAutocommit(block: Scope<G>.() -> R): R =
-    withContext(ioDispatcher) { autocommit(block) }

--- a/korm-core/src/commonMain/kotlin/SuspendExecutorAdapter.kt
+++ b/korm-core/src/commonMain/kotlin/SuspendExecutorAdapter.kt
@@ -1,0 +1,34 @@
+package io.github.knyazevs.korm
+
+import io.github.knyazevs.korm.resultset.ResultSet
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+/**
+ * Presents a blocking [SqlExecutor] as a [SuspendSqlExecutor] by offloading each call
+ * to [dispatcher] (the offload backend's strategy B). The driver stays blocking; this
+ * just keeps the calling coroutine from blocking its thread. A truly async backend
+ * (r2dbc) implements [SuspendSqlExecutor] natively instead of going through this.
+ */
+internal class SuspendExecutorAdapter(
+    private val sync: SqlExecutor,
+    private val dispatcher: CoroutineDispatcher,
+) : SuspendSqlExecutor {
+    override val dialect get() = sync.dialect
+    override val typeMapper get() = sync.typeMapper
+
+    override suspend fun <T> execute(sql: String, namedParameters: Map<String, Any?>, handler: (ResultSet) -> T): List<T> =
+        withContext(dispatcher) { sync.execute(sql, namedParameters, handler) }
+
+    override suspend fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T> =
+        withContext(dispatcher) { sync.execute(sql, paramSource, handler) }
+
+    override suspend fun execute(sql: String, namedParameters: Map<String, Any?>): Long =
+        withContext(dispatcher) { sync.execute(sql, namedParameters) }
+
+    override suspend fun execute(sql: String, paramSource: SqlParameterSource): Long =
+        withContext(dispatcher) { sync.execute(sql, paramSource) }
+
+    override suspend fun executeUpdate(sql: String, namedParameters: Map<String, Any?>) =
+        withContext(dispatcher) { sync.executeUpdate(sql, namedParameters) }
+}

--- a/korm-core/src/commonMain/kotlin/SuspendScope.kt
+++ b/korm-core/src/commonMain/kotlin/SuspendScope.kt
@@ -1,0 +1,111 @@
+package io.github.knyazevs.korm
+
+import io.github.knyazevs.korm.database.SuspendDatabase
+import io.github.knyazevs.korm.resultset.ResultSet
+
+/**
+ * The suspend counterpart of [Scope], the receiver inside a [suspendTransaction] /
+ * [suspendAutocommit] block. It pins one connection (via a [SuspendSqlExecutor]) and
+ * exposes the same table operations as [Scope], constrained to `Table<G, _>`, but as
+ * `suspend` functions — so the block may itself suspend (call other suspend code) while
+ * the connection stays pinned. Raw SQL run through [execute] / [executeUpdate] goes to
+ * the same pinned connection.
+ */
+class SuspendScope<G : Catalog> internal constructor(private val exec: SuspendSqlExecutor) {
+    private var savepointCounter = 0
+
+    /** Inserts [entity]; see [Scope.new]. */
+    suspend fun <T : Entity> Table<G, T>.new(entity: T, returning: Boolean = false): T? =
+        insert(entity, exec, returning)
+
+    /** Inserts all [entities] in one statement; see [Scope.new]. */
+    suspend fun <T : Entity> Table<G, T>.new(entities: List<T>, returning: Boolean = false): List<T> =
+        insertAll(entities, exec, returning)
+
+    /** Counts rows matching [query] (all rows by default). */
+    suspend fun <T : Entity> Table<G, T>.count(query: Query = Query()): Long = count(query, exec)
+
+    suspend fun <T : Entity> Table<G, T>.find(query: Query): List<T> = select(query, exec)
+    suspend fun <T : Entity> Table<G, T>.findById(id: Any): T? = selectById(id, exec)
+    suspend fun <T : Entity> Table<G, T>.all(): List<T> = selectAll(exec)
+    suspend fun <T : Entity> Table<G, T>.update(query: Query, entity: T) = updateRows(query, entity, exec)
+    suspend fun <T : Entity> Table<G, T>.deleteWhere(query: Query) = deleteRows(query, exec)
+    suspend fun <T : Entity> Table<G, T>.execSql(sql: String) = runRaw(sql, exec)
+
+    /** Creates this table from its column definitions (`CREATE TABLE [IF NOT EXISTS]`). */
+    suspend fun <T : Entity> Table<G, T>.createTable(ifNotExists: Boolean = true) =
+        exec.executeUpdate(createTableSql(exec.dialect, ifNotExists))
+
+    /** Drops this table (`DROP TABLE [IF EXISTS]`). */
+    suspend fun <T : Entity> Table<G, T>.dropTable(ifExists: Boolean = true) =
+        exec.executeUpdate(dropTableSql(exec.dialect, ifExists))
+
+    /** Runs the query, selecting the given fields (or all columns if none are given). */
+    suspend fun Join<G>.select(vararg fields: Selectable<*>): List<ResultRow> =
+        runSelect(exec, this, if (fields.isEmpty()) allColumns() else fields.toList())
+
+    /** Runs the query, mapping each [ResultRow] with [map] (a projection into your own type). */
+    suspend fun <R> Join<G>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
+        select(*fields).map(map)
+
+    /** Runs a two-table join, selecting the given fields (or all columns if none are given). */
+    suspend fun <A : Entity, B : Entity> JoinPair<G, A, B>.select(vararg fields: Selectable<*>): List<ResultRow> =
+        asJoin().select(*fields)
+
+    /** Runs a two-table join, mapping each [ResultRow] with [map]. */
+    suspend fun <A : Entity, B : Entity, R> JoinPair<G, A, B>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
+        asJoin().select(*fields, map = map)
+
+    /** Runs a two-table join, reconstructing both sides as a `Pair` of entities. */
+    suspend fun <A : Entity, B : Entity> JoinPair<G, A, B>.find(): List<Pair<A, B>> {
+        val aCols = left.getFieldDisplayNames()
+        val bCols = right.getFieldDisplayNames()
+        val rows = runSelect(exec, asJoin(), (aCols.values + bCols.values).toList())
+        return rows.map { row ->
+            left.factory(aCols.mapValues { (_, c) -> row.getOrNull(c) }.toMutableMap()) to
+                right.factory(bCols.mapValues { (_, c) -> row.getOrNull(c) }.toMutableMap())
+        }
+    }
+
+    /** Runs a raw query on the pinned connection, mapping each row with [handler]. */
+    suspend fun <R> execute(sql: String, params: Map<String, Any?> = emptyMap(), handler: (ResultSet) -> R): List<R> =
+        exec.execute(sql, params, handler)
+
+    /** Runs raw SQL on the pinned connection, returning the row/update count. */
+    suspend fun execute(sql: String, params: Map<String, Any?> = emptyMap()): Long = exec.execute(sql, params)
+
+    /** Runs a raw statement (DDL/DML) on the pinned connection. */
+    suspend fun executeUpdate(sql: String, params: Map<String, Any?> = emptyMap()) = exec.executeUpdate(sql, params)
+
+    /**
+     * Runs [block] inside a SAVEPOINT on the same connection: if it throws, only its
+     * work is rolled back (ROLLBACK TO SAVEPOINT) and the exception propagates; the
+     * enclosing transaction may continue if the caller catches it.
+     */
+    suspend fun <R> savepoint(block: suspend SuspendScope<G>.() -> R): R {
+        val name = "korm_sp_${savepointCounter++}"
+        exec.executeUpdate("SAVEPOINT $name")
+        return try {
+            block().also { exec.executeUpdate("RELEASE SAVEPOINT $name") }
+        } catch (e: Throwable) {
+            exec.executeUpdate("ROLLBACK TO SAVEPOINT $name")
+            throw e
+        }
+    }
+}
+
+/**
+ * Runs [block] in a transaction on a pinned connection: COMMIT when it returns,
+ * ROLLBACK if it throws. The suspend counterpart of [transaction]; [block] may itself
+ * suspend while the connection stays pinned. Whether this is true async or a blocking
+ * driver offloaded to a dispatcher depends on the backend's [SuspendDatabase.useConnection].
+ */
+suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendTransaction(block: suspend SuspendScope<G>.() -> R): R =
+    useConnection(transactional = true) { SuspendScope<G>(it).block() }
+
+/**
+ * Runs [block] on a pinned connection in autocommit (no surrounding transaction) — the
+ * suspend counterpart of [autocommit], the cheap path for reads / single statements.
+ */
+suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendAutocommit(block: suspend SuspendScope<G>.() -> R): R =
+    useConnection(transactional = false) { SuspendScope<G>(it).block() }

--- a/korm-core/src/commonMain/kotlin/SuspendSqlExecutor.kt
+++ b/korm-core/src/commonMain/kotlin/SuspendSqlExecutor.kt
@@ -1,0 +1,26 @@
+package io.github.knyazevs.korm
+
+import io.github.knyazevs.korm.resultset.ResultSet
+
+/**
+ * The suspend mirror of [SqlExecutor]: runs SQL against one connection inside a
+ * [io.github.knyazevs.korm.database.SuspendDatabase.useConnection] block. The
+ * [dialect] and [typeMapper] are the same seams used to render statements and
+ * convert values.
+ *
+ * Backends provide their own implementation: the offload backends wrap a blocking
+ * [SqlExecutor] and `withContext(ioDispatcher)` each call; a truly async backend
+ * (e.g. r2dbc) implements it natively. It is a SIBLING of [SqlExecutor], not a
+ * subtype — one object can't be both (a `suspend` and a non-`suspend` `execute`
+ * with the same parameters clash).
+ */
+interface SuspendSqlExecutor {
+    val dialect: Dialect
+    val typeMapper: TypeMapper
+
+    suspend fun <T> execute(sql: String, namedParameters: Map<String, Any?> = emptyMap(), handler: (ResultSet) -> T): List<T>
+    suspend fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T>
+    suspend fun execute(sql: String, namedParameters: Map<String, Any?> = emptyMap()): Long
+    suspend fun execute(sql: String, paramSource: SqlParameterSource): Long
+    suspend fun executeUpdate(sql: String, namedParameters: Map<String, Any?> = emptyMap())
+}

--- a/korm-core/src/commonMain/kotlin/Table.kt
+++ b/korm-core/src/commonMain/kotlin/Table.kt
@@ -9,7 +9,13 @@ private val logger = KotlinLogging.logger {}
  * A table definition: its [Meta] (name/schema) and columns, tagged with the catalog
  * [G] it belongs to. A table holds no connection — operations run inside a
  * [transaction] / [autocommit] scope (or [Scope]) which supplies the pinned
- * [SqlExecutor]. The operation methods are `internal`; call them through [Scope].
+ * [SqlExecutor], or inside their suspend counterparts via [SuspendScope]. The
+ * operation methods are `internal`; call them through [Scope] / [SuspendScope].
+ *
+ * Each operation is built in two parts: a pure `*Sql` helper that renders SQL +
+ * params (no I/O), and a thin runner. The blocking runner (taking [SqlExecutor])
+ * and the suspend runner (taking [SuspendSqlExecutor]) share the same `*Sql`
+ * helper and differ only in how they execute it.
  */
 abstract class Table<G: Catalog, T: Entity>(val meta: Meta, val factory: (MutableMap<String, Any?>) -> T) {
     private val fieldDisplayName: MutableMap<String, Column<*, *, *>> = mutableMapOf()
@@ -28,23 +34,23 @@ abstract class Table<G: Catalog, T: Entity>(val meta: Meta, val factory: (Mutabl
         fieldDisplayName[fieldName] = column
     }
 
-    private fun getColumnNames(exec: SqlExecutor): List<String> {
+    private fun getColumnNames(dialect: Dialect): List<String> {
         logger.trace { "get column names" }
-        return fieldDisplayName.map { exec.dialect.quoteIdentifier(it.value.name) }
+        return fieldDisplayName.map { dialect.quoteIdentifier(it.value.name) }
     }
 
-    private fun qualifiedTableName(exec: SqlExecutor): String = qualifiedName(exec.dialect)
+    private fun qualifiedTableName(dialect: Dialect): String = qualifiedName(dialect)
 
-    private fun paramBuilder(exec: SqlExecutor) = ParamBuilder(exec.dialect, exec.typeMapper)
+    private fun paramBuilder(dialect: Dialect, typeMapper: TypeMapper) = ParamBuilder(dialect, typeMapper)
 
     // find/findById/all SELECT every column in fieldDisplayName order, so the result columns
     // line up positionally — read them by index straight into the entity's field map, with no
     // per-row name→index map or intermediate allocations.
-    private fun mapToDao(rs: ResultSet, exec: SqlExecutor): T {
+    private fun mapToDao(rs: ResultSet, typeMapper: TypeMapper): T {
         val fields = HashMap<String, Any?>(fieldDisplayName.size * 2)
         var index = 0
         for ((fieldName, column) in fieldDisplayName) {
-            fields[fieldName] = exec.typeMapper.fromResult(rs, index, column.columnType)
+            fields[fieldName] = typeMapper.fromResult(rs, index, column.columnType)
             index++
         }
         return factory(fields)
@@ -64,120 +70,203 @@ abstract class Table<G: Catalog, T: Entity>(val meta: Meta, val factory: (Mutabl
         }
     }
 
-    internal fun runRaw(sql: String, exec: SqlExecutor) {
-        exec.execute(sql = sql.trimIndent())
-    }
+    // ---- pure SQL builders (no I/O) — shared by the blocking and suspend runners ----
 
-    internal fun selectById(id: Any, exec: SqlExecutor): T? {
+    private fun selectByIdSql(id: Any, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
         val pk = primaryKey.singleOrNull()
             ?: throw IllegalStateException(
                 "findById requires a single-column primary key on ${meta.tableName}; " +
                     "use find(...) for composite (or missing) keys",
             )
-        val builder = paramBuilder(exec)
+        val builder = paramBuilder(dialect, typeMapper)
         val idPlaceholder = builder.bind(id)
-        val sql = "SELECT ${this.getColumnNames(exec).joinToString ( ", " )} FROM ${qualifiedTableName(exec)} WHERE ${exec.dialect.quoteIdentifier(pk.name)} = $idPlaceholder"
-        return exec.execute<T>(sql = sql.trimIndent(), namedParameters = builder.params) { rs: ResultSet ->
-            this.mapToDao(rs = rs, exec = exec)
-        }.firstOrNull()
+        val sql = "SELECT ${getColumnNames(dialect).joinToString(", ")} FROM ${qualifiedTableName(dialect)} WHERE ${dialect.quoteIdentifier(pk.name)} = $idPlaceholder"
+        return sql.trimIndent() to builder.params
+    }
+
+    private fun selectSql(query: Query, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
+        val builder = paramBuilder(dialect, typeMapper)
+        val queryStr = query.toSql(builder)
+        val sql = "SELECT ${getColumnNames(dialect).joinToString(", ")} FROM ${qualifiedTableName(dialect)} $queryStr"
+        return sql.trimIndent() to builder.params
+    }
+
+    private fun selectAllSql(dialect: Dialect): String =
+        "SELECT ${getColumnNames(dialect).joinToString(", ")} FROM ${qualifiedTableName(dialect)}".trimIndent()
+
+    private fun insertSql(entity: T, dialect: Dialect, typeMapper: TypeMapper, returning: Boolean): Pair<String, Map<String, Any?>> {
+        val builder = paramBuilder(dialect, typeMapper)
+        val generatedFields = generateFieldToMap(entity)
+        val columns = generatedFields.joinToString(", ") { dialect.quoteIdentifier(it.first) }
+        val values = generatedFields.joinToString(", ") { builder.bind(it.second) }
+        val base = "INSERT INTO ${qualifiedTableName(dialect)} ($columns) VALUES ($values)"
+        val sql = if (returning) "$base RETURNING ${getColumnNames(dialect).joinToString(", ")}" else base
+        return sql to builder.params
+    }
+
+    private fun insertAllSql(entities: List<T>, dialect: Dialect, typeMapper: TypeMapper, returning: Boolean): Pair<String, Map<String, Any?>> {
+        val builder = paramBuilder(dialect, typeMapper)
+        val columns = fieldDisplayName.values.joinToString(", ") { dialect.quoteIdentifier(it.name) }
+        val tuples = entities.joinToString(", ") { entity ->
+            "(${generateFieldToMap(entity).joinToString(", ") { builder.bind(it.second) }})"
+        }
+        val base = "INSERT INTO ${qualifiedTableName(dialect)} ($columns) VALUES $tuples"
+        val sql = if (returning) "$base RETURNING ${getColumnNames(dialect).joinToString(", ")}" else base
+        return sql to builder.params
+    }
+
+    private fun countSql(query: Query, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
+        val builder = paramBuilder(dialect, typeMapper)
+        val queryStr = query.toSql(builder)
+        val sql = "SELECT COUNT(*) FROM ${qualifiedTableName(dialect)} $queryStr"
+        return sql.trimIndent() to builder.params
+    }
+
+    private fun updateSql(query: Query, entity: T, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
+        val builder = paramBuilder(dialect, typeMapper)
+        val updateFields = generatePresentFields(entity)
+        require(updateFields.isNotEmpty()) {
+            "update() needs at least one field set on the entity to update ${qualifiedTableName(dialect)}"
+        }
+        val generatedUpdateFields = updateFields
+            .joinToString(", ") { "${dialect.quoteIdentifier(it.first)}=${builder.bind(it.second)}" }
+        val queryStr = query.toSql(builder)
+        val sql = """
+            UPDATE ${qualifiedTableName(dialect)}
+            SET $generatedUpdateFields
+           $queryStr
+        """
+        return sql.trimIndent() to builder.params
+    }
+
+    private fun deleteSql(query: Query, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
+        val builder = paramBuilder(dialect, typeMapper)
+        val queryStr = query.toSql(builder)
+        val sql = "DELETE FROM ${qualifiedTableName(dialect)} $queryStr"
+        return sql.trimIndent() to builder.params
+    }
+
+    internal fun createTableSql(dialect: Dialect, ifNotExists: Boolean): String {
+        val columns = fieldDisplayName.values.joinToString(",\n    ") { col ->
+            val nullability = if (col.nullable) "" else " NOT NULL"
+            "${dialect.quoteIdentifier(col.name)} ${dialect.sqlType(col.columnType)}$nullability"
+        }
+        val pkClause = primaryKey
+            .takeIf { it.isNotEmpty() }
+            ?.joinToString(", ") { dialect.quoteIdentifier(it.name) }
+            ?.let { ",\n    PRIMARY KEY ($it)" }
+            .orEmpty()
+        val exists = if (ifNotExists) "IF NOT EXISTS " else ""
+        return "CREATE TABLE $exists${qualifiedTableName(dialect)} (\n    $columns$pkClause\n)"
+    }
+
+    internal fun dropTableSql(dialect: Dialect, ifExists: Boolean): String =
+        "DROP TABLE ${if (ifExists) "IF EXISTS " else ""}${qualifiedTableName(dialect)}"
+
+    // ---- blocking runners (called by Scope) ----
+
+    internal fun runRaw(sql: String, exec: SqlExecutor) {
+        exec.execute(sql = sql.trimIndent())
+    }
+
+    internal fun selectById(id: Any, exec: SqlExecutor): T? {
+        val (sql, params) = selectByIdSql(id, exec.dialect, exec.typeMapper)
+        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
     }
 
     internal fun select(query: Query, exec: SqlExecutor): List<T> {
-        val builder = paramBuilder(exec)
-        val queryStr = query.toSql(builder)
-        val sql = "SELECT ${this.getColumnNames(exec).joinToString ( ", " )} FROM ${qualifiedTableName(exec)} $queryStr"
-        return exec.execute(sql = sql.trimIndent(), namedParameters = builder.params) { rs: ResultSet ->
-            this.mapToDao(rs = rs, exec = exec)
-        }
+        val (sql, params) = selectSql(query, exec.dialect, exec.typeMapper)
+        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }
     }
 
-    internal fun selectAll(exec: SqlExecutor): List<T> {
-        val sql = "SELECT ${this.getColumnNames(exec).joinToString ( ", " )} FROM ${qualifiedTableName(exec)}"
-        return exec.execute(sql = sql.trimIndent()) { rs: ResultSet ->
-            this.mapToDao(rs = rs, exec = exec)
-        }
-    }
+    internal fun selectAll(exec: SqlExecutor): List<T> =
+        exec.execute(selectAllSql(exec.dialect)) { rs -> mapToDao(rs, exec.typeMapper) }
 
     internal fun insert(entity: T, exec: SqlExecutor, returning: Boolean): T? {
-        val builder = paramBuilder(exec)
-        val generatedFields = this.generateFieldToMap(entity)
-        val columns = generatedFields.joinToString(", ") { exec.dialect.quoteIdentifier(it.first) }
-        val values = generatedFields.joinToString(", ") { builder.bind(it.second) }
-        val base = "INSERT INTO ${qualifiedTableName(exec)} ($columns) VALUES ($values)"
+        val (sql, params) = insertSql(entity, exec.dialect, exec.typeMapper, returning)
         if (!returning) {
-            exec.executeUpdate(sql = base, namedParameters = builder.params)
+            exec.executeUpdate(sql = sql, namedParameters = params)
             return entity
         }
-        val sql = "$base RETURNING ${getColumnNames(exec).joinToString(", ")}"
-        return exec.execute(sql = sql, namedParameters = builder.params) { rs ->
-            this.mapToDao(rs = rs, exec = exec)
-        }.firstOrNull()
+        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
     }
 
     internal fun insertAll(entities: List<T>, exec: SqlExecutor, returning: Boolean): List<T> {
         if (entities.isEmpty()) return emptyList()
-        val builder = paramBuilder(exec)
-        val columns = this.fieldDisplayName.values.joinToString(", ") { exec.dialect.quoteIdentifier(it.name) }
-        val tuples = entities.joinToString(", ") { entity ->
-            "(${generateFieldToMap(entity).joinToString(", ") { builder.bind(it.second) }})"
-        }
-        val base = "INSERT INTO ${qualifiedTableName(exec)} ($columns) VALUES $tuples"
+        val (sql, params) = insertAllSql(entities, exec.dialect, exec.typeMapper, returning)
         if (!returning) {
-            exec.executeUpdate(sql = base, namedParameters = builder.params)
+            exec.executeUpdate(sql = sql, namedParameters = params)
             return entities
         }
-        val sql = "$base RETURNING ${getColumnNames(exec).joinToString(", ")}"
-        return exec.execute(sql = sql, namedParameters = builder.params) { rs ->
-            this.mapToDao(rs = rs, exec = exec)
-        }
+        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }
     }
 
     internal fun count(query: Query, exec: SqlExecutor): Long {
-        val builder = paramBuilder(exec)
-        val queryStr = query.toSql(builder)
-        val sql = "SELECT COUNT(*) FROM ${qualifiedTableName(exec)} $queryStr"
-        return exec.execute(sql.trimIndent(), builder.params) { rs -> rs.getLong(0) ?: 0L }.firstOrNull() ?: 0L
+        val (sql, params) = countSql(query, exec.dialect, exec.typeMapper)
+        return exec.execute(sql, params) { rs -> rs.getLong(0) ?: 0L }.firstOrNull() ?: 0L
     }
-
-    internal fun createTableSql(exec: SqlExecutor, ifNotExists: Boolean): String {
-        val columns = fieldDisplayName.values.joinToString(",\n    ") { col ->
-            val nullability = if (col.nullable) "" else " NOT NULL"
-            "${exec.dialect.quoteIdentifier(col.name)} ${exec.dialect.sqlType(col.columnType)}$nullability"
-        }
-        val pkClause = primaryKey
-            .takeIf { it.isNotEmpty() }
-            ?.joinToString(", ") { exec.dialect.quoteIdentifier(it.name) }
-            ?.let { ",\n    PRIMARY KEY ($it)" }
-            .orEmpty()
-        val exists = if (ifNotExists) "IF NOT EXISTS " else ""
-        return "CREATE TABLE $exists${qualifiedTableName(exec)} (\n    $columns$pkClause\n)"
-    }
-
-    internal fun dropTableSql(exec: SqlExecutor, ifExists: Boolean): String =
-        "DROP TABLE ${if (ifExists) "IF EXISTS " else ""}${qualifiedTableName(exec)}"
 
     internal fun updateRows(query: Query, entity: T, exec: SqlExecutor) {
-        val builder = paramBuilder(exec)
-        val updateFields = this.generatePresentFields(entity)
-        require(updateFields.isNotEmpty()) {
-            "update() needs at least one field set on the entity to update ${qualifiedTableName(exec)}"
-        }
-        val generatedUpdateFields = updateFields
-            .joinToString(", ") { "${exec.dialect.quoteIdentifier(it.first)}=${builder.bind(it.second)}" }
-        val queryStr = query.toSql(builder)
-        val sql = """
-            UPDATE ${qualifiedTableName(exec)}
-            SET $generatedUpdateFields
-           $queryStr
-        """
-        exec.executeUpdate(sql = sql.trimIndent(), namedParameters = builder.params)
+        val (sql, params) = updateSql(query, entity, exec.dialect, exec.typeMapper)
+        exec.executeUpdate(sql = sql, namedParameters = params)
     }
 
     internal fun deleteRows(query: Query, exec: SqlExecutor) {
-        val builder = paramBuilder(exec)
-        val queryStr = query.toSql(builder)
-        val sql = "DELETE FROM ${qualifiedTableName(exec)} $queryStr"
-        exec.executeUpdate(sql = sql.trimIndent(), namedParameters = builder.params)
+        val (sql, params) = deleteSql(query, exec.dialect, exec.typeMapper)
+        exec.executeUpdate(sql = sql, namedParameters = params)
+    }
+
+    // ---- suspend runners (called by SuspendScope) — same *Sql helpers, suspend execution ----
+
+    internal suspend fun runRaw(sql: String, exec: SuspendSqlExecutor) {
+        exec.execute(sql = sql.trimIndent())
+    }
+
+    internal suspend fun selectById(id: Any, exec: SuspendSqlExecutor): T? {
+        val (sql, params) = selectByIdSql(id, exec.dialect, exec.typeMapper)
+        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+    }
+
+    internal suspend fun select(query: Query, exec: SuspendSqlExecutor): List<T> {
+        val (sql, params) = selectSql(query, exec.dialect, exec.typeMapper)
+        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }
+    }
+
+    internal suspend fun selectAll(exec: SuspendSqlExecutor): List<T> =
+        exec.execute(selectAllSql(exec.dialect)) { rs -> mapToDao(rs, exec.typeMapper) }
+
+    internal suspend fun insert(entity: T, exec: SuspendSqlExecutor, returning: Boolean): T? {
+        val (sql, params) = insertSql(entity, exec.dialect, exec.typeMapper, returning)
+        if (!returning) {
+            exec.executeUpdate(sql = sql, namedParameters = params)
+            return entity
+        }
+        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+    }
+
+    internal suspend fun insertAll(entities: List<T>, exec: SuspendSqlExecutor, returning: Boolean): List<T> {
+        if (entities.isEmpty()) return emptyList()
+        val (sql, params) = insertAllSql(entities, exec.dialect, exec.typeMapper, returning)
+        if (!returning) {
+            exec.executeUpdate(sql = sql, namedParameters = params)
+            return entities
+        }
+        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }
+    }
+
+    internal suspend fun count(query: Query, exec: SuspendSqlExecutor): Long {
+        val (sql, params) = countSql(query, exec.dialect, exec.typeMapper)
+        return exec.execute(sql, params) { rs -> rs.getLong(0) ?: 0L }.firstOrNull() ?: 0L
+    }
+
+    internal suspend fun updateRows(query: Query, entity: T, exec: SuspendSqlExecutor) {
+        val (sql, params) = updateSql(query, entity, exec.dialect, exec.typeMapper)
+        exec.executeUpdate(sql = sql, namedParameters = params)
+    }
+
+    internal suspend fun deleteRows(query: Query, exec: SuspendSqlExecutor) {
+        val (sql, params) = deleteSql(query, exec.dialect, exec.typeMapper)
+        exec.executeUpdate(sql = sql, namedParameters = params)
     }
 
     /**

--- a/korm-core/src/commonMain/kotlin/database/SuspendDatabase.kt
+++ b/korm-core/src/commonMain/kotlin/database/SuspendDatabase.kt
@@ -1,0 +1,24 @@
+package io.github.knyazevs.korm.database
+
+import io.github.knyazevs.korm.Catalog
+import io.github.knyazevs.korm.SuspendSqlExecutor
+
+/**
+ * The suspend counterpart of [Database], tagged with the [Catalog] [G] it connects to.
+ *
+ * It is a SIBLING of [Database], NOT a subtype: a truly async backend (e.g. r2dbc)
+ * cannot provide the blocking [Database.usePinned], so the two hierarchies stand
+ * apart. A blocking backend (JDBC/SQLite) may implement BOTH; an async backend
+ * implements only this one.
+ */
+interface SuspendDatabase<out G : Catalog> : AutoCloseable {
+    /**
+     * Pins one connection for the duration of [block]; the [SuspendSqlExecutor] passed
+     * to it routes every statement to that connection. Wraps BEGIN/COMMIT/ROLLBACK when
+     * [transactional] is true, otherwise runs in autocommit. Backend-specific.
+     */
+    suspend fun <R> useConnection(transactional: Boolean, block: suspend (SuspendSqlExecutor) -> R): R
+
+    /** Closes the underlying connection(s); the database is unusable afterwards. */
+    override fun close()
+}

--- a/korm-core/src/commonTest/kotlin/DatabaseMock.kt
+++ b/korm-core/src/commonTest/kotlin/DatabaseMock.kt
@@ -2,10 +2,12 @@ import io.github.knyazevs.korm.SqlExecutor
 import io.github.knyazevs.korm.SqlParameterSource
 import io.github.knyazevs.korm.StandardDialect
 import io.github.knyazevs.korm.StandardTypeMapper
+import io.github.knyazevs.korm.SuspendSqlExecutor
 import io.github.knyazevs.korm.database.Database
+import io.github.knyazevs.korm.database.SuspendDatabase
 import io.github.knyazevs.korm.resultset.ResultSet
 
-class DatabaseMock: Database<Nothing> {
+class DatabaseMock: Database<Nothing>, SuspendDatabase<Nothing> {
 
     override val dialect = StandardDialect
     override val typeMapper = StandardTypeMapper
@@ -13,6 +15,12 @@ class DatabaseMock: Database<Nothing> {
     // The mock records SQL rather than pinning a real connection, so it just runs
     // the block against itself (BEGIN/COMMIT are no-ops here).
     override fun <R> usePinned(transactional: Boolean, block: (SqlExecutor) -> R): R = block(this)
+
+    // Suspend path: hand the block a tiny SuspendSqlExecutor that delegates to this mock's
+    // recording. A separate object (not `this`) because a class can't implement both
+    // SqlExecutor and SuspendSqlExecutor — their execute() overloads clash.
+    override suspend fun <R> useConnection(transactional: Boolean, block: suspend (SuspendSqlExecutor) -> R): R =
+        block(SuspendMockExecutor(this))
 
     override fun close() = Unit
 
@@ -48,4 +56,25 @@ class DatabaseMock: Database<Nothing> {
         internalSql = sql
         internalParams = namedParameters
     }
+}
+
+// Mirrors DatabaseMock onto the suspend executor surface by delegating to its blocking methods.
+private class SuspendMockExecutor(private val mock: DatabaseMock) : SuspendSqlExecutor {
+    override val dialect get() = mock.dialect
+    override val typeMapper get() = mock.typeMapper
+
+    override suspend fun <T> execute(sql: String, namedParameters: Map<String, Any?>, handler: (ResultSet) -> T): List<T> =
+        mock.execute(sql, namedParameters, handler)
+
+    override suspend fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T> =
+        mock.execute(sql, paramSource, handler)
+
+    override suspend fun execute(sql: String, namedParameters: Map<String, Any?>): Long =
+        mock.execute(sql, namedParameters)
+
+    override suspend fun execute(sql: String, paramSource: SqlParameterSource): Long =
+        mock.execute(sql, paramSource)
+
+    override suspend fun executeUpdate(sql: String, namedParameters: Map<String, Any?>) =
+        mock.executeUpdate(sql, namedParameters)
 }

--- a/korm-core/src/commonTest/kotlin/SuspendTest.kt
+++ b/korm-core/src/commonTest/kotlin/SuspendTest.kt
@@ -10,7 +10,7 @@ class SuspendTest {
 
     @Test
     fun suspendTransactionRunsTheBlock() = runTest {
-        TableTest.db.suspendTransaction {
+        TableTest.suspendDb.suspendTransaction {
             TestTable.findById(Uuid.random())
         }
         assertTrue(TableTest.databaseMockObj.internalSql.contains("SELECT"))
@@ -18,7 +18,7 @@ class SuspendTest {
 
     @Test
     fun suspendAutocommitReturnsValue() = runTest {
-        val result: List<TestEntity> = TableTest.db.suspendAutocommit { TestTable.all() }
+        val result: List<TestEntity> = TableTest.suspendDb.suspendAutocommit { TestTable.all() }
         assertEquals(emptyList(), result)
         assertTrue(TableTest.databaseMockObj.internalSql.contains("SELECT"))
     }

--- a/korm-core/src/commonTest/kotlin/TableTest.kt
+++ b/korm-core/src/commonTest/kotlin/TableTest.kt
@@ -2,6 +2,7 @@ import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import kotlin.uuid.Uuid
 import io.github.knyazevs.korm.*
 import io.github.knyazevs.korm.database.Database
+import io.github.knyazevs.korm.database.SuspendDatabase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -362,6 +363,9 @@ class TableTest {
         // Same instance, viewed as Database<TestCatalog> (covariance: Database<Nothing>
         // <: Database<TestCatalog>) so transaction { } resolves the catalog tag.
         val db: Database<TestCatalog> = databaseMockObj
+
+        // Same instance, viewed as SuspendDatabase<TestCatalog>, so suspendTransaction { } resolves the tag.
+        val suspendDb: SuspendDatabase<TestCatalog> = databaseMockObj
 
         fun remoteNewLinesAndSpaces(value: String): String {
             return value.replace("\n", "").replace(" ", "")

--- a/korm-core/src/jvmMain/kotlin/IoDispatcher.jvm.kt
+++ b/korm-core/src/jvmMain/kotlin/IoDispatcher.jvm.kt
@@ -1,6 +1,15 @@
 package io.github.knyazevs.korm
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.Executors
 
-internal actual val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+/**
+ * Offload dispatcher for the blocking JDBC drivers behind suspend transactions.
+ * Backed by VIRTUAL THREADS (Loom, requires JDK 21+): a coroutine that blocks on a
+ * driver call unmounts its carrier thread, so blocking is cheap and concurrency is
+ * bounded only by the connection pool — not by a fixed thread pool. This is what makes
+ * the offload (strategy B) path scale without a truly async driver.
+ */
+internal actual val ioDispatcher: CoroutineDispatcher =
+    Executors.newVirtualThreadPerTaskExecutor().asCoroutineDispatcher()

--- a/korm-jdbc/build.gradle.kts
+++ b/korm-jdbc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 
     jvm {
         testRuns["test"].executionTask.configure {

--- a/korm-jdbc/src/jvmMain/kotlin/io/github/knyazevs/korm/jdbc/JdbcDatabase.kt
+++ b/korm-jdbc/src/jvmMain/kotlin/io/github/knyazevs/korm/jdbc/JdbcDatabase.kt
@@ -2,12 +2,18 @@ package io.github.knyazevs.korm.jdbc
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import io.github.knyazevs.korm.ConnectionPool
 import io.github.knyazevs.korm.Dialect
+import io.github.knyazevs.korm.PinnedConnection
 import io.github.knyazevs.korm.SqlExecutor
 import io.github.knyazevs.korm.SqlParameterSource
+import io.github.knyazevs.korm.SuspendSqlExecutor
 import io.github.knyazevs.korm.TypeMapper
 import io.github.knyazevs.korm.database.Database
+import io.github.knyazevs.korm.database.SuspendDatabase
 import io.github.knyazevs.korm.resultset.ResultSet
+import io.github.knyazevs.korm.runConnection
+import io.github.knyazevs.korm.runPinned
 import io.github.knyazevs.korm.sqlException
 import java.sql.Connection
 import java.sql.PreparedStatement
@@ -46,7 +52,7 @@ open class JdbcDatabase(
     private val wrap: ResultSetWrapper,
     private val translate: SqlExceptionTranslator = StandardSqlExceptionTranslator,
     connectionInitSql: String? = null,
-) : Database<Nothing> {
+) : Database<Nothing>, SuspendDatabase<Nothing> {
 
     private val ds: HikariDataSource = HikariDataSource(HikariConfig().apply {
         this.jdbcUrl = jdbcUrl
@@ -55,6 +61,13 @@ open class JdbcDatabase(
         this.maximumPoolSize = poolSize
         if (connectionInitSql != null) this.connectionInitSql = connectionInitSql
     })
+
+    // One pool, two entry points: usePinned (blocking) and useConnection (suspend) both
+    // run on it. acquireSuspending uses the default (offload the blocking checkout).
+    private val pool = object : ConnectionPool {
+        override fun acquire(): PinnedConnection =
+            JdbcPinnedConnection(ds.connection, dialect, typeMapper, wrap, translate)
+    }
 
     override fun close() = ds.close()
 
@@ -78,29 +91,44 @@ open class JdbcDatabase(
         ds.connection.use { executor(it).executeUpdate(sql, namedParameters) }
 
     override fun <R> usePinned(transactional: Boolean, block: (SqlExecutor) -> R): R =
-        ds.connection.use { conn ->
-            val exec = executor(conn)
-            if (!transactional) return@use block(exec)
-            val previousAutoCommit = conn.autoCommit
-            conn.autoCommit = false
-            try {
-                val result = block(exec)
-                translateSql { conn.commit() }
-                result
-            } catch (e: Throwable) {
-                runCatching { conn.rollback() }
-                throw e
-            } finally {
-                runCatching { conn.autoCommit = previousAutoCommit }
-            }
-        }
+        pool.runPinned(transactional, block)
 
-    private inline fun <T> translateSql(block: () -> T): T =
+    override suspend fun <R> useConnection(transactional: Boolean, block: suspend (SuspendSqlExecutor) -> R): R =
+        pool.runConnection(transactional, block)
+}
+
+/** A [PinnedConnection] over one borrowed JDBC connection. */
+private class JdbcPinnedConnection(
+    private val conn: Connection,
+    dialect: Dialect,
+    typeMapper: TypeMapper,
+    wrap: ResultSetWrapper,
+    private val translate: SqlExceptionTranslator,
+) : PinnedConnection {
+    override val executor: SqlExecutor = JdbcExecutor(conn, dialect, typeMapper, wrap, translate)
+    private var previousAutoCommit = true
+
+    override fun begin() {
+        previousAutoCommit = conn.autoCommit
+        conn.autoCommit = false
+    }
+
+    override fun commit() {
         try {
-            block()
+            conn.commit()
         } catch (e: SQLException) {
             throw translate(e)
         }
+    }
+
+    override fun rollback() {
+        conn.rollback()
+    }
+
+    override fun release() {
+        runCatching { conn.autoCommit = previousAutoCommit }
+        conn.close()
+    }
 }
 
 /** An [SqlExecutor] bound to one already-open JDBC connection. */

--- a/korm-ktor-di/build.gradle.kts
+++ b/korm-ktor-di/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 val ktorVersion = "3.5.0"
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 
     jvm {
         testRuns["test"].executionTask.configure {

--- a/korm-ktor-di/src/commonMain/kotlin/Dependencies.kt
+++ b/korm-ktor-di/src/commonMain/kotlin/Dependencies.kt
@@ -1,8 +1,8 @@
 package io.github.knyazevs.korm.ktor.di
 
 import io.github.knyazevs.korm.Catalog
-import io.github.knyazevs.korm.Scope
-import io.github.knyazevs.korm.database.Database
+import io.github.knyazevs.korm.SuspendScope
+import io.github.knyazevs.korm.database.SuspendDatabase
 import io.github.knyazevs.korm.ktor.KormHandle
 import io.github.knyazevs.korm.suspendAutocommit
 import io.github.knyazevs.korm.suspendTransaction
@@ -11,26 +11,26 @@ import io.ktor.server.plugins.di.dependencies
 import io.ktor.server.plugins.di.resolve
 
 /**
- * Resolves the [Database] for catalog [G] from Ktor's built-in DI, wrapped in a [KormHandle].
- * Register it with the matching parameterized type so the catalog is part of the key (Ktor DI
- * keys by full type, so distinct catalogs don't collide):
+ * Resolves the [SuspendDatabase] for catalog [G] from Ktor's built-in DI, wrapped in a
+ * [KormHandle]. Register it with the matching parameterized type so the catalog is part of the
+ * key (Ktor DI keys by full type, so distinct catalogs don't collide):
  * ```
- * dependencies { provide<Database<AppCatalog>> { createDatabase(...) } }
+ * dependencies { provide<SuspendDatabase<AppCatalog>> { createDatabase(...) } }
  * ```
  * This is the chain form (c): `call.korm<AppCatalog>().transaction { ... }`.
  */
 suspend inline fun <reified G : Catalog> ApplicationCall.korm(): KormHandle<G> =
-    KormHandle(application.dependencies.resolve<Database<G>>())
+    KormHandle(application.dependencies.resolve<SuspendDatabase<G>>())
 
 // --- (a) catalog as a TYPE argument — `call.transaction<AppCatalog, _> { ... }` ---------------
 // The `_` lets the return type infer while the catalog is given explicitly as a type.
 
 suspend inline fun <reified G : Catalog, R> ApplicationCall.transaction(
-    noinline block: Scope<G>.() -> R,
+    noinline block: suspend SuspendScope<G>.() -> R,
 ): R = korm<G>().database.suspendTransaction(block)
 
 suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
-    noinline block: Scope<G>.() -> R,
+    noinline block: suspend SuspendScope<G>.() -> R,
 ): R = korm<G>().database.suspendAutocommit(block)
 
 // --- (b) catalog as a VALUE — `call.transaction(AppCatalog) { ... }` --------------------------
@@ -38,10 +38,10 @@ suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
 
 suspend inline fun <reified G : Catalog, R> ApplicationCall.transaction(
     catalog: G,
-    noinline block: Scope<G>.() -> R,
+    noinline block: suspend SuspendScope<G>.() -> R,
 ): R = korm<G>().database.suspendTransaction(block)
 
 suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
     catalog: G,
-    noinline block: Scope<G>.() -> R,
+    noinline block: suspend SuspendScope<G>.() -> R,
 ): R = korm<G>().database.suspendAutocommit(block)

--- a/korm-ktor-koin/build.gradle.kts
+++ b/korm-ktor-koin/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 val koinVersion = "4.1.0"
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 
     jvm {
         testRuns["test"].executionTask.configure {

--- a/korm-ktor-koin/src/commonMain/kotlin/Koin.kt
+++ b/korm-ktor-koin/src/commonMain/kotlin/Koin.kt
@@ -1,8 +1,8 @@
 package io.github.knyazevs.korm.ktor.koin
 
 import io.github.knyazevs.korm.Catalog
-import io.github.knyazevs.korm.Scope
-import io.github.knyazevs.korm.database.Database
+import io.github.knyazevs.korm.SuspendScope
+import io.github.knyazevs.korm.database.SuspendDatabase
 import io.github.knyazevs.korm.ktor.KormHandle
 import io.github.knyazevs.korm.suspendAutocommit
 import io.github.knyazevs.korm.suspendTransaction
@@ -11,14 +11,14 @@ import org.koin.core.qualifier.Qualifier
 import org.koin.ktor.ext.getKoin
 
 /**
- * Resolves the [Database] for catalog [G] from Koin, wrapped in a [KormHandle] — the chain form
- * (c): `call.korm<AppCatalog>().transaction { ... }`.
+ * Resolves the [SuspendDatabase] for catalog [G] from Koin, wrapped in a [KormHandle] — the chain
+ * form (c): `call.korm<AppCatalog>().transaction { ... }`.
  *
- * Note: Koin keys by `KClass`, so generics are erased — `get<Database<AppCatalog>>()` and
- * `get<Database<OtherCatalog>>()` resolve to the same key. If you run more than one catalog,
+ * Note: Koin keys by `KClass`, so generics are erased — `get<SuspendDatabase<AppCatalog>>()` and
+ * `get<SuspendDatabase<OtherCatalog>>()` resolve to the same key. If you run more than one catalog,
  * register and resolve them with a [qualifier]:
  * ```
- * single<Database<AppCatalog>>(named("app")) { createDatabase(...) }
+ * single<SuspendDatabase<AppCatalog>>(named("app")) { createDatabase(...) }
  * // call.korm<AppCatalog>(named("app"))
  * ```
  */
@@ -30,11 +30,11 @@ inline fun <reified G : Catalog> ApplicationCall.korm(qualifier: Qualifier? = nu
 // For a named dependency use the value form (b) or `korm<G>(qualifier).transaction { }`.
 
 suspend inline fun <reified G : Catalog, R> ApplicationCall.transaction(
-    noinline block: Scope<G>.() -> R,
+    noinline block: suspend SuspendScope<G>.() -> R,
 ): R = korm<G>().database.suspendTransaction(block)
 
 suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
-    noinline block: Scope<G>.() -> R,
+    noinline block: suspend SuspendScope<G>.() -> R,
 ): R = korm<G>().database.suspendAutocommit(block)
 
 // --- (b) catalog as a VALUE — `call.transaction(AppCatalog) { ... }` --------------------------
@@ -43,11 +43,11 @@ suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
 suspend inline fun <reified G : Catalog, R> ApplicationCall.transaction(
     catalog: G,
     qualifier: Qualifier? = null,
-    noinline block: Scope<G>.() -> R,
+    noinline block: suspend SuspendScope<G>.() -> R,
 ): R = korm<G>(qualifier).database.suspendTransaction(block)
 
 suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
     catalog: G,
     qualifier: Qualifier? = null,
-    noinline block: Scope<G>.() -> R,
+    noinline block: suspend SuspendScope<G>.() -> R,
 ): R = korm<G>(qualifier).database.suspendAutocommit(block)

--- a/korm-ktor/build.gradle.kts
+++ b/korm-ktor/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 val ktorVersion = "3.5.0"
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 
     jvm {
         testRuns["test"].executionTask.configure {

--- a/korm-ktor/src/commonMain/kotlin/Handle.kt
+++ b/korm-ktor/src/commonMain/kotlin/Handle.kt
@@ -1,26 +1,26 @@
 package io.github.knyazevs.korm.ktor
 
 import io.github.knyazevs.korm.Catalog
-import io.github.knyazevs.korm.Scope
-import io.github.knyazevs.korm.database.Database
+import io.github.knyazevs.korm.SuspendScope
+import io.github.knyazevs.korm.database.SuspendDatabase
 import io.github.knyazevs.korm.suspendAutocommit
 import io.github.knyazevs.korm.suspendTransaction
 import kotlin.jvm.JvmInline
 
 /**
- * An allocation-free wrapper around a resolved [Database] that offers terse [transaction] /
+ * An allocation-free wrapper around a resolved [SuspendDatabase] that offers terse [transaction] /
  * [autocommit] without a second type argument. It's the chain form (c) of the DI helpers:
  * `call.korm<AppCatalog>().transaction { ... }` keeps the catalog a pure type (no value, no `_`)
  * at the cost of one extra `.korm<G>()` hop. Built by the `korm-ktor-di` / `korm-ktor-koin`
  * `korm<G>()` accessors.
  */
 @JvmInline
-value class KormHandle<G : Catalog>(val database: Database<G>)
+value class KormHandle<G : Catalog>(val database: SuspendDatabase<G>)
 
 /** Runs [block] in a transaction on the wrapped database; see [io.github.knyazevs.korm.suspendTransaction]. */
-suspend fun <G : Catalog, R> KormHandle<G>.transaction(block: Scope<G>.() -> R): R =
+suspend fun <G : Catalog, R> KormHandle<G>.transaction(block: suspend SuspendScope<G>.() -> R): R =
     database.suspendTransaction(block)
 
 /** Runs [block] in autocommit on the wrapped database; see [io.github.knyazevs.korm.suspendAutocommit]. */
-suspend fun <G : Catalog, R> KormHandle<G>.autocommit(block: Scope<G>.() -> R): R =
+suspend fun <G : Catalog, R> KormHandle<G>.autocommit(block: suspend SuspendScope<G>.() -> R): R =
     database.suspendAutocommit(block)

--- a/korm-ktor/src/commonMain/kotlin/KormPlugin.kt
+++ b/korm-ktor/src/commonMain/kotlin/KormPlugin.kt
@@ -1,6 +1,5 @@
 package io.github.knyazevs.korm.ktor
 
-import io.github.knyazevs.korm.database.Database
 import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.application.createApplicationPlugin
 import io.ktor.server.application.hooks.MonitoringEvent
@@ -8,15 +7,15 @@ import io.ktor.server.application.log
 
 /** Configuration for the [Korm] plugin. */
 class KormConfig {
-    internal val managed = mutableListOf<Database<*>>()
+    internal val managed = mutableListOf<AutoCloseable>()
 
     /**
-     * Registers [db] to be [Database.close]d when the application stops. Use this only if you
-     * are NOT managing the database's lifecycle elsewhere — Ktor's built-in DI already closes
-     * `AutoCloseable` dependencies (which a [Database] is) on shutdown, so registering it there
-     * makes this plugin unnecessary.
+     * Registers [db] to be `close`d when the application stops. Accepts any [AutoCloseable] —
+     * both `Database` and `SuspendDatabase` (incl. the r2dbc driver) qualify. Use this only if
+     * you are NOT managing the database's lifecycle elsewhere — Ktor's built-in DI already closes
+     * `AutoCloseable` dependencies on shutdown, so registering it there makes this unnecessary.
      */
-    fun manage(db: Database<*>) {
+    fun manage(db: AutoCloseable) {
         managed += db
     }
 }

--- a/korm-ktor/src/commonMain/kotlin/Transactions.kt
+++ b/korm-ktor/src/commonMain/kotlin/Transactions.kt
@@ -1,15 +1,16 @@
 package io.github.knyazevs.korm.ktor
 
 import io.github.knyazevs.korm.Catalog
-import io.github.knyazevs.korm.Scope
-import io.github.knyazevs.korm.database.Database
+import io.github.knyazevs.korm.SuspendScope
+import io.github.knyazevs.korm.database.SuspendDatabase
 import io.github.knyazevs.korm.suspendAutocommit
 import io.github.knyazevs.korm.suspendTransaction
 import io.ktor.server.application.ApplicationCall
 
 /**
- * Runs [block] in a transaction on [db] (BEGIN/COMMIT, ROLLBACK on throw), suspending the
- * calling coroutine while the blocking driver works (see [suspendTransaction]).
+ * Runs [block] in a transaction on [db] (BEGIN/COMMIT, ROLLBACK on throw) without blocking the
+ * worker — [block] is itself `suspend` and may suspend while the connection stays pinned. Works
+ * with any backend's [SuspendDatabase] (offload JDBC/libpq, or truly-async r2dbc).
  *
  * This overload is DI-agnostic: you pass the database explicitly, so it works with any way of
  * obtaining it — Koin (`call.transaction(call.get()) { ... }`), Ktor's built-in DI, or a plain
@@ -17,8 +18,8 @@ import io.ktor.server.application.ApplicationCall
  * the database for you.
  */
 suspend fun <G : Catalog, R> ApplicationCall.transaction(
-    db: Database<G>,
-    block: Scope<G>.() -> R,
+    db: SuspendDatabase<G>,
+    block: suspend SuspendScope<G>.() -> R,
 ): R = db.suspendTransaction(block)
 
 /**
@@ -26,6 +27,6 @@ suspend fun <G : Catalog, R> ApplicationCall.transaction(
  * single statements. See [transaction] for the DI-agnostic rationale.
  */
 suspend fun <G : Catalog, R> ApplicationCall.autocommit(
-    db: Database<G>,
-    block: Scope<G>.() -> R,
+    db: SuspendDatabase<G>,
+    block: suspend SuspendScope<G>.() -> R,
 ): R = db.suspendAutocommit(block)

--- a/korm-postgres/build.gradle.kts
+++ b/korm-postgres/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 
     jvm {
         testRuns["test"].executionTask.configure {
@@ -40,6 +40,9 @@ kotlin {
                 // return type, so :korm-core is an api dependency.
                 api(project(":korm-core"))
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
+                // PostgresDialect casts a JsonElement bind to ::jsonb (needed so the truly-typed
+                // r2dbc driver doesn't send it as text; harmless for the text-based JDBC/libpq paths).
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
                 implementation("io.github.oshai:kotlin-logging:7.0.3")
             }
         }

--- a/korm-postgres/src/commonMain/kotlin/PostgresDialect.kt
+++ b/korm-postgres/src/commonMain/kotlin/PostgresDialect.kt
@@ -1,14 +1,20 @@
 package io.github.knyazevs.korm
 
+import kotlinx.serialization.json.JsonElement
 import kotlin.uuid.Uuid
 
 /**
- * Postgres dialect: standard SQL rendering plus a `::uuid` cast on UUID binds, so a
- * text-bound UUID is interpreted with the right type by the server.
+ * Postgres dialect: standard SQL rendering plus `::uuid` / `::jsonb` casts on UUID and
+ * JSON binds, so a text-bound value is interpreted with the right type by the server.
+ * The casts are explicit (not reliant on `stringtype=unspecified`), so they're correct
+ * for the truly-typed r2dbc driver as well as the text-based JDBC/libpq paths.
  */
 object PostgresDialect : Dialect by StandardDialect {
-    override fun renderBind(name: String, value: Any?): String =
-        if (value is Uuid) ":$name::uuid" else StandardDialect.renderBind(name, value)
+    override fun renderBind(name: String, value: Any?): String = when (value) {
+        is Uuid -> ":$name::uuid"
+        is JsonElement -> ":$name::jsonb"
+        else -> StandardDialect.renderBind(name, value)
+    }
 
     override fun sqlType(type: Column.ColumnNameEnum): String = when (type) {
         Column.ColumnNameEnum.Instant -> "timestamptz"

--- a/korm-postgres/src/commonMain/kotlin/PostgresDriver.kt
+++ b/korm-postgres/src/commonMain/kotlin/PostgresDriver.kt
@@ -1,10 +1,12 @@
 package io.github.knyazevs.korm
 
 import io.github.knyazevs.korm.database.Database
+import io.github.knyazevs.korm.database.SuspendDatabase
 
 /**
- * A Postgres-backed [Database]. This is the type returned by the driver factories;
- * it adds [AutoCloseable] so the underlying connection pool can be released
- * (or used via a `use { }` block). All query methods are inherited from [Database].
+ * A Postgres-backed [Database] (and [SuspendDatabase]). This is the type returned by the
+ * driver factories; it adds [AutoCloseable] so the underlying connection pool can be
+ * released (or used via a `use { }` block). Blocking query methods come from [Database];
+ * the suspend path (suspendTransaction/suspendAutocommit) comes from [SuspendDatabase].
  */
-interface PostgresDriver : Database<Nothing>, AutoCloseable
+interface PostgresDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoCloseable

--- a/korm-postgres/src/nativeMain/kotlin/io/github/moreirasantos/pgkn/PostgresDriver.kt
+++ b/korm-postgres/src/nativeMain/kotlin/io/github/moreirasantos/pgkn/PostgresDriver.kt
@@ -13,14 +13,20 @@ import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import libpq.*
+import io.github.knyazevs.korm.ConnectionPool
 import io.github.knyazevs.korm.Dialect
+import io.github.knyazevs.korm.PinnedConnection
 import io.github.knyazevs.korm.PostgresDialect
 import io.github.knyazevs.korm.PostgresDriver
 import io.github.knyazevs.korm.SqlExecutor
 import io.github.knyazevs.korm.SqlParameterSource
 import io.github.knyazevs.korm.StandardTypeMapper
+import io.github.knyazevs.korm.SuspendSqlExecutor
 import io.github.knyazevs.korm.TypeMapper
+import io.github.knyazevs.korm.database.SuspendDatabase
 import io.github.knyazevs.korm.resultset.ResultSet
+import io.github.knyazevs.korm.runConnection
+import io.github.knyazevs.korm.runPinned
 import io.github.knyazevs.korm.sqlException
 
 private val logger = KLogger("io.github.moreirasantos.pgkn.PostgresDriverKt")
@@ -50,7 +56,7 @@ private class PostgresDriverImpl(
     user: String,
     password: String,
     private val poolSize: Int,
-) : PostgresDriver {
+) : PostgresDriver, SuspendDatabase<Nothing> {
 
     init {
         require(poolSize >= 1) { "poolSize must be >= 1, was $poolSize" }
@@ -123,20 +129,45 @@ private class PostgresDriverImpl(
             PQclear(runQuery(conn, sql, namedParameters))
         }
 
-    override fun <R> usePinned(transactional: Boolean, block: (SqlExecutor) -> R): R =
-        withConnection { conn ->
-            val executor = NativeExecutor(conn)
-            if (!transactional) return@withConnection block(executor)
-            PQclear(doExecute(conn, "BEGIN"))
-            try {
-                val result = block(executor)
-                PQclear(doExecute(conn, "COMMIT"))
-                result
-            } catch (e: Throwable) {
-                runCatching { PQclear(doExecute(conn, "ROLLBACK")) }
-                throw e
+    // One pool, two entry points (blocking usePinned + suspend useConnection). acquire mirrors
+    // withConnection's borrow + liveness check; acquireSuspending overrides the default to take
+    // the Channel's natural suspend path (pool.receive()) instead of offloading a blocking borrow.
+    private val connectionPool = object : ConnectionPool {
+        override fun acquire(): PinnedConnection {
+            val connection = pool.tryReceive().getOrNull() ?: try {
+                runBlocking { pool.receive() }
+            } catch (_: ClosedReceiveChannelException) {
+                throw ConnectionClosedException()
             }
+            ensureAlive(connection)
+            return PgPinnedConnection(connection)
         }
+
+        override suspend fun acquireSuspending(): PinnedConnection {
+            val connection = pool.tryReceive().getOrNull() ?: try {
+                pool.receive()
+            } catch (_: ClosedReceiveChannelException) {
+                throw ConnectionClosedException()
+            }
+            ensureAlive(connection)
+            return PgPinnedConnection(connection)
+        }
+    }
+
+    private inner class PgPinnedConnection(private val conn: CPointer<PGconn>) : PinnedConnection {
+        override val executor: SqlExecutor = NativeExecutor(conn)
+        override fun begin() { PQclear(doExecute(conn, "BEGIN")) }
+        override fun commit() { PQclear(doExecute(conn, "COMMIT")) }
+        override fun rollback() { PQclear(doExecute(conn, "ROLLBACK")) }
+        // Capacity == poolSize, so a borrowed connection always fits back in.
+        override fun release() { pool.trySend(conn) }
+    }
+
+    override fun <R> usePinned(transactional: Boolean, block: (SqlExecutor) -> R): R =
+        connectionPool.runPinned(transactional, block)
+
+    override suspend fun <R> useConnection(transactional: Boolean, block: suspend (SuspendSqlExecutor) -> R): R =
+        connectionPool.runConnection(transactional, block)
 
     // An SqlExecutor bound to the pinned connection for the duration of usePinned.
     private inner class NativeExecutor(private val conn: CPointer<PGconn>) : SqlExecutor {

--- a/korm-r2dbc/build.gradle.kts
+++ b/korm-r2dbc/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    kotlin("multiplatform")
+}
+
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    jvmToolchain(21)
+
+    jvm {
+        testRuns["test"].executionTask.configure {
+            useJUnitPlatform()
+        }
+    }
+
+    sourceSets {
+        val jvmMain by getting {
+            dependencies {
+                // The r2dbc driver returns core's ResultSet and implements core's
+                // SuspendDatabase, so :korm-core is part of the public API.
+                api(project(":korm-core"))
+                // PostgresDialect (the ::uuid cast) is reused verbatim for SQL rendering.
+                api(project(":korm-postgres"))
+                implementation("org.postgresql:r2dbc-postgresql:1.0.7.RELEASE")
+                implementation("io.r2dbc:r2dbc-pool:1.0.2.RELEASE")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+                implementation("org.testcontainers:postgresql:1.20.4")
+            }
+        }
+    }
+}

--- a/korm-r2dbc/src/jvmMain/kotlin/io/github/knyazevs/korm/r2dbc/NamedParams.kt
+++ b/korm-r2dbc/src/jvmMain/kotlin/io/github/knyazevs/korm/r2dbc/NamedParams.kt
@@ -1,0 +1,49 @@
+package io.github.knyazevs.korm.r2dbc
+
+/** A SQL string with its `:name` placeholders rewritten to Postgres `$N`, plus the names in order. */
+internal class ParsedSql(val sql: String, val names: List<String>)
+
+/**
+ * Rewrites korm's Spring-style `:name` placeholders to r2dbc-postgresql's positional
+ * `$1, $2, ...` and records the names in occurrence order so values can be bound by
+ * index. `::` casts (Postgres) and quoted string literals are left untouched. This is
+ * the same parse as the JDBC NamedParamStatement, differing only in the emitted marker.
+ */
+internal fun parseNamedParams(sql: String): ParsedSql {
+    val out = StringBuilder(sql.length)
+    val names = ArrayList<String>()
+    var i = 0
+    while (i < sql.length) {
+        val c = sql[i]
+        when {
+            c == '\'' || c == '"' -> {
+                // Copy a quoted literal verbatim so ':' inside it is not treated as a parameter.
+                out.append(c)
+                i++
+                while (i < sql.length) {
+                    val ch = sql[i]
+                    out.append(ch)
+                    i++
+                    if (ch == c) break
+                }
+            }
+            c == ':' && i + 1 < sql.length && sql[i + 1] == ':' -> {
+                // Postgres "::" cast operator, not a parameter.
+                out.append("::")
+                i += 2
+            }
+            c == ':' && i + 1 < sql.length && (sql[i + 1].isLetter() || sql[i + 1] == '_') -> {
+                var j = i + 1
+                while (j < sql.length && (sql[j].isLetterOrDigit() || sql[j] == '_')) j++
+                names.add(sql.substring(i + 1, j))
+                out.append('$').append(names.size) // $1, $2, ... (1-based)
+                i = j
+            }
+            else -> {
+                out.append(c)
+                i++
+            }
+        }
+    }
+    return ParsedSql(out.toString(), names)
+}

--- a/korm-r2dbc/src/jvmMain/kotlin/io/github/knyazevs/korm/r2dbc/R2dbcDatabase.kt
+++ b/korm-r2dbc/src/jvmMain/kotlin/io/github/knyazevs/korm/r2dbc/R2dbcDatabase.kt
@@ -1,0 +1,81 @@
+package io.github.knyazevs.korm.r2dbc
+
+import io.github.knyazevs.korm.Dialect
+import io.github.knyazevs.korm.PostgresDialect
+import io.github.knyazevs.korm.StandardTypeMapper
+import io.github.knyazevs.korm.SuspendSqlExecutor
+import io.github.knyazevs.korm.TypeMapper
+import io.github.knyazevs.korm.database.SuspendDatabase
+import io.r2dbc.pool.ConnectionPool
+import io.r2dbc.pool.ConnectionPoolConfiguration
+import io.r2dbc.postgresql.PostgresqlConnectionConfiguration
+import io.r2dbc.postgresql.PostgresqlConnectionFactory
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.reactive.awaitSingle
+import kotlinx.coroutines.withContext
+
+/**
+ * A truly async (non-blocking) Postgres [SuspendDatabase], backed by r2dbc-postgresql
+ * over a reactive [ConnectionPool]. It implements ONLY the suspend hierarchy — there is
+ * no blocking [io.github.knyazevs.korm.database.Database] here — which is exactly why
+ * SuspendDatabase is a sibling of Database, not a subtype.
+ *
+ * The phantom catalog tag is [Nothing], so by covariance it fits any
+ * `SuspendDatabase<G>`; pin the tag at the call site (`val db: SuspendDatabase<MyCatalog>`).
+ */
+class R2dbcDatabase internal constructor(
+    private val pool: ConnectionPool,
+    private val dialect: Dialect,
+    private val typeMapper: TypeMapper,
+) : SuspendDatabase<Nothing> {
+
+    override suspend fun <R> useConnection(transactional: Boolean, block: suspend (SuspendSqlExecutor) -> R): R {
+        val connection = pool.create().awaitSingle()
+        try {
+            if (transactional) connection.beginTransaction().awaitFirstOrNull()
+            val exec = R2dbcExecutor(connection, dialect, typeMapper)
+            return try {
+                block(exec).also { if (transactional) connection.commitTransaction().awaitFirstOrNull() }
+            } catch (e: Throwable) {
+                if (transactional) {
+                    withContext(NonCancellable) { runCatching { connection.rollbackTransaction().awaitFirstOrNull() } }
+                }
+                throw e
+            }
+        } finally {
+            withContext(NonCancellable) { runCatching { connection.close().awaitFirstOrNull() } }
+        }
+    }
+
+    override fun close() {
+        pool.dispose()
+    }
+}
+
+/**
+ * Opens an async Postgres database over r2dbc with a reactive connection pool of
+ * [poolSize]. Returns it tagged [Nothing] (covariance pins the catalog at the call site).
+ */
+fun createR2dbcDatabase(
+    host: String,
+    port: Int = 5432,
+    database: String,
+    user: String,
+    password: String,
+    poolSize: Int = 10,
+): R2dbcDatabase {
+    val connectionFactory = PostgresqlConnectionFactory(
+        PostgresqlConnectionConfiguration.builder()
+            .host(host)
+            .port(port)
+            .database(database)
+            .username(user)
+            .password(password)
+            .build(),
+    )
+    val poolConfiguration = ConnectionPoolConfiguration.builder(connectionFactory)
+        .maxSize(poolSize)
+        .build()
+    return R2dbcDatabase(ConnectionPool(poolConfiguration), PostgresDialect, StandardTypeMapper)
+}

--- a/korm-r2dbc/src/jvmMain/kotlin/io/github/knyazevs/korm/r2dbc/R2dbcExecutor.kt
+++ b/korm-r2dbc/src/jvmMain/kotlin/io/github/knyazevs/korm/r2dbc/R2dbcExecutor.kt
@@ -1,0 +1,89 @@
+package io.github.knyazevs.korm.r2dbc
+
+import io.github.knyazevs.korm.Dialect
+import io.github.knyazevs.korm.SqlParameterSource
+import io.github.knyazevs.korm.SuspendSqlExecutor
+import io.github.knyazevs.korm.TypeMapper
+import io.github.knyazevs.korm.resultset.ResultSet
+import io.github.knyazevs.korm.sqlException
+import io.r2dbc.spi.Connection
+import io.r2dbc.spi.R2dbcException
+import io.r2dbc.spi.Statement
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.reactive.asFlow
+
+/**
+ * A [SuspendSqlExecutor] bound to one r2dbc [Connection]. Unlike the offload backends
+ * there is NO dispatcher hop: each call drives the reactive driver and bridges it to
+ * suspend via kotlinx-coroutines-reactive. The SQL rendering ([Dialect]) and value
+ * conversion ([TypeMapper]) are reused verbatim from korm-postgres; only the bind step
+ * differs — `:name` is rewritten to `$N` and bound by index.
+ */
+internal class R2dbcExecutor(
+    private val connection: Connection,
+    override val dialect: Dialect,
+    override val typeMapper: TypeMapper,
+) : SuspendSqlExecutor {
+
+    private fun prepare(sql: String, namedParameters: Map<String, Any?>): Statement {
+        val parsed = parseNamedParams(sql)
+        val statement = connection.createStatement(parsed.sql)
+        parsed.names.forEachIndexed { index, name ->
+            when (val value = namedParameters[name]) {
+                // korm's TypeMapper has already reduced values to String/primitive; a null
+                // binds as text and any ::cast in the SQL turns it into a typed NULL.
+                null -> statement.bindNull(index, String::class.java)
+                else -> statement.bind(index, value)
+            }
+        }
+        return statement
+    }
+
+    override suspend fun <T> execute(sql: String, namedParameters: Map<String, Any?>, handler: (ResultSet) -> T): List<T> =
+        translating {
+            val out = ArrayList<T>()
+            prepare(sql, namedParameters).execute().asFlow().collect { result ->
+                // Box the handler's result: it may be nullable, but asFlow requires a non-null
+                // element type, and the box itself is always non-null.
+                result.map { row, meta -> Box(handler(R2dbcResultSet(row, meta))) }.asFlow().collect { out.add(it.value) }
+            }
+            out
+        }
+
+    override suspend fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T> =
+        execute(sql, paramSource.toMap(), handler)
+
+    override suspend fun execute(sql: String, namedParameters: Map<String, Any?>): Long =
+        translating {
+            var total = 0L
+            prepare(sql, namedParameters).execute().asFlow().collect { result ->
+                result.rowsUpdated.asFlow().collect { total += it }
+            }
+            total
+        }
+
+    override suspend fun execute(sql: String, paramSource: SqlParameterSource): Long =
+        execute(sql, paramSource.toMap())
+
+    override suspend fun executeUpdate(sql: String, namedParameters: Map<String, Any?>): Unit =
+        translating {
+            prepare(sql, namedParameters).execute().asFlow().collect { result ->
+                result.rowsUpdated.asFlow().collect { }
+            }
+        }
+
+    // Map r2dbc's exceptions to korm's typed ones via the same SQLSTATE helper the JDBC
+    // backend uses (UniqueViolation 23505, ForeignKey 23503, ...).
+    private suspend fun <T> translating(block: suspend () -> T): T =
+        try {
+            block()
+        } catch (e: R2dbcException) {
+            throw sqlException(e.message ?: "SQL error", e.sqlState, e)
+        }
+}
+
+private fun SqlParameterSource.toMap(): Map<String, Any?> =
+    (parameterNames ?: emptyArray()).associateWith { getValue(it) }
+
+/** Non-null wrapper so a possibly-nullable handler result can flow through `Publisher.asFlow()`. */
+private class Box<T>(val value: T)

--- a/korm-r2dbc/src/jvmMain/kotlin/io/github/knyazevs/korm/r2dbc/R2dbcResultSet.kt
+++ b/korm-r2dbc/src/jvmMain/kotlin/io/github/knyazevs/korm/r2dbc/R2dbcResultSet.kt
@@ -1,0 +1,70 @@
+package io.github.knyazevs.korm.r2dbc
+
+import io.github.knyazevs.korm.resultset.ResultSet
+import io.r2dbc.postgresql.codec.Json
+import io.r2dbc.spi.Row
+import io.r2dbc.spi.RowMetadata
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.toKotlinInstant
+import kotlinx.datetime.toKotlinLocalDate
+import kotlinx.datetime.toKotlinLocalDateTime
+import kotlinx.datetime.toKotlinLocalTime
+
+/**
+ * Adapts one r2dbc [Row] to korm's [ResultSet]. r2dbc already hands the mapping
+ * function a positioned row per result row, so [next] is never used by korm's per-row
+ * handler — the cursor model collapses to a single row. Column indexes are 0-based, as
+ * in r2dbc and in korm's positional read path.
+ *
+ * The text types (UUID/BigDecimal/Json) are read through [getString] (korm parses them
+ * from text), so reading the raw value and toString()'ing it lines up with the same
+ * text mapping the JDBC/libpq backends use.
+ */
+internal class R2dbcResultSet(
+    private val row: Row,
+    private val metadata: RowMetadata,
+) : ResultSet {
+
+    override val columns: Array<String> by lazy {
+        metadata.columnMetadatas.map { it.name }.toTypedArray()
+    }
+
+    override fun next(): Boolean = false
+
+    override fun getString(columnIndex: Int): String? = when (val v = row.get(columnIndex)) {
+        null -> null
+        // json/jsonb come back as r2dbc-postgresql's Json wrapper; its toString() isn't the raw
+        // text korm's getJson()/text mapping expects, so unwrap it explicitly.
+        is Json -> v.asString()
+        else -> v.toString()
+    }
+
+    override fun getBoolean(columnIndex: Int): Boolean? = row.get(columnIndex, Boolean::class.javaObjectType)
+
+    override fun getShort(columnIndex: Int): Short? = row.get(columnIndex, Short::class.javaObjectType)
+
+    override fun getInt(columnIndex: Int): Int? = row.get(columnIndex, Int::class.javaObjectType)
+
+    override fun getLong(columnIndex: Int): Long? = row.get(columnIndex, Long::class.javaObjectType)
+
+    override fun getFloat(columnIndex: Int): Float? = row.get(columnIndex, Float::class.javaObjectType)
+
+    override fun getDouble(columnIndex: Int): Double? = row.get(columnIndex, Double::class.javaObjectType)
+
+    override fun getBytes(columnIndex: Int): ByteArray? = row.get(columnIndex, ByteArray::class.java)
+
+    override fun getDate(columnIndex: Int): LocalDate? =
+        row.get(columnIndex, java.time.LocalDate::class.java)?.toKotlinLocalDate()
+
+    override fun getTime(columnIndex: Int): LocalTime? =
+        row.get(columnIndex, java.time.LocalTime::class.java)?.toKotlinLocalTime()
+
+    override fun getLocalDateTime(columnIndex: Int): LocalDateTime? =
+        row.get(columnIndex, java.time.LocalDateTime::class.java)?.toKotlinLocalDateTime()
+
+    override fun getInstant(columnIndex: Int): Instant? =
+        row.get(columnIndex, java.time.OffsetDateTime::class.java)?.toInstant()?.toKotlinInstant()
+}

--- a/korm-r2dbc/src/jvmTest/kotlin/io/github/knyazevs/korm/r2dbc/R2dbcIntegrationTest.kt
+++ b/korm-r2dbc/src/jvmTest/kotlin/io/github/knyazevs/korm/r2dbc/R2dbcIntegrationTest.kt
@@ -1,0 +1,143 @@
+package io.github.knyazevs.korm.r2dbc
+
+import io.github.knyazevs.korm.Catalog
+import io.github.knyazevs.korm.Column
+import io.github.knyazevs.korm.Entity
+import io.github.knyazevs.korm.Query
+import io.github.knyazevs.korm.Table
+import io.github.knyazevs.korm.UniqueViolationException
+import io.github.knyazevs.korm.count
+import io.github.knyazevs.korm.database.SuspendDatabase
+import io.github.knyazevs.korm.eq
+import io.github.knyazevs.korm.suspendAutocommit
+import io.github.knyazevs.korm.suspendTransaction
+import kotlinx.coroutines.runBlocking
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.PostgreSQLContainer
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * End-to-end test of the async r2dbc backend against a real Postgres (Testcontainers).
+ * Exercises suspendTransaction/suspendAutocommit → R2dbcDatabase.useConnection (no
+ * offload, pure reactive→suspend) over the same Table DSL the JDBC/libpq backends use.
+ * Skips gracefully when Docker isn't available.
+ */
+class R2dbcIntegrationTest {
+
+    private val dockerAvailable = DockerClientFactory.instance().isDockerAvailable
+    private var container: PostgreSQLContainer<*>? = null
+    private var db: SuspendDatabase<R2Catalog>? = null
+
+    @BeforeTest
+    fun setUp() {
+        if (!dockerAvailable) return
+        val pg = PostgreSQLContainer("postgres:16-alpine")
+        pg.start()
+        container = pg
+        db = createR2dbcDatabase(
+            host = pg.host,
+            port = pg.firstMappedPort,
+            database = pg.databaseName,
+            user = pg.username,
+            password = pg.password,
+            poolSize = 4,
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        db?.close()
+        container?.stop()
+    }
+
+    @Test
+    fun crudRoundTrip() {
+        if (!dockerAvailable) return
+        val database = db!!
+        runBlocking {
+            val id = Uuid.random()
+            database.suspendTransaction {
+                Widgets.createTable()
+                Widgets.new(Widget().apply {
+                    this.id = id
+                    this.name = "async-widget"
+                    this.qty = 7
+                })
+            }
+
+            val found = database.suspendAutocommit { Widgets.findById(id) }
+            assertEquals(id, found?.id)
+            assertEquals("async-widget", found?.name)
+            assertEquals(7, found?.qty)
+
+            val byName = database.suspendAutocommit { Widgets.find(Query(Widgets.name eq "async-widget")) }
+            assertEquals(1, byName.size)
+
+            assertTrue(database.suspendAutocommit { Widgets.count() } >= 1)
+        }
+    }
+
+    @Test
+    fun transactionRollsBackOnThrow() {
+        if (!dockerAvailable) return
+        val database = db!!
+        runBlocking {
+            database.suspendTransaction { Widgets.createTable() }
+            val id = Uuid.random()
+
+            assertFailsWith<IllegalStateException> {
+                database.suspendTransaction {
+                    Widgets.new(Widget().apply {
+                        this.id = id
+                        this.name = "doomed"
+                        this.qty = 1
+                    })
+                    error("boom")
+                }
+            }
+
+            assertNull(database.suspendAutocommit { Widgets.findById(id) })
+        }
+    }
+
+    @Test
+    fun typedUniqueViolation() {
+        if (!dockerAvailable) return
+        val database = db!!
+        runBlocking {
+            database.suspendTransaction { Widgets.createTable() }
+            val id = Uuid.random()
+            database.suspendTransaction {
+                Widgets.new(Widget().apply { this.id = id; this.name = "dup"; this.qty = 1 })
+            }
+            assertFailsWith<UniqueViolationException> {
+                database.suspendTransaction {
+                    Widgets.new(Widget().apply { this.id = id; this.name = "dup2"; this.qty = 2 })
+                }
+            }
+        }
+    }
+}
+
+object R2Catalog : Catalog
+
+class Widget(override var fields: MutableMap<String, Any?> = mutableMapOf()) : Entity(fields) {
+    var id by Widgets.id
+    var name by Widgets.name
+    var qty by Widgets.qty
+}
+
+object Widgets : Table<R2Catalog, Widget>(Table.Meta("widgets"), ::Widget) {
+    val id by Column.UUID(primaryKey = true)
+    val name by Column.Text()
+    val qty by Column.Int()
+
+    init { id; name; qty }
+}

--- a/korm-sqlite/build.gradle.kts
+++ b/korm-sqlite/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 
     jvm {
         testRuns["test"].executionTask.configure {
@@ -63,6 +63,7 @@ kotlin {
                 implementation("com.ionspin.kotlin:bignum:0.3.10")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
             }
         }
         val jvmMain by getting {

--- a/korm-sqlite/src/commonMain/kotlin/SqliteDriver.kt
+++ b/korm-sqlite/src/commonMain/kotlin/SqliteDriver.kt
@@ -1,10 +1,12 @@
 package io.github.knyazevs.korm
 
 import io.github.knyazevs.korm.database.Database
+import io.github.knyazevs.korm.database.SuspendDatabase
 
 /**
- * A SQLite-backed [Database]. This is the type returned by [createSqliteDatabase];
- * it adds [AutoCloseable] so the underlying connection(s) can be released (or used
- * via a `use { }` block). All query methods are inherited from [Database].
+ * A SQLite-backed [Database] (and [SuspendDatabase]). This is the type returned by
+ * [createSqliteDatabase]; it adds [AutoCloseable] so the underlying connection(s) can be
+ * released (or used via a `use { }` block). Blocking query methods come from [Database];
+ * the suspend path (suspendTransaction/suspendAutocommit) comes from [SuspendDatabase].
  */
-interface SqliteDriver : Database<Nothing>, AutoCloseable
+interface SqliteDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoCloseable

--- a/korm-sqlite/src/commonTest/kotlin/SqliteSuspendTest.kt
+++ b/korm-sqlite/src/commonTest/kotlin/SqliteSuspendTest.kt
@@ -1,0 +1,66 @@
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import io.github.knyazevs.korm.createSqliteDatabase
+import io.github.knyazevs.korm.database.SuspendDatabase
+import io.github.knyazevs.korm.suspendAutocommit
+import io.github.knyazevs.korm.suspendTransaction
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.uuid.Uuid
+
+/**
+ * End-to-end test of the suspend path on a real backend (SQLite, JVM + Native). It
+ * exercises [suspendTransaction] / [suspendAutocommit] → SuspendDatabase.useConnection
+ * → the offload runner (SuspendExecutorAdapter on the IO dispatcher). Reuses the
+ * top-level SqCatalog/Products/Product from SqliteIntegrationTest (shared-cache :memory:).
+ */
+class SqliteSuspendTest {
+
+    private val db: SuspendDatabase<SqCatalog> = createSqliteDatabase(":memory:")
+
+    @Test
+    fun suspendCrudRoundTrip() = runTest {
+        val id = Uuid.random()
+        db.suspendTransaction {
+            Products.createTable()
+            Products.new(Product().apply {
+                this.id = id
+                this.price = BigDecimal.fromInt(42)
+                this.qty = 3
+                this.displayName = "async-widget"
+                this.note = null
+                this.rank = null
+            })
+        }
+
+        val found = db.suspendAutocommit { Products.findById(id) }
+        assertEquals(id, found?.id)
+        assertEquals("async-widget", found?.displayName)
+        assertEquals(3, found?.qty)
+    }
+
+    @Test
+    fun suspendTransactionRollsBackOnThrow() = runTest {
+        val id = Uuid.random()
+        db.suspendTransaction { Products.createTable() }
+
+        assertFailsWith<IllegalStateException> {
+            db.suspendTransaction {
+                Products.new(Product().apply {
+                    this.id = id
+                    this.price = BigDecimal.fromInt(1)
+                    this.qty = 1
+                    this.displayName = "doomed"
+                    this.note = null
+                    this.rank = null
+                })
+                error("boom")
+            }
+        }
+
+        // The insert must have been rolled back with the transaction.
+        val found = db.suspendAutocommit { Products.findById(id) }
+        assertEquals(null, found)
+    }
+}

--- a/korm-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
+++ b/korm-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
@@ -2,6 +2,7 @@ package io.github.knyazevs.korm
 
 import cnames.structs.sqlite3
 import cnames.structs.sqlite3_stmt
+import io.github.knyazevs.korm.database.SuspendDatabase
 import io.github.knyazevs.korm.resultset.ResultSet
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.CFunction
@@ -34,7 +35,7 @@ actual fun createSqliteDatabase(path: String, poolSize: Int): SqliteDriver =
     SqliteNativeDriver(path, poolSize)
 
 @OptIn(ExperimentalForeignApi::class)
-private class SqliteNativeDriver(path: String, private val poolSize: Int) : SqliteDriver {
+private class SqliteNativeDriver(path: String, private val poolSize: Int) : SqliteDriver, SuspendDatabase<Nothing> {
 
     init {
         require(poolSize >= 1) { "poolSize must be >= 1, was $poolSize" }
@@ -90,20 +91,42 @@ private class SqliteNativeDriver(path: String, private val poolSize: Int) : Sqli
         withConnection { conn -> updateOrCount(conn, sql, mapBinder(namedParameters)) }
     }
 
-    override fun <R> usePinned(transactional: Boolean, block: (SqlExecutor) -> R): R =
-        withConnection { conn ->
-            val executor = NativeExecutor(conn)
-            if (!transactional) return@withConnection block(executor)
-            rawExec(conn, "BEGIN")
-            try {
-                val result = block(executor)
-                rawExec(conn, "COMMIT")
-                result
-            } catch (e: Throwable) {
-                runCatching { rawExec(conn, "ROLLBACK") }
-                throw e
+    // One pool, two entry points (blocking usePinned + suspend useConnection). acquire mirrors
+    // withConnection's borrow; acquireSuspending overrides the default to take the Channel's
+    // natural suspend path (pool.receive()) instead of offloading a blocking borrow.
+    private val connectionPool = object : ConnectionPool {
+        override fun acquire(): PinnedConnection {
+            val connection = pool.tryReceive().getOrNull() ?: try {
+                runBlocking { pool.receive() }
+            } catch (_: ClosedReceiveChannelException) {
+                throw QueryException("SQLite connection pool is closed")
             }
+            return SqlitePinnedConnection(connection)
         }
+
+        override suspend fun acquireSuspending(): PinnedConnection {
+            val connection = pool.tryReceive().getOrNull() ?: try {
+                pool.receive()
+            } catch (_: ClosedReceiveChannelException) {
+                throw QueryException("SQLite connection pool is closed")
+            }
+            return SqlitePinnedConnection(connection)
+        }
+    }
+
+    private inner class SqlitePinnedConnection(private val conn: CPointer<sqlite3>) : PinnedConnection {
+        override val executor: SqlExecutor = NativeExecutor(conn)
+        override fun begin() { rawExec(conn, "BEGIN") }
+        override fun commit() { rawExec(conn, "COMMIT") }
+        override fun rollback() { rawExec(conn, "ROLLBACK") }
+        override fun release() { pool.trySend(conn) }
+    }
+
+    override fun <R> usePinned(transactional: Boolean, block: (SqlExecutor) -> R): R =
+        connectionPool.runPinned(transactional, block)
+
+    override suspend fun <R> useConnection(transactional: Boolean, block: suspend (SuspendSqlExecutor) -> R): R =
+        connectionPool.runConnection(transactional, block)
 
     // An SqlExecutor bound to the pinned connection for the duration of usePinned.
     private inner class NativeExecutor(private val conn: CPointer<sqlite3>) : SqlExecutor {

--- a/samples/README.md
+++ b/samples/README.md
@@ -6,6 +6,7 @@ Each subdirectory is a focused, runnable sample. Run gradle commands from the re
 |---|---|---|---|
 | [ktor-di](ktor-di) | Postgres | yes (compose) | Ktor CRUD, database from Ktor's built-in DI |
 | [ktor-koin](ktor-koin) | Postgres | yes (compose) | Ktor CRUD, database from Koin |
+| [r2dbc](r2dbc) | Postgres (async) | yes (compose) | Same Ktor CRUD on the non-blocking r2dbc driver (JVM only) |
 | [sqlite-cache](sqlite-cache) | Postgres + SQLite | yes (compose) | SQLite as a read-through cache in front of Postgres |
 | [crud-sqlite](crud-sqlite) | SQLite | no | Standalone CRUD + migrations (JVM + native) |
 | [sharding](sharding) | SQLite | no | Multiple catalogs (compile-time safety) + sharding |

--- a/samples/crud-sqlite/build.gradle.kts
+++ b/samples/crud-sqlite/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
         }
     }
 
-    jvmToolchain(17)
+    jvmToolchain(21)
     jvm {
         binaries {
             executable {

--- a/samples/ktor-di/build.gradle.kts
+++ b/samples/ktor-di/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
         }
     }
 
-    jvmToolchain(17)
+    jvmToolchain(21)
     jvm {
         binaries {
             executable {

--- a/samples/ktor-di/src/commonMain/kotlin/Application.kt
+++ b/samples/ktor-di/src/commonMain/kotlin/Application.kt
@@ -4,7 +4,7 @@ package io.github.knyazevs.korm.samples.ktordi
 
 import io.github.knyazevs.korm.KormException
 import io.github.knyazevs.korm.Query
-import io.github.knyazevs.korm.database.Database
+import io.github.knyazevs.korm.database.SuspendDatabase
 import io.github.knyazevs.korm.database.createDatabase
 import io.github.knyazevs.korm.eq
 import io.github.knyazevs.korm.ktor.di.autocommit
@@ -29,15 +29,15 @@ import kotlin.uuid.Uuid
 
 /**
  * Wires korm into Ktor through the built-in DI:
- *  - `dependencies { provide<Database<AppCatalog>> { ... } }` registers the database. Ktor DI keys
- *    by the full parameterized type (so catalogs don't collide) and auto-closes it on shutdown
- *    (a [Database] is `AutoCloseable`) — no lifecycle plugin needed.
+ *  - `dependencies { provide<SuspendDatabase<AppCatalog>> { ... } }` registers the database. Ktor DI
+ *    keys by the full parameterized type (so catalogs don't collide) and auto-closes it on shutdown
+ *    (a [SuspendDatabase] is `AutoCloseable`) — no lifecycle plugin needed.
  *  - routes use the reified `call.transaction<AppCatalog> { }` / `call.autocommit<AppCatalog> { }`
  *    helpers from `korm-ktor-di`, which resolve the database from DI for you.
  */
 fun Application.module() {
     dependencies {
-        provide<Database<AppCatalog>> {
+        provide<SuspendDatabase<AppCatalog>> {
             createDatabase(
                 host = "localhost",
                 port = 5432,

--- a/samples/ktor-di/src/jvmTest/kotlin/KtorDiTest.kt
+++ b/samples/ktor-di/src/jvmTest/kotlin/KtorDiTest.kt
@@ -1,8 +1,9 @@
 package io.github.knyazevs.korm.samples.ktordi
 
-import io.github.knyazevs.korm.autocommit
-import io.github.knyazevs.korm.database.Database
+import io.github.knyazevs.korm.database.SuspendDatabase
 import io.github.knyazevs.korm.database.createDatabase
+import io.github.knyazevs.korm.suspendAutocommit
+import kotlinx.coroutines.runBlocking
 import io.ktor.client.request.get
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
@@ -28,18 +29,18 @@ class KtorDiTest {
 
         val pg = PostgreSQLContainer("postgres:16-alpine").apply { start() }
         try {
-            val db: Database<AppCatalog> = createDatabase(
+            val db: SuspendDatabase<AppCatalog> = createDatabase(
                 host = pg.host,
                 port = pg.firstMappedPort,
                 database = pg.databaseName,
                 user = pg.username,
                 password = pg.password,
             )
-            db.autocommit { ProductTable.dropTable(); ProductTable.createTable() }
+            runBlocking { db.suspendAutocommit { ProductTable.dropTable(); ProductTable.createTable() } }
 
             testApplication {
                 application {
-                    dependencies { provide<Database<AppCatalog>> { db } }
+                    dependencies { provide<SuspendDatabase<AppCatalog>> { db } }
                     configure()
                 }
 

--- a/samples/ktor-koin/build.gradle.kts
+++ b/samples/ktor-koin/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
         }
     }
 
-    jvmToolchain(17)
+    jvmToolchain(21)
     jvm {
         binaries {
             executable {

--- a/samples/r2dbc/README.md
+++ b/samples/r2dbc/README.md
@@ -1,0 +1,34 @@
+# r2dbc sample
+
+A Ktor CRUD service backed by the **async, non-blocking** Postgres driver (`korm-r2dbc`,
+r2dbc-postgresql) — and wired through the **same** `korm-ktor-di` helpers as the blocking
+[ktor-di](../ktor-di) sample.
+
+The point of this sample is the diff against `ktor-di`: it's a single line.
+
+```kotlin
+// ktor-di (blocking JDBC, offloaded to a virtual thread):
+provide<SuspendDatabase<AppCatalog>> { createDatabase(...) }
+
+// r2dbc (truly non-blocking, with pipelining):
+provide<SuspendDatabase<AppCatalog>> { createR2dbcDatabase(...) }
+```
+
+The routes and the `call.transaction` / `call.autocommit` helpers are identical — the suspend
+API is backend-transparent. JVM-only, since r2dbc has no Kotlin/Native target.
+
+## Run
+
+```sh
+docker compose -f samples/r2dbc/docker-compose.yml up -d   # start Postgres
+./gradlew :samples:r2dbc:runJvm                            # run on http://localhost:8080
+docker compose -f samples/r2dbc/docker-compose.yml down    # stop Postgres
+```
+
+Endpoints: `GET /`, `PUT /create`, `POST /update?id=…`, `DELETE /delete?id=…`
+(bodies are `{"price":…,"payload":{…}}`).
+
+## Test
+
+`./gradlew :samples:r2dbc:jvmTest` runs an end-to-end CRUD test against a real Postgres via
+Testcontainers (skips gracefully if Docker isn't available).

--- a/samples/r2dbc/build.gradle.kts
+++ b/samples/r2dbc/build.gradle.kts
@@ -1,0 +1,56 @@
+plugins {
+    kotlin("multiplatform")
+    kotlin("plugin.serialization") version "2.4.0"
+}
+
+group = "io.github.knyazevs.korm.samples.r2dbc"
+version = "1.0"
+
+repositories {
+    mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.jetbrains.space/public/p/ktor/eap")
+    }
+}
+
+val ktorVersion = "3.5.0"
+
+// JVM-only: r2dbc (and korm-r2dbc) are JVM-only, so this sample has no native target.
+kotlin {
+    jvmToolchain(21)
+    jvm {
+        binaries {
+            executable {
+                mainClass.set("io.github.knyazevs.korm.samples.r2dbc.MainKt")
+            }
+        }
+        testRuns["test"].executionTask.configure { useJUnitPlatform() }
+    }
+
+    sourceSets {
+        val jvmMain by getting {
+            dependencies {
+                implementation("io.ktor:ktor-server-core:$ktorVersion")
+                implementation("io.ktor:ktor-server-netty:$ktorVersion")
+                implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
+                implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+                implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                implementation("org.slf4j:slf4j-simple:2.0.16")
+
+                // The async (non-blocking) Postgres backend...
+                implementation(project(":korm-r2dbc"))
+                // ...used through the SAME ktor-di helpers as the blocking sample — the routes
+                // are identical; only the registered driver differs.
+                implementation(project(":korm-ktor-di"))
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation("io.ktor:ktor-server-test-host:$ktorVersion")
+                implementation("org.testcontainers:postgresql:1.20.4")
+            }
+        }
+    }
+}

--- a/samples/r2dbc/docker-compose.yml
+++ b/samples/r2dbc/docker-compose.yml
@@ -1,0 +1,17 @@
+# Postgres for the r2dbc sample. Start it before running the app:
+#   docker compose -f samples/r2dbc/docker-compose.yml up -d
+# These settings match the ones hardcoded in the sample
+# (localhost:5432, user/db "postgres", password "password").
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: korm-r2dbc-postgres
+    environment:
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 3s
+      retries: 20

--- a/samples/r2dbc/src/jvmMain/kotlin/Application.kt
+++ b/samples/r2dbc/src/jvmMain/kotlin/Application.kt
@@ -1,19 +1,21 @@
 @file:OptIn(ExperimentalUuidApi::class)
 
-package io.github.knyazevs.korm.samples.ktorkoin
+package io.github.knyazevs.korm.samples.r2dbc
 
 import io.github.knyazevs.korm.KormException
 import io.github.knyazevs.korm.Query
 import io.github.knyazevs.korm.database.SuspendDatabase
-import io.github.knyazevs.korm.database.createDatabase
 import io.github.knyazevs.korm.eq
+import io.github.knyazevs.korm.ktor.di.autocommit
+import io.github.knyazevs.korm.ktor.di.transaction
 import io.github.knyazevs.korm.ktor.httpStatusCode
-import io.github.knyazevs.korm.ktor.koin.autocommit
-import io.github.knyazevs.korm.ktor.koin.transaction
+import io.github.knyazevs.korm.r2dbc.createR2dbcDatabase
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.di.dependencies
+import io.ktor.server.plugins.di.provide
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
@@ -22,43 +24,35 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 import io.ktor.server.routing.routing
-import org.koin.dsl.module
-import org.koin.dsl.onClose
-import org.koin.ktor.plugin.Koin
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 /**
- * Wires korm into Ktor through Koin:
- *  - `install(Koin) { modules(...) }` registers the database; `onClose { it?.close() }` closes the
- *    pool when Koin shuts down with the application (Koin does not auto-close like Ktor DI does).
- *  - routes use the reified `call.transaction<AppCatalog> { }` / `call.autocommit<AppCatalog> { }`
- *    helpers from `korm-ktor-koin`, which resolve the database from Koin.
+ * The same korm + Ktor wiring as the `ktor-di` sample, but backed by the ASYNC r2dbc driver
+ * instead of blocking JDBC. The only difference is the registered dependency:
  *
- * Note: Koin keys by `KClass`, so generics are erased. With a single catalog this is fine; for
- * multiple catalogs register and resolve with a `named(...)` qualifier (see korm-ktor-koin docs).
+ *     provide<SuspendDatabase<AppCatalog>> { createR2dbcDatabase(...) }
+ *
+ * The routes and the `call.transaction` / `call.autocommit` helpers are byte-for-byte identical
+ * to the blocking sample — the suspend API is backend-transparent. r2dbc gives true non-blocking
+ * I/O (and pipelining) here, where JDBC would offload to a thread.
  */
 fun Application.module() {
-    install(Koin) {
-        modules(
-            module {
-                single<SuspendDatabase<AppCatalog>> {
-                    createDatabase(
-                        host = "localhost",
-                        port = 5432,
-                        database = "postgres",
-                        user = "postgres",
-                        password = "password",
-                    )
-                } onClose { it?.close() }
-            },
-        )
+    dependencies {
+        provide<SuspendDatabase<AppCatalog>> {
+            createR2dbcDatabase(
+                host = "localhost",
+                port = 5432,
+                database = "postgres",
+                user = "postgres",
+                password = "password",
+            )
+        }
     }
-
     configure()
 }
 
-/** Plugins + routes, without installing Koin — so tests can register their own modules. */
+/** Plugins + routes, without creating the database — so tests can register their own. */
 fun Application.configure() {
     install(ContentNegotiation) { json() }
     install(StatusPages) {
@@ -66,7 +60,6 @@ fun Application.configure() {
     }
 
     routing {
-        // Catalog given as a type argument; `_` lets the return type infer.
         get("/") {
             val products = call.autocommit<AppCatalog, _> { ProductTable.all() }
             call.respond(products.map { it.toDto() })

--- a/samples/r2dbc/src/jvmMain/kotlin/Domain.kt
+++ b/samples/r2dbc/src/jvmMain/kotlin/Domain.kt
@@ -1,0 +1,40 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package io.github.knyazevs.korm.samples.r2dbc
+
+import io.github.knyazevs.korm.Catalog
+import io.github.knyazevs.korm.Column
+import io.github.knyazevs.korm.Entity
+import io.github.knyazevs.korm.Table
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/** A [Catalog] is a marker type for a logical database; it pins tables and the database together. */
+object AppCatalog : Catalog
+
+object ProductTable : Table<AppCatalog, ProductEntity>(Meta("products"), ::ProductEntity) {
+    val id by Column.UUID(primaryKey = true)
+    val price by Column.Int()
+    val payload by Column.Json()
+
+    init { id; price; payload }
+}
+
+class ProductEntity(override var fields: MutableMap<String, Any?> = mutableMapOf()) : Entity(fields) {
+    var id by ProductTable.id
+    var price by ProductTable.price
+    var payload by ProductTable.payload
+}
+
+@Serializable
+data class ProductDTO(val id: Uuid? = null, val price: Int? = null, val payload: JsonElement? = null) {
+    fun toDomain(): ProductEntity = ProductEntity().apply {
+        id = this@ProductDTO.id
+        price = this@ProductDTO.price
+        payload = this@ProductDTO.payload
+    }
+}
+
+fun ProductEntity.toDto() = ProductDTO(id, price, payload)

--- a/samples/r2dbc/src/jvmMain/kotlin/Main.kt
+++ b/samples/r2dbc/src/jvmMain/kotlin/Main.kt
@@ -1,0 +1,14 @@
+package io.github.knyazevs.korm.samples.r2dbc
+
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+
+/**
+ * Runs the async-r2dbc sample on Netty. Needs a Postgres on localhost:5432 (postgres/password) —
+ * `docker compose -f samples/r2dbc/docker-compose.yml up -d` provides one. The `products` table is
+ * created on the first `/create` if you add a migration; this sample expects it to exist (the test
+ * creates it). Start with `./gradlew :samples:r2dbc:runJvm`.
+ */
+fun main() {
+    embeddedServer(Netty, port = 8080) { module() }.start(wait = true)
+}

--- a/samples/r2dbc/src/jvmTest/kotlin/R2dbcSampleTest.kt
+++ b/samples/r2dbc/src/jvmTest/kotlin/R2dbcSampleTest.kt
@@ -1,9 +1,8 @@
-package io.github.knyazevs.korm.samples.ktorkoin
+package io.github.knyazevs.korm.samples.r2dbc
 
 import io.github.knyazevs.korm.database.SuspendDatabase
-import io.github.knyazevs.korm.database.createDatabase
+import io.github.knyazevs.korm.r2dbc.createR2dbcDatabase
 import io.github.knyazevs.korm.suspendAutocommit
-import kotlinx.coroutines.runBlocking
 import io.ktor.client.request.get
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
@@ -11,25 +10,18 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
-import io.ktor.server.application.Application
-import io.ktor.server.application.install
+import io.ktor.server.plugins.di.dependencies
+import io.ktor.server.plugins.di.provide
 import io.ktor.server.testing.testApplication
-import org.koin.dsl.module
-import org.koin.ktor.plugin.Koin
+import kotlinx.coroutines.runBlocking
 import org.testcontainers.DockerClientFactory
 import org.testcontainers.containers.PostgreSQLContainer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-// Top-level so `install` resolves against Application only (inside application { } both
-// Application.install and ApplicationTestBuilder.install are in scope → ambiguous).
-private fun Application.registerKoin(db: SuspendDatabase<AppCatalog>) {
-    install(Koin) { modules(module { single<SuspendDatabase<AppCatalog>> { db } }) }
-}
-
-/** Exercises the ktor-koin sample end-to-end against a real Postgres (Testcontainers, JVM only). */
-class KtorKoinTest {
+/** Exercises the async r2dbc sample end-to-end against a real Postgres (Testcontainers, JVM only). */
+class R2dbcSampleTest {
 
     @Test
     fun createThenList() {
@@ -37,7 +29,7 @@ class KtorKoinTest {
 
         val pg = PostgreSQLContainer("postgres:16-alpine").apply { start() }
         try {
-            val db: SuspendDatabase<AppCatalog> = createDatabase(
+            val db: SuspendDatabase<AppCatalog> = createR2dbcDatabase(
                 host = pg.host,
                 port = pg.firstMappedPort,
                 database = pg.databaseName,
@@ -48,19 +40,20 @@ class KtorKoinTest {
 
             testApplication {
                 application {
-                    registerKoin(db)
+                    dependencies { provide<SuspendDatabase<AppCatalog>> { db } }
                     configure()
                 }
 
                 val created = client.put("/create") {
                     contentType(ContentType.Application.Json)
-                    setBody("""{"price":7,"payload":{"k":"v"}}""")
+                    setBody("""{"price":42,"payload":{"k":"v"}}""")
                 }
                 assertEquals(HttpStatusCode.OK, created.status)
+                assertTrue(created.bodyAsText().contains("\"price\":42"))
 
                 val list = client.get("/")
                 assertEquals(HttpStatusCode.OK, list.status)
-                assertTrue(list.bodyAsText().contains("\"price\":7"), "list body: ${list.bodyAsText()}")
+                assertTrue(list.bodyAsText().contains("\"price\":42"), "list body: ${list.bodyAsText()}")
             }
 
             db.close()

--- a/samples/sharding/build.gradle.kts
+++ b/samples/sharding/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
         }
     }
 
-    jvmToolchain(17)
+    jvmToolchain(21)
     jvm {
         binaries {
             executable {

--- a/samples/sqlite-cache/build.gradle.kts
+++ b/samples/sqlite-cache/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
         }
     }
 
-    jvmToolchain(17)
+    jvmToolchain(21)
     jvm {
         binaries {
             executable {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 rootProject.name = "korm"
-include("korm-core", "korm-postgres", "korm-jdbc", "korm-sqlite", "benchmarks")
+include("korm-core", "korm-postgres", "korm-jdbc", "korm-sqlite", "korm-r2dbc", "benchmarks")
 include("korm-ktor", "korm-ktor-di", "korm-ktor-koin")
 include("korm-bom")
 include(
@@ -20,4 +20,5 @@ include(
     "samples:crud-sqlite",
     "samples:sharding",
     "samples:sqlite-cache",
+    "samples:r2dbc",
 )


### PR DESCRIPTION
Adds a first-class suspend/coroutine API to korm and a truly-async Postgres backend, while keeping the blocking API intact.

## What & why
Until now the only coroutine support was an offload wrapper over the blocking drivers. This PR makes suspend a first-class, backend-pluggable path:

- **Suspend core** — `SuspendDatabase` / `SuspendSqlExecutor` / `SuspendScope`, siblings of the blocking types (an async backend can't implement the blocking `usePinned`). Suspend lives at the interface; how a connection is held is a backend detail.
- **Offload backend** (SQLite, PG/JDBC, native libpq) — one shared `ConnectionPool` SPI drives both `usePinned` and `useConnection`. On JVM the offload dispatcher is a **virtual-thread** executor (Loom), so blocking is cheap and concurrency is bounded only by the pool.
- **Async backend** — new JVM-only `korm-r2dbc` over r2dbc-postgresql: real non-blocking I/O (and pipelining), implementing only the suspend hierarchy.
- **Ktor** — `call.transaction` / `call.autocommit` migrated to suspend; backend-transparent.

## Scope decision
Compose Multiplatform targets use SQLite only (local file → offload is the ceiling, like Room). True async matters for server-side Postgres; on JVM that's r2dbc now. Native true-async (a pure-Kotlin wire-protocol driver) is intentionally deferred.

## Breaking
- Requires **JDK 21**.
- The old non-suspend `suspendTransaction` / `suspendAutocommit` (on `Database`, non-suspend block) are replaced by the `SuspendScope`-based ones on `SuspendDatabase`. Pre-1.0, so done as a clean replace.

## Verification
- `SqliteSuspendTest` (CRUD + rollback) green on JVM + native.
- `R2dbcIntegrationTest` (CRUD, rollback, typed unique-violation) green vs real Postgres (Testcontainers).
- ktor-di / ktor-koin / new r2dbc sample integration tests green vs real Postgres.
- No regression in the blocking path (korm-postgres all-types incl json).
- CI updated to cover the suspend path, korm-r2dbc and the r2dbc sample.

## New sample
`samples:r2dbc` — the same Ktor CRUD as `ktor-di`, one-line diff (`createR2dbcDatabase`), showing the suspend API is backend-transparent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)