### PR TITLE
Structural result keys, ResultRow.entity(), and AI-agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,156 @@
+# Korm for AI agents
+
+Type-safe Kotlin Multiplatform ORM / SQL DSL. This file is the canonical, copy-ready
+reference: prefer the forms shown here over any you might infer. Package is
+`io.github.kormium`. Full docs in [`docs/`](docs/README.md); deeper examples in
+[`samples/`](samples/README.md).
+
+## Mental model (read this first)
+
+- A `Catalog` is a compile-time database identity; a `Database<G>` is an instance of it.
+- A `Table<G, T>` is a pure schema descriptor; `T : Entity` holds the row's values.
+- **All queries run inside a scope**: `db.transaction { ... }` (BEGIN/COMMIT/ROLLBACK) or
+  `db.autocommit { ... }` (one pinned connection, no explicit tx — use for reads). Table
+  operations (`find`, `insert`, `update`, joins, ...) **only exist inside that block** — they
+  are extensions on the scope, not on the table globally.
+- Suspend mirror: `db.suspendTransaction { ... }` / `db.suspendAutocommit { ... }` with the
+  same API. (`korm-r2dbc` is true async; JDBC/SQLite/libpq are offloaded blocking.)
+
+## Define a schema
+
+```kotlin
+import io.github.kormium.*
+
+object App : Catalog
+
+object Users : Table<App, User>("users", ::User) {
+    val id by Column.UUID().primaryKey()
+    val name by Column.Text()
+    val age by Column.Int()
+    val note by Column.Text().nullable()   // nullable -> entity property is String?
+}
+
+class User : Entity() {
+    var id by Users.id        // non-null column -> non-null property (no `!!` needed)
+    var name by Users.name
+    var age by Users.age
+    var note by Users.note    // String?
+}
+```
+
+## Connect
+
+```kotlin
+import io.github.kormium.database.createDatabase
+
+val db: Database<App> = createDatabase(
+    host = "localhost", database = "postgres", user = "postgres", password = "password",
+)
+// SQLite: createSqliteDatabase(path = ":memory:")   (from korm-sqlite)
+```
+
+## Read — the canonical single-table form
+
+```kotlin
+val adults: List<User> = db.autocommit {
+    Users.find {
+        where { Users.age gtEq 18 }
+        where { Users.name like "A%" }   // multiple where { } blocks AND together
+        orderBy DESC Users.age
+        limit = 50
+        offset = 0
+    }
+}
+
+val ada: User? = db.autocommit { Users.findById(uuid) }   // targets the primary key
+val all: List<User> = db.autocommit { Users.all() }
+val n: Long = db.autocommit { Users.count { where { Users.age gtEq 18 } } }
+```
+
+Predicates: `eq`, `gtEq`, `gt`, `ltEq`, `lt`, `like`, `inList(...)`, `isNull()`,
+`isNotNull()`, combine with `and` / `or` / `not(...)`. Values are typed (`Users.age eq 18`,
+not `"18"`) and always bound as parameters.
+
+For a reusable query, build a `Query` directly: `Users.find(Query(Users.age gtEq 18))`.
+
+## Write
+
+```kotlin
+db.transaction {
+    Users.insert(user)                       // plain INSERT, returns the entity
+    Users.insert(user, returning = true)     // INSERT ... RETURNING for DB-generated values
+    Users.insertAll(listOf(a, b, c))
+
+    Users.update(User().apply { age = 37 }) { where { Users.id eq id } }   // only set fields
+    Users.deleteWhere { where { Users.name eq "Ada" } }
+}
+```
+
+`update` writes only the properties you assigned on the patch entity; untouched ones are left
+alone (assigning `null` does set NULL).
+
+## Joins
+
+```kotlin
+// Read rows, then index by the column you selected:
+db.autocommit {
+    (Users innerJoin Orders on (Users.id eq Orders.userId))
+        .where(Users.age gtEq 18)            // note: .where(expr) on a join, not a where { } block
+        .select()
+        .map { row -> row[Users.name] to row[Orders.total] }
+}
+
+// Two-table join -> entity pairs:
+val pairs: List<Pair<User, Order>> = db.autocommit {
+    (Users innerJoin Orders on (Users.id eq Orders.userId)).find()
+}
+
+// Three or more tables -> select() + row.entity(Table) for whole entities:
+val triples = db.autocommit {
+    (Users innerJoin Orders on (Users.id eq Orders.userId)
+           innerJoin Items  on (Orders.id eq Items.orderId))
+        .select()
+        .map { Triple(it.entity(Users), it.entity(Orders), it.entity(Items)) }
+}
+```
+
+`leftJoin` is available; read nullable right-side fields with `row.getOrNull(col)`.
+
+## Aggregates
+
+```kotlin
+val total = Orders.total.sum()
+db.autocommit {
+    (Users innerJoin Orders on (Users.id eq Orders.userId))
+        .groupBy(Users.id)
+        .having(total gt Value(BigDecimal.fromInt(100)))
+        .select(Users.name, count(), total)
+}.forEach { row ->
+    println("${row[Users.name]}: ${row[count()]} orders, ${row[total]}")
+}
+```
+
+Aggregates: `count()`, `col.count()`, `col.min()`, `col.max()`, `col.sum()`, `col.avg()`.
+Read them from a row by the same expression you selected — keys are structural, so
+`row[count()]` works with a fresh instance (a `val` is handy for reuse / `having`, not
+required). Single-table grouping starts from `Table.query()`.
+
+## Which form for what
+
+| Task | Use |
+|------|-----|
+| Filtered read, one table | `Table.find { where { } orderBy limit }` |
+| By primary key | `Table.findById(id)` |
+| Reusable/prebuilt query | `Table.find(Query(...))` |
+| Two-table join as entities | `(A innerJoin B on ...).find()` |
+| 3+ table join as entities | `.select()` + `row.entity(Table)` |
+| Columns / aggregates from a join | `.select(...)` + `row[col]` / `row[agg]` |
+| Single-table grouping | `Table.query().groupBy(...).select(...)` |
+
+## Gotchas
+
+- Operations are scope extensions — they don't compile outside `db.transaction { }` /
+  `db.autocommit { }` (or the `suspend*` variants).
+- A `Table<G, _>` can only be used in a `Database<G>` scope; mixing catalogs is a compile error.
+- `findById` targets the primary key and throws on a composite key — use `find(Query(col eq v))`.
+- Read nullable join columns with `getOrNull`; `row[col]` throws on NULL/absent.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -141,27 +141,37 @@ rows.forEach { row ->
 }
 ```
 
-Joining a third table keeps the `select(...)` projection forms. The two-entity `Pair`
-mapping is intentionally limited to two-table joins.
+`find()` (entity `Pair`s) is limited to two-table joins, but `select()` returns rows you can
+rebuild any table's entity from with `row.entity(Table)`, so three-or-more-table joins still
+read as whole entities:
+
+```kotlin
+val rows = db.autocommit {
+    (Users innerJoin Orders on (Users.id eq Orders.userId)
+           innerJoin Items  on (Orders.id eq Items.orderId))
+        .select()
+        .map { Triple(it.entity(Users), it.entity(Orders), it.entity(Items)) }
+}
+```
 
 ## Aggregations
 
-Keep aggregate expressions in `val`s and reuse those values when reading rows. Aggregates
-are keyed by expression identity.
+Read an aggregate from a row with the same expression you selected. Aggregates are keyed
+structurally, so a freshly built expression reads the same value — a `val` is convenient for
+reuse (and for `having(...)`), but no longer required to read the row back.
 
 ```kotlin
-val orders = count()
 val total = Orders.total.sum()
 
 val result = db.autocommit {
     (Users innerJoin Orders on (Users.id eq Orders.userId))
         .groupBy(Users.id)
         .having(total gt Value(BigDecimal.fromInt(100)))
-        .select(Users.name, orders, total)
+        .select(Users.name, count(), total)
 }
 
 result.forEach { row ->
-    println("${row[Users.name]}: ${row[orders]} orders, ${row[total]}")
+    println("${row[Users.name]}: ${row[count()]} orders, ${row[total]}")
 }
 ```
 

--- a/korm-core/src/commonMain/kotlin/Aggregate.kt
+++ b/korm-core/src/commonMain/kotlin/Aggregate.kt
@@ -6,10 +6,11 @@ import kotlin.jvm.JvmName
 // Aggregates are Selectable (appear in SELECT and are read from a ResultRow) and, since
 // Selectable is an Expression, can also appear in `having(...)` (e.g. `total gt Value(100)`).
 
-/** `COUNT(*)` — the number of rows in the group. Hold the result in a `val` to read it. */
+/** `COUNT(*)` — the number of rows in the group. */
 fun count(): Selectable<Long> = object : Selectable<Long> {
     override fun toSql(builder: ParamBuilder) = "COUNT(*)"
     override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Long? = rs.getLong(index)
+    override fun resultKey() = "COUNT(*)"
 }
 
 /** `COUNT(column)` — the non-null values of the column in the group. */
@@ -18,6 +19,7 @@ fun Column<*, *, *>.count(): Selectable<Long> {
     return object : Selectable<Long> {
         override fun toSql(builder: ParamBuilder) = "COUNT(${column.toSql(builder)})"
         override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Long? = rs.getLong(index)
+        override fun resultKey() = "COUNT(${column.resultKey()})"
     }
 }
 
@@ -49,12 +51,14 @@ fun Column<kotlin.Long, *, *>.sum(): Selectable<Long> = LongAggregate(this)
 private class ColumnAggregate<Z>(private val fn: String, private val column: Column<Z, *, *>) : Selectable<Z> {
     override fun toSql(builder: ParamBuilder) = "$fn(${column.toSql(builder)})"
     override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Z? = column.read(rs, index, typeMapper)
+    override fun resultKey() = "$fn(${column.resultKey()})"
 }
 
 // SUM(column) read as a Long (the server-side bigint width), regardless of the column's own type.
 private class LongAggregate(private val column: Column<*, *, *>) : Selectable<Long> {
     override fun toSql(builder: ParamBuilder) = "SUM(${column.toSql(builder)})"
     override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Long? = rs.getLong(index)
+    override fun resultKey() = "SUM(${column.resultKey()})"
 }
 
 /** `AVG(column)` as a Double. */
@@ -63,5 +67,6 @@ fun Column<*, *, *>.avg(): Selectable<Double> {
     return object : Selectable<Double> {
         override fun toSql(builder: ParamBuilder) = "AVG(${column.toSql(builder)})"
         override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Double? = rs.getDouble(index)
+        override fun resultKey() = "AVG(${column.resultKey()})"
     }
 }

--- a/korm-core/src/commonMain/kotlin/Column.kt
+++ b/korm-core/src/commonMain/kotlin/Column.kt
@@ -61,6 +61,10 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
     override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Z? =
         typeMapper.fromResult(rs, index, columnType) as Z?
 
+    // The property delegate yields a fresh Column per access, so identity can't key a result row;
+    // table+SQL-name is the stable, dialect-independent key (aggregates embed this for their target).
+    override fun resultKey(): Any = "${table.tableName}.$name"
+
     /**
      * A non-null column. Its entity property is `Z`: assigning `null` is a compile error, and
      * reading a field that was never assigned (or that the database returned as `NULL`) throws.

--- a/korm-core/src/commonMain/kotlin/Join.kt
+++ b/korm-core/src/commonMain/kotlin/Join.kt
@@ -11,6 +11,14 @@ import io.github.kormium.resultset.ResultSet
 interface Selectable<Z> : Expression {
     /** Reads this field's value from the result row at [index]. */
     fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z?
+
+    /**
+     * A stable, structural key identifying this field in a [ResultRow] — independent of the
+     * instance and the dialect. Two fields that select the same thing share a key, so a row can
+     * be read with a freshly built field (`row[Orders.total.sum()]`) without hoisting it into a
+     * `val`. Columns key by `table.name`; aggregates by their function over their target's key.
+     */
+    fun resultKey(): Any
 }
 
 internal enum class JoinType(val sql: String) { INNER("INNER JOIN"), LEFT("LEFT JOIN") }
@@ -125,13 +133,20 @@ class ResultRow internal constructor(private val values: Map<Any, Any?>) {
         @Suppress("UNCHECKED_CAST")
         return values[fieldKey(field)] as Z?
     }
+
+    /**
+     * Reconstructs [table]'s entity from this row. Works for any number of joined tables, so a
+     * three-or-more-table join reads as whole entities: `select()` (all columns), then
+     * `map { Triple(it.entity(A), it.entity(B), it.entity(C)) }`. Columns not present in the row
+     * read back as null.
+     */
+    fun <T : Entity> entity(table: Table<*, T>): T =
+        table.hydrate(table.getFieldDisplayNames().mapValues { (_, c) -> getOrNull(c) }.toMutableMap())
 }
 
-// Identifies a selected field. A Column's property delegate yields a fresh instance on each
-// access, so instance identity can't be used — key columns by table+name instead; aggregates
-// (held by the caller in a val) are keyed by instance.
-internal fun fieldKey(field: Selectable<*>): Any =
-    if (field is Column<*, *, *>) "${field.tableRef.tableName}.${field.name}" else field
+// Identifies a selected field by its structural key, so a row reads back regardless of which
+// instance is used (a Column's delegate and an aggregate factory both yield fresh instances).
+internal fun fieldKey(field: Selectable<*>): Any = field.resultKey()
 
 // Qualifies a table reference.
 internal fun Table<*, *>.qualifiedName(dialect: Dialect): String {

--- a/korm-core/src/commonMain/kotlin/Scope.kt
+++ b/korm-core/src/commonMain/kotlin/Scope.kt
@@ -108,15 +108,8 @@ class Scope<G : Catalog> internal constructor(
         asJoin().select(*fields, map = map)
 
     /** Runs a two-table join, reconstructing both sides as a `Pair` of entities. */
-    fun <A : Entity, B : Entity> JoinPair<G, A, B>.find(): List<Pair<A, B>> {
-        val aCols = left.getFieldDisplayNames()
-        val bCols = right.getFieldDisplayNames()
-        val rows = runSelect(exec, asJoin(), (aCols.values + bCols.values).toList())
-        return rows.map { row ->
-            left.hydrate(aCols.mapValues { (_, c) -> row.getOrNull(c) }.toMutableMap()) to
-                right.hydrate(bCols.mapValues { (_, c) -> row.getOrNull(c) }.toMutableMap())
-        }
-    }
+    fun <A : Entity, B : Entity> JoinPair<G, A, B>.find(): List<Pair<A, B>> =
+        select().map { row -> row.entity(left) to row.entity(right) }
 
     /** Runs a raw query on the pinned connection, mapping each row with [handler]. */
     fun <R> execute(sql: String, params: Map<String, Any?> = emptyMap(), handler: (ResultSet) -> R): List<R> =

--- a/korm-core/src/commonMain/kotlin/SuspendScope.kt
+++ b/korm-core/src/commonMain/kotlin/SuspendScope.kt
@@ -92,15 +92,8 @@ class SuspendScope<G : Catalog> internal constructor(
         asJoin().select(*fields, map = map)
 
     /** Runs a two-table join, reconstructing both sides as a `Pair` of entities. */
-    suspend fun <A : Entity, B : Entity> JoinPair<G, A, B>.find(): List<Pair<A, B>> {
-        val aCols = left.getFieldDisplayNames()
-        val bCols = right.getFieldDisplayNames()
-        val rows = runSelect(exec, asJoin(), (aCols.values + bCols.values).toList())
-        return rows.map { row ->
-            left.hydrate(aCols.mapValues { (_, c) -> row.getOrNull(c) }.toMutableMap()) to
-                right.hydrate(bCols.mapValues { (_, c) -> row.getOrNull(c) }.toMutableMap())
-        }
-    }
+    suspend fun <A : Entity, B : Entity> JoinPair<G, A, B>.find(): List<Pair<A, B>> =
+        select().map { row -> row.entity(left) to row.entity(right) }
 
     /** Runs a raw query on the pinned connection, mapping each row with [handler]. */
     suspend fun <R> execute(sql: String, params: Map<String, Any?> = emptyMap(), handler: (ResultSet) -> R): List<R> =

--- a/korm-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/korm-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -194,7 +194,7 @@ class SqliteIntegrationTest {
         assertEquals(2.5, row.aDouble)
         assertEquals(true, row.aBool)
         assertEquals("txt", row.aText)
-        assertEquals(0, BigDecimal.fromInt(123).compareTo(row.aDecimal!!))
+        assertEquals(0, BigDecimal.fromInt(123).compareTo(row.aDecimal))
         assertEquals(instant, row.anInstant)
         assertEquals(json, row.aJson)
         assertEquals(9_000_000_000L, row.aLong)

--- a/korm-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/korm-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -340,6 +340,40 @@ class SqliteIntegrationTest {
 
         db.transaction { Books.deleteWhere(Query(Books.id eq bookId)); Authors.deleteWhere(Query(Authors.id eq authorId)) }
     }
+
+    /**
+     * `ResultRow.entity(table)` rebuilds whole entities from a join row (the path 3+-table joins
+     * use), and an aggregate reads back with a freshly built instance — no `val` hoisting needed.
+     */
+    @Test
+    fun testEntityHydrationAndFreshAggregateKey() {
+        val authorId = Uuid.random()
+        db.transaction {
+            Authors.execSql(authorsDdl)
+            Books.execSql(booksDdl)
+            Authors.insert(Author().apply { id = authorId; name = "Grace" })
+            Books.insert(Book().apply { id = Uuid.random(); this.authorId = authorId; title = "A" })
+            Books.insert(Book().apply { id = Uuid.random(); this.authorId = authorId; title = "B" })
+        }
+
+        val (author, book) = db.autocommit {
+            (Authors innerJoin Books on (Authors.id eq Books.authorId))
+                .where(Books.title eq "A")
+                .select()
+                .map { it.entity(Authors) to it.entity(Books) }
+        }.single()
+        assertEquals(authorId, author.id)
+        assertEquals("Grace", author.name)
+        assertEquals("A", book.title)
+
+        // Selected with one count(), read with a different count() instance — structural key matches.
+        val n = db.autocommit {
+            Books.query().groupBy(Books.authorId).select(Books.authorId, count())
+        }.single()[count()]
+        assertEquals(2L, n)
+
+        db.transaction { Books.deleteWhere(Query(Books.authorId eq authorId)); Authors.deleteWhere(Query(Authors.id eq authorId)) }
+    }
 }
 
 object SqCatalog : Catalog

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,28 @@
+# Korm
+
+> Type-safe ORM and SQL DSL for Kotlin Multiplatform (JVM + Native). Tables, entities, typed
+> predicates, transactions, joins, aggregations and migrations, with compile-time
+> database↔table safety. Backends: PostgreSQL (JDBC + native libpq), SQLite, async r2dbc,
+> plus Ktor integration. Package `io.github.kormium`.
+
+All queries run inside `db.transaction { }` or `db.autocommit { }` (suspend mirrors:
+`db.suspendTransaction { }` / `db.suspendAutocommit { }`). Table operations are scope
+extensions, not global table methods.
+
+## Start here
+
+- [AGENTS.md](AGENTS.md): canonical, copy-ready snippets for every common task (read this first)
+- [Quick start](docs/quick-start.md): minimal end-to-end setup
+- [Tables and entities](docs/tables-and-entities.md): columns, nullability, primary keys
+
+## Reference
+
+- [Queries, joins and aggregations](docs/queries.md): `find { where { } }`, joins, `entity()`, aggregates
+- [Transactions, suspend API and migrations](docs/transactions-and-migrations.md): scopes, savepoints, `migrate`
+- [Backends](docs/backends.md): PostgreSQL / SQLite / r2dbc driver setup
+- [Ktor integration](docs/ktor.md): per-DI-framework artifacts and request-scoped helpers
+- [Installation](docs/installation.md): Gradle, BOM, native system libraries
+
+## Examples
+
+- [samples/](samples/README.md): runnable projects (CRUD, Ktor DI/Koin, sharding, read-through cache, r2dbc)


### PR DESCRIPTION
## Why

Two read-result footguns plus an effort to make the library cheap and correct for AI coding agents. The trigger: even with full repo access, an agent reached for the low-level `(A innerJoin B on ...).select()` API instead of the canonical single-table `find { where {} }` block DSL — because nothing led with the idiomatic path.

## Changes

**Fix — aggregates no longer need a `val`.** `Selectable.resultKey()` gives every selectable a stable, dialect-independent key (columns by `"table.name"`, aggregates by `"FN(target)"`). `ResultRow` keys by it, so `row[Orders.total.sum()]` reads back with a freshly built instance. Removes the old `if (field is Column)` special-case and the instance-keying of aggregates.

**Fix — `find()` beyond two tables.** New `ResultRow.entity(table): T` rebuilds any joined table's entity from a row, so 3+-table joins read as whole entities:
```kotlin
.select().map { Triple(it.entity(A), it.entity(B), it.entity(C)) }
```
The two-table `JoinPair.find()` (sync + suspend) is now sugar over `select().map { it.entity(left) to it.entity(right) }`.

**Docs for agents.** `AGENTS.md` (canonical copy-ready snippets, leading with `find { where {} }`, a "which form for what" table, and gotchas) + `llms.txt` (index), and a refreshed `docs/queries.md`.

Both code changes are additive — no existing public signature changed.

## Tests

- New `SqliteIntegrationTest.testEntityHydrationAndFreshAggregateKey` (entity rebuild from a join row + reading `count()` with a fresh instance) — green on JVM and macOS arm64.
- `korm-core:jvmTest`, `korm-sqlite:jvmTest`, `korm-sqlite:macosArm64Test` pass; `korm-r2dbc` / `korm-ktor-di` compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)