### PR TITLE
Reactive Flow queries (korm-observe) + WriteListener commit hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to korm are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] — Reactive queries
+
+### Added
+- **`korm-observe`** module: reactive `Flow` queries. `Table.observe(db) { where { … } }`
+  emits the result now and re-emits after every committed write to the table; a generic
+  `SuspendDatabase.observe(tables) { … }` covers joins and custom fetches. Writes are
+  conflated. See [Observing changes](docs/observe.md).
+- **`WriteListener` commit hook** on `Database` / `SuspendDatabase`
+  (`db.writeListeners.add { tables -> … }`): notified, after commit, with the set of tables a
+  scope wrote. A generic seam (also usable for cache invalidation, audit, metrics) that backs
+  `korm-observe`.
+- **`invalidates` argument** on the raw `Scope.execute` / `executeUpdate` (and suspend
+  counterparts): declare the tables a raw statement writes so observers are notified — the
+  analog of Room's `@RawQuery(observedEntities = …)`.
+
+### Changed
+- **Breaking: `Database` no longer extends `SqlExecutor`.** The pooled, scope-less
+  `db.execute(...)` / `db.executeUpdate(...)` is removed — run one-off statements through a
+  scope instead: `db.autocommit { execute(...) }`. This makes every write transactional and
+  observable. `SuspendDatabase` was never an executor, so it is unchanged. The
+  `SqlParameterSource` overloads now live only on the pinned `SqlExecutor` inside a scope.
+
 ## [0.2.0] — API redesign
 
 A breaking redesign of the core API. Korm now models runtime query/insert/update mapping

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,7 @@ val publishableModules = setOf(
     "korm-jdbc",
     "korm-sqlite",
     "korm-r2dbc",
+    "korm-observe",
     "korm-ktor",
     "korm-ktor-di",
     "korm-ktor-koin",

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,15 +15,16 @@ is intentionally short; the deeper material lives here.
 5. [Transactions and migrations](transactions-and-migrations.md) - scopes, savepoints,
    suspend API, async backends and migrations.
 6. [Backends](backends.md) - PostgreSQL, SQLite, r2dbc and platform support.
-7. [Ktor integration](ktor.md) - DI-agnostic, Ktor DI and Koin helpers.
-8. [API cookbook](api-cookbook.md) - copy-pasteable recipes for common tasks.
-9. [API ergonomics](api-ergonomics.md) - current canonical API style and escape hatches.
-10. [Observability](observability.md) - target logging, metrics and failure visibility.
-11. [Production guide](production-guide.md) - conservative guidance for real services.
-12. [Compatibility policy](compatibility.md) - supported versions, targets and API policy.
-13. [Design](design.md) - internal architecture and extension points.
-14. [Roadmap](roadmap.md) - current baseline, pre-1.0 hardening and future work.
-15. [Project guide](project.md) - samples, benchmarks, testing and contribution notes.
+7. [Observing changes](observe.md) - reactive `Flow` queries that re-emit on writes.
+8. [Ktor integration](ktor.md) - DI-agnostic, Ktor DI and Koin helpers.
+9. [API cookbook](api-cookbook.md) - copy-pasteable recipes for common tasks.
+10. [API ergonomics](api-ergonomics.md) - current canonical API style and escape hatches.
+11. [Observability](observability.md) - target logging, metrics and failure visibility.
+12. [Production guide](production-guide.md) - conservative guidance for real services.
+13. [Compatibility policy](compatibility.md) - supported versions, targets and API policy.
+14. [Design](design.md) - internal architecture and extension points.
+15. [Roadmap](roadmap.md) - current baseline, pre-1.0 hardening and future work.
+16. [Project guide](project.md) - samples, benchmarks, testing and contribution notes.
 
 ## API Surface
 
@@ -36,6 +37,7 @@ Korm is split into small artifacts:
 | `korm-postgres` | PostgreSQL dialect and drivers: JDBC/HikariCP on JVM, libpq on Native |
 | `korm-sqlite` | SQLite dialect and drivers: sqlite-jdbc, sqlite3 and AndroidX SQLite |
 | `korm-r2dbc` | True async PostgreSQL on JVM, suspend API only |
+| `korm-observe` | Reactive `Flow` queries that re-emit when watched tables change |
 | `korm-jdbc` | Internal/shared JVM JDBC plumbing used by JVM drivers |
 | `korm-ktor` | Ktor helpers without a DI dependency |
 | `korm-ktor-di` | Ktor built-in DI integration |

--- a/docs/design.md
+++ b/docs/design.md
@@ -24,6 +24,7 @@ transactions and indexes.
 | `korm-postgres` | PostgreSQL dialect and backend factories for JDBC/libpq |
 | `korm-sqlite` | SQLite dialect and backend factories for sqlite-jdbc/sqlite3/AndroidX SQLite |
 | `korm-r2dbc` | Async PostgreSQL `SuspendDatabase` implementation |
+| `korm-observe` | Reactive `Flow` queries over core's `WriteListener` commit hook |
 | `korm-jdbc` | Shared JVM JDBC execution, pooling and named parameter binding |
 | `korm-ktor*` | Server integration over the suspend API |
 
@@ -164,7 +165,10 @@ A backend needs:
 2. A `TypeMapper` or reuse of `StandardTypeMapper`.
 3. A `ResultSet` adapter.
 4. A `SqlExecutor` for blocking, a `SuspendSqlExecutor` for suspend, or both.
-5. A `Database` and/or `SuspendDatabase` implementation.
+5. A `Database` and/or `SuspendDatabase` implementation. The handle is not itself a
+   `SqlExecutor`; it hands a pinned executor to `usePinned` / `useConnection`. To support
+   reactive observation, override `writeListeners` with a real `WriteListeners()` (the
+   default `WriteListeners.Disabled` opts out at no cost).
 6. A factory function that returns the driver.
 7. Tests for SQL rendering, type round trips, transactions and error mapping.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -42,11 +42,13 @@ dependencies {
 | `korm-postgres` | You use PostgreSQL through JDBC on JVM or libpq on Native |
 | `korm-sqlite` | You use SQLite on JVM, Native or Android |
 | `korm-r2dbc` | You want non-blocking PostgreSQL on JVM |
+| `korm-observe` | You want reactive `Flow` queries that re-emit when data changes |
 | `korm-ktor` | You want explicit database passing in Ktor routes |
 | `korm-ktor-di` | You use Ktor's built-in DI container |
 | `korm-ktor-koin` | You use Koin in a Ktor application |
 
-Backend artifacts bring `korm-core` transitively.
+Backend artifacts bring `korm-core` transitively. `korm-observe` is pure common code and
+supports the same targets as `korm-core` (JVM, Native, Android, iOS).
 
 ## Native Libraries
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -162,11 +162,28 @@ Before recommending Korm for production, observability should have:
 - query timing hook or metrics bridge;
 - pool metrics guide for JDBC/HikariCP;
 - examples for Ktor `StatusPages`;
-- tests proving observers run on success and failure once that API exists.
+- tests proving observers run on success and failure (the `WriteListener` commit hook now
+  exists — see below).
+
+## Write Notification
+
+`Database`/`SuspendDatabase` expose a `writeListeners: WriteListeners` registry. After a
+`transaction { }` / `autocommit { }` (or suspend counterpart) commits, every registered
+`WriteListener` is called with the set of table names written during it (rolled-back work
+notifies nothing). This is a generic, synchronous commit hook — it backs `korm-observe`
+([Observing changes](observe.md)) but is equally usable for cache invalidation, audit or
+metrics:
+
+```kotlin
+db.writeListeners.add { tables -> log.info("committed writes to {}", tables) }
+```
+
+Raw SQL declares its tables via the `invalidates` argument on `execute`/`executeUpdate`;
+see [Observing changes](observe.md#raw-sql).
 
 ## Current Recommendation
 
-Until a public observability API exists:
+For timing and pool metrics (not yet covered by a built-in API):
 
 - rely on typed exceptions for application-level handling;
 - configure HikariCP metrics directly for JVM JDBC pool visibility;

--- a/docs/observe.md
+++ b/docs/observe.md
@@ -1,0 +1,87 @@
+# Observing Changes
+
+`korm-observe` turns a query into a `Flow` that re-emits whenever the data it reads changes.
+It is the building block for reactive UIs (Compose Multiplatform, Android) the way Room's
+observable queries are — without Korm adopting an annotation processor or SQL strings.
+
+```kotlin
+dependencies {
+    implementation("io.github.kormium:korm-observe")
+}
+```
+
+## Observing a Table
+
+```kotlin
+import io.github.kormium.observe.observe
+
+val adults: Flow<List<User>> = Users.observe(db) {
+    where { Users.age gtEq 18 }
+}
+```
+
+`Users.observe(db) { … }` emits the query result once immediately, then re-runs the query and
+emits again after every committed write that touches the `users` table. With no block it
+observes every row. `db` is the suspend database handle (`SuspendDatabase<G>`); every shipped
+driver provides one.
+
+The query block is the same one used by [`Table.find`](queries.md): predicates, ordering,
+`limit`/`offset`. Reads run in `suspendAutocommit`.
+
+## How Invalidation Works
+
+Korm tracks which tables each `transaction { }` / `autocommit { }` (and their suspend
+counterparts) writes, and notifies observers **after the block commits**. A rolled-back
+transaction notifies nothing. Bursts of writes are conflated — a flood of commits collapses
+into a single re-fetch rather than one per commit.
+
+```kotlin
+// This commit re-fires every Flow observing "users":
+db.suspendTransaction { Users.insert(user) }
+```
+
+## The Generic Form
+
+For multi-table queries (joins) or custom fetch logic, use the lower-level overload and pass
+the tables to watch:
+
+```kotlin
+val dashboard: Flow<Dashboard> = db.observe(setOf("users", "orders")) {
+    // any SuspendScope read(s)
+    Dashboard(
+        userCount = Users.count(),
+        orderCount = Orders.count(),
+    )
+}
+```
+
+## Raw SQL
+
+Korm cannot see which tables raw SQL touches, so declare them with `invalidates` so observers
+(and any future cache) are notified on commit — the analog of Room's
+`@RawQuery(observedEntities = …)`:
+
+```kotlin
+db.transaction {
+    executeUpdate("UPDATE products SET price = price * 2", invalidates = listOf(Products))
+}
+```
+
+Without `invalidates`, a raw write commits normally but does not fire observers.
+
+## Boundaries
+
+Observation sees writes made **through this database handle's API**. It does not see:
+
+- writes by another process or another `Database` instance over the same database;
+- raw SQL whose tables you did not declare via `invalidates`;
+- cascading changes from triggers or `ON DELETE CASCADE` (only the table you wrote is marked).
+
+This is the same default boundary Room has for a single in-process database. Cross-process
+invalidation (PostgreSQL `LISTEN/NOTIFY`, SQLite update hooks) is a separate, later concern.
+
+## Lifecycle
+
+Each collector registers its own listener and removes it automatically when collection stops
+(the `Flow` is cold). Nothing to close manually. A backend whose driver does not enable
+notification emits the initial value and nothing further.

--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -122,7 +122,9 @@ services should still translate database errors into application-specific respon
 
 ## Observability
 
-Until Korm ships a public observer/metrics API:
+A `WriteListener` commit hook (`db.writeListeners`) is available for write notification —
+cache invalidation, audit, metrics on commit — and backs reactive `korm-observe` queries.
+For timing/pool metrics, which are not yet built in:
 
 - wrap repository/service calls with timers;
 - configure HikariCP metrics directly on JVM JDBC deployments;

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -204,3 +204,9 @@ Use raw SQL only when the SQL text is fully controlled by your application:
 ```kotlin
 Users.find(Query(RawExpression("""lower("name") = 'ada'""")))
 ```
+
+## Observing Changes
+
+To re-run a query automatically whenever its data changes, use `korm-observe`:
+`Users.observe(db) { where { Users.age gtEq 18 } }` returns a `Flow<List<User>>` that
+re-emits after every committed write to the table. See [Observing changes](observe.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,6 +16,7 @@ Shipped today:
 - typed table/entity DSL;
 - typed predicates, joins and aggregations;
 - transactions, savepoints, suspend scopes and migrations;
+- reactive `Flow` queries (`korm-observe`) over a `WriteListener` commit hook;
 - Ktor integration for explicit database passing, Ktor DI and Koin;
 - Maven Central publishing with a BOM.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-version = 0.2.0
+version = 0.3.0
 group = io.github.kormium
 
 # The `samples` modules still use a custom-named native target (e.g. macosX64("native"))

--- a/korm-core/src/commonMain/kotlin/Scope.kt
+++ b/korm-core/src/commonMain/kotlin/Scope.kt
@@ -13,16 +13,29 @@ class Scope<G : Catalog> internal constructor(
     private val exec: SqlExecutor,
     /** The owning database's configuration (e.g. the default [BatchInsertMode]). */
     internal val config: KormConfig = KormConfig(),
+    /**
+     * Tables written during this scope, collected for write notification. The owning
+     * [transaction] / [autocommit] fires them at [io.github.kormium.WriteListeners] once the
+     * block commits. Over-collection (e.g. a rolled-back savepoint) is safe — it only causes
+     * a spurious refresh, never a missed one.
+     */
+    internal val dirtyTables: MutableSet<String> = mutableSetOf(),
 ) {
     private var savepointCounter = 0
+
+    private fun Table<G, *>.markWritten() {
+        dirtyTables.add(tableName)
+    }
 
     /**
      * Inserts [entity]. By default returns the entity as given (a plain INSERT — the fast
      * path). Pass `returning = true` to fetch the stored row back via SQL `RETURNING`, e.g. to
      * read database-generated columns; then it returns that row (or null if none).
      */
-    fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): T? =
-        insert(entity, exec, returning)
+    fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): T? {
+        markWritten()
+        return insert(entity, exec, returning)
+    }
 
     /**
      * Inserts all [entities] in one statement. By default returns [entities] as given; pass
@@ -32,27 +45,38 @@ class Scope<G : Catalog> internal constructor(
         entities: List<T>,
         returning: Boolean = false,
         batchInsertMode: BatchInsertMode = config.batchInsertMode,
-    ): List<T> = insertAll(entities, exec, returning, batchInsertMode)
+    ): List<T> {
+        markWritten()
+        return insertAll(entities, exec, returning, batchInsertMode)
+    }
 
     /**
      * Insert-or-update on a single-column conflict target: inserts [entity]'s present fields,
      * and on conflict with [onConflict] updates with [update]'s present fields. Pass
      * `returning = true` to fetch the resulting row.
      */
-    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, *>, update: T, returning: Boolean = false): T? =
-        upsert(entity, listOf(onConflict), update, exec, returning)
+    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, *>, update: T, returning: Boolean = false): T? {
+        markWritten()
+        return upsert(entity, listOf(onConflict), update, exec, returning)
+    }
 
     /** Insert-or-update on a composite (multi-column) conflict target; see the single-column overload. */
-    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, *>>, update: T, returning: Boolean = false): T? =
-        upsert(entity, onConflict, update, exec, returning)
+    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, *>>, update: T, returning: Boolean = false): T? {
+        markWritten()
+        return upsert(entity, onConflict, update, exec, returning)
+    }
 
     /** Insert-or-do-nothing on a single-column conflict target; returns the affected row count (1 inserted, 0 ignored). */
-    fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: Column<*, *, *>): Long =
-        insertOrIgnore(entity, listOf(onConflict), exec)
+    fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: Column<*, *, *>): Long {
+        markWritten()
+        return insertOrIgnore(entity, listOf(onConflict), exec)
+    }
 
     /** Insert-or-do-nothing on a composite conflict target; see the single-column overload. */
-    fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: List<Column<*, *, *>>): Long =
-        insertOrIgnore(entity, onConflict, exec)
+    fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: List<Column<*, *, *>>): Long {
+        markWritten()
+        return insertOrIgnore(entity, onConflict, exec)
+    }
 
     /** Counts rows matching [query] (all rows by default). */
     fun <T : Entity> Table<G, T>.count(query: Query = Query()): Long = count(query, exec)
@@ -69,27 +93,40 @@ class Scope<G : Catalog> internal constructor(
     fun <T : Entity> Table<G, T>.findById(id: Any): T? = selectById(id, exec)
     fun <T : Entity> Table<G, T>.all(): List<T> = selectAll(exec)
     /** Updates rows matching [query] with the present fields of [entity]; returns the affected row count. */
-    fun <T : Entity> Table<G, T>.update(query: Query, entity: T): Long = updateRows(query, entity, exec)
+    fun <T : Entity> Table<G, T>.update(query: Query, entity: T): Long {
+        markWritten()
+        return updateRows(query, entity, exec)
+    }
 
     /**
      * Block form of [update]: `Users.update(patch) { where { Users.id eq id } }`. Multiple
      * `where { }` blocks AND together; an empty block updates every row. Returns the affected
      * row count (e.g. 0 means no row matched — useful for not-found / optimistic-locking checks).
      */
-    fun <T : Entity> Table<G, T>.update(entity: T, block: QueryBuilder.() -> Unit): Long =
-        updateRows(QueryBuilder().apply(block).build(), entity, exec)
+    fun <T : Entity> Table<G, T>.update(entity: T, block: QueryBuilder.() -> Unit): Long {
+        markWritten()
+        return updateRows(QueryBuilder().apply(block).build(), entity, exec)
+    }
 
     /** Deletes rows matching [query]; returns the affected row count. */
-    fun <T : Entity> Table<G, T>.deleteWhere(query: Query): Long = deleteRows(query, exec)
+    fun <T : Entity> Table<G, T>.deleteWhere(query: Query): Long {
+        markWritten()
+        return deleteRows(query, exec)
+    }
 
     /**
      * Block form of [deleteWhere]: `Users.deleteWhere { where { Users.deletedAt neq null } }`.
      * An empty block deletes every row. Returns the affected row count.
      */
-    fun <T : Entity> Table<G, T>.deleteWhere(block: QueryBuilder.() -> Unit): Long =
-        deleteRows(QueryBuilder().apply(block).build(), exec)
+    fun <T : Entity> Table<G, T>.deleteWhere(block: QueryBuilder.() -> Unit): Long {
+        markWritten()
+        return deleteRows(QueryBuilder().apply(block).build(), exec)
+    }
 
-    fun <T : Entity> Table<G, T>.execSql(sql: String) = runRaw(sql, exec)
+    fun <T : Entity> Table<G, T>.execSql(sql: String) {
+        markWritten()
+        runRaw(sql, exec)
+    }
 
     /** Runs the query, selecting the given fields (or all columns if none are given). */
     fun Join<G>.select(vararg fields: Selectable<*>): List<ResultRow> =
@@ -118,15 +155,40 @@ class Scope<G : Catalog> internal constructor(
         }
     }
 
-    /** Runs a raw query on the pinned connection, mapping each row with [handler]. */
-    fun <R> execute(sql: String, params: Map<String, Any?> = emptyMap(), handler: (ResultSet) -> R): List<R> =
-        exec.execute(sql, params, handler)
+    /**
+     * Runs a raw query on the pinned connection, mapping each row with [handler]. Korm can't
+     * see which tables raw SQL touches, so pass any it writes in [invalidates] to notify write
+     * listeners (e.g. `korm-observe`) on commit; leave it empty for a pure read.
+     */
+    fun <R> execute(
+        sql: String,
+        params: Map<String, Any?> = emptyMap(),
+        invalidates: List<Table<G, *>> = emptyList(),
+        handler: (ResultSet) -> R,
+    ): List<R> {
+        invalidates.forEach { it.markWritten() }
+        return exec.execute(sql, params, handler)
+    }
 
-    /** Runs raw SQL on the pinned connection, returning the row/update count. */
-    fun execute(sql: String, params: Map<String, Any?> = emptyMap()): Long = exec.execute(sql, params)
+    /** Runs raw SQL on the pinned connection, returning the row/update count. See [invalidates]. */
+    fun execute(
+        sql: String,
+        params: Map<String, Any?> = emptyMap(),
+        invalidates: List<Table<G, *>> = emptyList(),
+    ): Long {
+        invalidates.forEach { it.markWritten() }
+        return exec.execute(sql, params)
+    }
 
-    /** Runs a raw statement (DDL/DML) on the pinned connection. */
-    fun executeUpdate(sql: String, params: Map<String, Any?> = emptyMap()) = exec.executeUpdate(sql, params)
+    /** Runs a raw statement (DDL/DML) on the pinned connection. See [invalidates]. */
+    fun executeUpdate(
+        sql: String,
+        params: Map<String, Any?> = emptyMap(),
+        invalidates: List<Table<G, *>> = emptyList(),
+    ) {
+        invalidates.forEach { it.markWritten() }
+        exec.executeUpdate(sql, params)
+    }
 
     /**
      * Runs [block] inside a SAVEPOINT on the same connection: if it throws, only its
@@ -151,12 +213,21 @@ class Scope<G : Catalog> internal constructor(
  * catalog [G]. Calling another database's `transaction` inside opens an independent
  * transaction (separate connection); use [Scope.savepoint] for a nested unit.
  */
-fun <G : Catalog, R> Database<G>.transaction(block: Scope<G>.() -> R): R =
-    usePinned(transactional = true) { Scope<G>(it, config).block() }
+fun <G : Catalog, R> Database<G>.transaction(block: Scope<G>.() -> R): R {
+    // The dirty-table set outlives the block so we can fire it after the commit returns.
+    val dirty = mutableSetOf<String>()
+    val result = usePinned(transactional = true) { Scope<G>(it, config, dirty).block() }
+    writeListeners.fire(dirty)
+    return result
+}
 
 /**
  * Runs [block] on a pinned connection in autocommit (no surrounding transaction) —
  * the cheap path for reads / single statements.
  */
-fun <G : Catalog, R> Database<G>.autocommit(block: Scope<G>.() -> R): R =
-    usePinned(transactional = false) { Scope<G>(it, config).block() }
+fun <G : Catalog, R> Database<G>.autocommit(block: Scope<G>.() -> R): R {
+    val dirty = mutableSetOf<String>()
+    val result = usePinned(transactional = false) { Scope<G>(it, config, dirty).block() }
+    writeListeners.fire(dirty)
+    return result
+}

--- a/korm-core/src/commonMain/kotlin/SuspendScope.kt
+++ b/korm-core/src/commonMain/kotlin/SuspendScope.kt
@@ -15,35 +15,54 @@ class SuspendScope<G : Catalog> internal constructor(
     private val exec: SuspendSqlExecutor,
     /** The owning database's configuration (e.g. the default [BatchInsertMode]). */
     internal val config: KormConfig = KormConfig(),
+    /** Tables written during this scope; see [Scope.dirtyTables]. */
+    internal val dirtyTables: MutableSet<String> = mutableSetOf(),
 ) {
     private var savepointCounter = 0
 
+    private fun Table<G, *>.markWritten() {
+        dirtyTables.add(tableName)
+    }
+
     /** Inserts [entity]; see [Scope.insert]. */
-    suspend fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): T? =
-        insert(entity, exec, returning)
+    suspend fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): T? {
+        markWritten()
+        return insert(entity, exec, returning)
+    }
 
     /** Inserts all [entities] in one statement; see [Scope.insertAll]. */
     suspend fun <T : Entity> Table<G, T>.insertAll(
         entities: List<T>,
         returning: Boolean = false,
         batchInsertMode: BatchInsertMode = config.batchInsertMode,
-    ): List<T> = insertAll(entities, exec, returning, batchInsertMode)
+    ): List<T> {
+        markWritten()
+        return insertAll(entities, exec, returning, batchInsertMode)
+    }
 
     /** Insert-or-update on a single-column conflict target; see [Scope.upsert]. */
-    suspend fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, *>, update: T, returning: Boolean = false): T? =
-        upsert(entity, listOf(onConflict), update, exec, returning)
+    suspend fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, *>, update: T, returning: Boolean = false): T? {
+        markWritten()
+        return upsert(entity, listOf(onConflict), update, exec, returning)
+    }
 
     /** Insert-or-update on a composite conflict target; see [Scope.upsert]. */
-    suspend fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, *>>, update: T, returning: Boolean = false): T? =
-        upsert(entity, onConflict, update, exec, returning)
+    suspend fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, *>>, update: T, returning: Boolean = false): T? {
+        markWritten()
+        return upsert(entity, onConflict, update, exec, returning)
+    }
 
     /** Insert-or-do-nothing on a single-column conflict target; see [Scope.insertOrIgnore]. */
-    suspend fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: Column<*, *, *>): Long =
-        insertOrIgnore(entity, listOf(onConflict), exec)
+    suspend fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: Column<*, *, *>): Long {
+        markWritten()
+        return insertOrIgnore(entity, listOf(onConflict), exec)
+    }
 
     /** Insert-or-do-nothing on a composite conflict target; see [Scope.insertOrIgnore]. */
-    suspend fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: List<Column<*, *, *>>): Long =
-        insertOrIgnore(entity, onConflict, exec)
+    suspend fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: List<Column<*, *, *>>): Long {
+        markWritten()
+        return insertOrIgnore(entity, onConflict, exec)
+    }
 
     /** Counts rows matching [query] (all rows by default). */
     suspend fun <T : Entity> Table<G, T>.count(query: Query = Query()): Long = count(query, exec)
@@ -60,20 +79,33 @@ class SuspendScope<G : Catalog> internal constructor(
     suspend fun <T : Entity> Table<G, T>.findById(id: Any): T? = selectById(id, exec)
     suspend fun <T : Entity> Table<G, T>.all(): List<T> = selectAll(exec)
     /** Updates rows matching [query] with the present fields of [entity]; returns the affected row count. */
-    suspend fun <T : Entity> Table<G, T>.update(query: Query, entity: T): Long = updateRows(query, entity, exec)
+    suspend fun <T : Entity> Table<G, T>.update(query: Query, entity: T): Long {
+        markWritten()
+        return updateRows(query, entity, exec)
+    }
 
     /** Block form of [update]; see [Scope.update]. */
-    suspend fun <T : Entity> Table<G, T>.update(entity: T, block: QueryBuilder.() -> Unit): Long =
-        updateRows(QueryBuilder().apply(block).build(), entity, exec)
+    suspend fun <T : Entity> Table<G, T>.update(entity: T, block: QueryBuilder.() -> Unit): Long {
+        markWritten()
+        return updateRows(QueryBuilder().apply(block).build(), entity, exec)
+    }
 
     /** Deletes rows matching [query]; returns the affected row count. */
-    suspend fun <T : Entity> Table<G, T>.deleteWhere(query: Query): Long = deleteRows(query, exec)
+    suspend fun <T : Entity> Table<G, T>.deleteWhere(query: Query): Long {
+        markWritten()
+        return deleteRows(query, exec)
+    }
 
     /** Block form of [deleteWhere]; see [Scope.deleteWhere]. */
-    suspend fun <T : Entity> Table<G, T>.deleteWhere(block: QueryBuilder.() -> Unit): Long =
-        deleteRows(QueryBuilder().apply(block).build(), exec)
+    suspend fun <T : Entity> Table<G, T>.deleteWhere(block: QueryBuilder.() -> Unit): Long {
+        markWritten()
+        return deleteRows(QueryBuilder().apply(block).build(), exec)
+    }
 
-    suspend fun <T : Entity> Table<G, T>.execSql(sql: String) = runRaw(sql, exec)
+    suspend fun <T : Entity> Table<G, T>.execSql(sql: String) {
+        markWritten()
+        runRaw(sql, exec)
+    }
 
     /** Runs the query, selecting the given fields (or all columns if none are given). */
     suspend fun Join<G>.select(vararg fields: Selectable<*>): List<ResultRow> =
@@ -102,15 +134,40 @@ class SuspendScope<G : Catalog> internal constructor(
         }
     }
 
-    /** Runs a raw query on the pinned connection, mapping each row with [handler]. */
-    suspend fun <R> execute(sql: String, params: Map<String, Any?> = emptyMap(), handler: (ResultSet) -> R): List<R> =
-        exec.execute(sql, params, handler)
+    /**
+     * Runs a raw query on the pinned connection, mapping each row with [handler]. Pass any
+     * tables the SQL writes in [invalidates] to notify write listeners on commit; see
+     * [Scope.execute].
+     */
+    suspend fun <R> execute(
+        sql: String,
+        params: Map<String, Any?> = emptyMap(),
+        invalidates: List<Table<G, *>> = emptyList(),
+        handler: (ResultSet) -> R,
+    ): List<R> {
+        invalidates.forEach { it.markWritten() }
+        return exec.execute(sql, params, handler)
+    }
 
-    /** Runs raw SQL on the pinned connection, returning the row/update count. */
-    suspend fun execute(sql: String, params: Map<String, Any?> = emptyMap()): Long = exec.execute(sql, params)
+    /** Runs raw SQL on the pinned connection, returning the row/update count. See [invalidates]. */
+    suspend fun execute(
+        sql: String,
+        params: Map<String, Any?> = emptyMap(),
+        invalidates: List<Table<G, *>> = emptyList(),
+    ): Long {
+        invalidates.forEach { it.markWritten() }
+        return exec.execute(sql, params)
+    }
 
-    /** Runs a raw statement (DDL/DML) on the pinned connection. */
-    suspend fun executeUpdate(sql: String, params: Map<String, Any?> = emptyMap()) = exec.executeUpdate(sql, params)
+    /** Runs a raw statement (DDL/DML) on the pinned connection. See [invalidates]. */
+    suspend fun executeUpdate(
+        sql: String,
+        params: Map<String, Any?> = emptyMap(),
+        invalidates: List<Table<G, *>> = emptyList(),
+    ) {
+        invalidates.forEach { it.markWritten() }
+        exec.executeUpdate(sql, params)
+    }
 
     /**
      * Runs [block] inside a SAVEPOINT on the same connection: if it throws, only its
@@ -135,12 +192,20 @@ class SuspendScope<G : Catalog> internal constructor(
  * suspend while the connection stays pinned. Whether this is true async or a blocking
  * driver offloaded to a dispatcher depends on the backend's [SuspendDatabase.useConnection].
  */
-suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendTransaction(block: suspend SuspendScope<G>.() -> R): R =
-    useConnection(transactional = true) { SuspendScope<G>(it, config).block() }
+suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendTransaction(block: suspend SuspendScope<G>.() -> R): R {
+    val dirty = mutableSetOf<String>()
+    val result = useConnection(transactional = true) { SuspendScope<G>(it, config, dirty).block() }
+    writeListeners.fire(dirty)
+    return result
+}
 
 /**
  * Runs [block] on a pinned connection in autocommit (no surrounding transaction) — the
  * suspend counterpart of [autocommit], the cheap path for reads / single statements.
  */
-suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendAutocommit(block: suspend SuspendScope<G>.() -> R): R =
-    useConnection(transactional = false) { SuspendScope<G>(it, config).block() }
+suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendAutocommit(block: suspend SuspendScope<G>.() -> R): R {
+    val dirty = mutableSetOf<String>()
+    val result = useConnection(transactional = false) { SuspendScope<G>(it, config, dirty).block() }
+    writeListeners.fire(dirty)
+    return result
+}

--- a/korm-core/src/commonMain/kotlin/WriteListener.kt
+++ b/korm-core/src/commonMain/kotlin/WriteListener.kt
@@ -1,0 +1,60 @@
+package io.github.kormium
+
+import kotlin.concurrent.Volatile
+
+/**
+ * Notified after a [transaction] / [autocommit] block (or their suspend counterparts)
+ * commits, with the set of table names written during it. This is the generic,
+ * non-reactive seam the rest of the system builds on: the `korm-observe` module turns
+ * it into a `Flow`, but it is equally useful for cache invalidation, audit or metrics.
+ *
+ * [onCommit] is called synchronously on the thread that ran the transaction, so keep it
+ * cheap and non-blocking — fan out to a coroutine/`Flow` off the hot path if you need to.
+ */
+fun interface WriteListener {
+    /** [tables] is the non-empty set of table names written by the just-committed block. */
+    fun onCommit(tables: Set<String>)
+}
+
+/** Handle returned by [WriteListeners.add]; call [remove] to unregister the listener. */
+fun interface Registration {
+    fun remove()
+}
+
+/**
+ * Per-database registry of [WriteListener]s. A backend that supports change notification
+ * exposes its own instance through [io.github.kormium.database.Database.writeListeners] /
+ * [io.github.kormium.database.SuspendDatabase.writeListeners]; backends that do not get
+ * the shared [Disabled] registry, which ignores everything at zero cost (so observation
+ * simply never fires there).
+ *
+ * Registration is expected at setup time (few listeners, rarely changed); the registry is
+ * copy-on-write so [fire] iterates a stable snapshot without locking on the hot path.
+ */
+open class WriteListeners {
+    @Volatile
+    private var listeners: List<WriteListener> = emptyList()
+
+    /** Registers [listener]; returns a [Registration] that removes it again. */
+    open fun add(listener: WriteListener): Registration {
+        listeners = listeners + listener
+        return Registration {
+            listeners = listeners.filterNot { it === listener }
+        }
+    }
+
+    /** Delivers [tables] to every registered listener. No-op when [tables] is empty. */
+    fun fire(tables: Set<String>) {
+        if (tables.isEmpty()) return
+        val snapshot = listeners
+        for (l in snapshot) l.onCommit(tables)
+    }
+
+    /** True if at least one listener is registered (lets callers skip dirty-set bookkeeping). */
+    val isActive: Boolean get() = listeners.isNotEmpty()
+
+    /** The shared no-op registry for backends that don't support write notification. */
+    object Disabled : WriteListeners() {
+        override fun add(listener: WriteListener): Registration = Registration {}
+    }
+}

--- a/korm-core/src/commonMain/kotlin/database/Database.kt
+++ b/korm-core/src/commonMain/kotlin/database/Database.kt
@@ -3,6 +3,7 @@ package io.github.kormium.database
 import io.github.kormium.Catalog
 import io.github.kormium.KormConfig
 import io.github.kormium.SqlExecutor
+import io.github.kormium.WriteListeners
 
 /**
  * A database handle, tagged with the [Catalog] [G] it connects to. The tag is
@@ -11,10 +12,21 @@ import io.github.kormium.SqlExecutor
  * the tag by assigning it to a `Database<MyCatalog>`. A [io.github.kormium.Table]
  * tagged with the same catalog can then be used against it via
  * [io.github.kormium.transaction] / [io.github.kormium.autocommit].
+ *
+ * SQL runs only through a pinned [SqlExecutor] inside a scope — the database handle is not
+ * itself an [SqlExecutor]. Run one-off statements via `autocommit { execute(...) }` so every
+ * write goes through a scope (and is therefore transactional and observable).
  */
-interface Database<out G : Catalog> : SqlExecutor, AutoCloseable {
+interface Database<out G : Catalog> : AutoCloseable {
     /** Per-database configuration; defaults to [KormConfig] defaults unless a backend overrides it. */
     val config: KormConfig get() = KormConfig()
+
+    /**
+     * The write-notification registry for this database. The default [WriteListeners.Disabled]
+     * means change observation (e.g. `korm-observe`) does nothing; a backend opts in by
+     * overriding this with a real [WriteListeners] instance.
+     */
+    val writeListeners: WriteListeners get() = WriteListeners.Disabled
 
     /**
      * Pins one connection for the duration of [block]; the [SqlExecutor] passed to it

--- a/korm-core/src/commonMain/kotlin/database/SuspendDatabase.kt
+++ b/korm-core/src/commonMain/kotlin/database/SuspendDatabase.kt
@@ -3,6 +3,7 @@ package io.github.kormium.database
 import io.github.kormium.Catalog
 import io.github.kormium.KormConfig
 import io.github.kormium.SuspendSqlExecutor
+import io.github.kormium.WriteListeners
 
 /**
  * The suspend counterpart of [Database], tagged with the [Catalog] [G] it connects to.
@@ -15,6 +16,13 @@ import io.github.kormium.SuspendSqlExecutor
 interface SuspendDatabase<out G : Catalog> : AutoCloseable {
     /** Per-database configuration; defaults to [KormConfig] defaults unless a backend overrides it. */
     val config: KormConfig get() = KormConfig()
+
+    /**
+     * The write-notification registry for this database. The default [WriteListeners.Disabled]
+     * means change observation (e.g. `korm-observe`) does nothing; a backend opts in by
+     * overriding this with a real [WriteListeners] instance.
+     */
+    val writeListeners: WriteListeners get() = WriteListeners.Disabled
 
     /**
      * Pins one connection for the duration of [block]; the [SuspendSqlExecutor] passed

--- a/korm-core/src/commonTest/kotlin/DatabaseMock.kt
+++ b/korm-core/src/commonTest/kotlin/DatabaseMock.kt
@@ -1,5 +1,6 @@
 import io.github.kormium.KormConfig
 import io.github.kormium.SqlExecutor
+import io.github.kormium.WriteListeners
 import io.github.kormium.SqlParameterSource
 import io.github.kormium.StandardDialect
 import io.github.kormium.StandardTypeMapper
@@ -10,74 +11,78 @@ import io.github.kormium.resultset.ResultSet
 
 class DatabaseMock: Database<Nothing>, SuspendDatabase<Nothing> {
 
-    override val dialect = StandardDialect
-    override val typeMapper = StandardTypeMapper
     override var config = KormConfig()
-
-    // The mock records SQL rather than pinning a real connection, so it just runs
-    // the block against itself (BEGIN/COMMIT are no-ops here).
-    override fun <R> usePinned(transactional: Boolean, block: (SqlExecutor) -> R): R = block(this)
-
-    // Suspend path: hand the block a tiny SuspendSqlExecutor that delegates to this mock's
-    // recording. A separate object (not `this`) because a class can't implement both
-    // SqlExecutor and SuspendSqlExecutor — their execute() overloads clash.
-    override suspend fun <R> useConnection(transactional: Boolean, block: suspend (SuspendSqlExecutor) -> R): R =
-        block(SuspendMockExecutor(this))
-
-    override fun close() = Unit
+    override val writeListeners = WriteListeners()
 
     var result: Any? = null
     var internalSql: String = ""
     var internalParams: Map<String, Any?> = emptyMap()
 
+    // The mock records SQL rather than pinning a real connection; both the blocking and the
+    // suspend scopes get an executor that writes back into these fields (BEGIN/COMMIT are no-ops).
+    override fun <R> usePinned(transactional: Boolean, block: (SqlExecutor) -> R): R =
+        block(MockExecutor(this))
+
+    override suspend fun <R> useConnection(transactional: Boolean, block: suspend (SuspendSqlExecutor) -> R): R =
+        block(SuspendMockExecutor(this))
+
+    override fun close() = Unit
+}
+
+// Records the SQL/params it is handed (and returns the mock's canned [DatabaseMock.result]).
+private class MockExecutor(private val mock: DatabaseMock) : SqlExecutor {
+    override val dialect = StandardDialect
+    override val typeMapper = StandardTypeMapper
+
     override fun <T> execute(sql: String, namedParameters: Map<String, Any?>, handler: (ResultSet) -> T): List<T> {
-        internalSql = sql
-        internalParams = namedParameters
+        mock.internalSql = sql
+        mock.internalParams = namedParameters
         @Suppress("UNCHECKED_CAST")
-        return (result as List<T>?) ?: listOf()
+        return (mock.result as List<T>?) ?: listOf()
     }
 
     override fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T> {
-        internalSql = sql
+        mock.internalSql = sql
         @Suppress("UNCHECKED_CAST")
-        return (result as List<T>?) ?: listOf()
+        return (mock.result as List<T>?) ?: listOf()
     }
 
     override fun execute(sql: String, namedParameters: Map<String, Any?>): Long {
-        internalSql = sql
-        internalParams = namedParameters
-        return (result as Long?) ?: 0L
+        mock.internalSql = sql
+        mock.internalParams = namedParameters
+        return (mock.result as Long?) ?: 0L
     }
 
     override fun execute(sql: String, paramSource: SqlParameterSource): Long {
-        internalSql = sql
-        return (result as Long?) ?: 0L
+        mock.internalSql = sql
+        return (mock.result as Long?) ?: 0L
     }
 
     override fun executeUpdate(sql: String, namedParameters: Map<String, Any?>): Long {
-        internalSql = sql
-        internalParams = namedParameters
-        return (result as Long?) ?: 0L
+        mock.internalSql = sql
+        mock.internalParams = namedParameters
+        return (mock.result as Long?) ?: 0L
     }
 }
 
-// Mirrors DatabaseMock onto the suspend executor surface by delegating to its blocking methods.
-private class SuspendMockExecutor(private val mock: DatabaseMock) : SuspendSqlExecutor {
-    override val dialect get() = mock.dialect
-    override val typeMapper get() = mock.typeMapper
+// Mirrors MockExecutor onto the suspend executor surface by delegating to a blocking instance.
+private class SuspendMockExecutor(mock: DatabaseMock) : SuspendSqlExecutor {
+    private val delegate = MockExecutor(mock)
+    override val dialect get() = delegate.dialect
+    override val typeMapper get() = delegate.typeMapper
 
     override suspend fun <T> execute(sql: String, namedParameters: Map<String, Any?>, handler: (ResultSet) -> T): List<T> =
-        mock.execute(sql, namedParameters, handler)
+        delegate.execute(sql, namedParameters, handler)
 
     override suspend fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T> =
-        mock.execute(sql, paramSource, handler)
+        delegate.execute(sql, paramSource, handler)
 
     override suspend fun execute(sql: String, namedParameters: Map<String, Any?>): Long =
-        mock.execute(sql, namedParameters)
+        delegate.execute(sql, namedParameters)
 
     override suspend fun execute(sql: String, paramSource: SqlParameterSource): Long =
-        mock.execute(sql, paramSource)
+        delegate.execute(sql, paramSource)
 
     override suspend fun executeUpdate(sql: String, namedParameters: Map<String, Any?>) =
-        mock.executeUpdate(sql, namedParameters)
+        delegate.executeUpdate(sql, namedParameters)
 }

--- a/korm-core/src/commonTest/kotlin/WriteListenerTest.kt
+++ b/korm-core/src/commonTest/kotlin/WriteListenerTest.kt
@@ -1,0 +1,130 @@
+import io.github.kormium.autocommit
+import io.github.kormium.database.Database
+import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.suspendTransaction
+import io.github.kormium.transaction
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class WriteListenerTest {
+
+    private fun freshDb(): Pair<Database<TestCatalog>, SuspendDatabase<TestCatalog>> {
+        val mock = DatabaseMock()
+        return mock to mock
+    }
+
+    @Test
+    fun writeFiresListenerWithTableName() {
+        val (db, _) = freshDb()
+        var fired: Set<String>? = null
+        db.writeListeners.add { fired = it }
+
+        db.transaction { TestTable.insert(TestEntity()) }
+
+        assertEquals(setOf("products"), fired)
+    }
+
+    @Test
+    fun readOnlyTransactionDoesNotFire() {
+        val (db, _) = freshDb()
+        var fired = false
+        db.writeListeners.add { fired = true }
+
+        db.transaction { TestTable.find { } }
+
+        assertTrue(!fired, "a read-only transaction must not notify write listeners")
+    }
+
+    @Test
+    fun rolledBackTransactionDoesNotFire() {
+        val (db, _) = freshDb()
+        var fired = false
+        db.writeListeners.add { fired = true }
+
+        assertFailsWith<IllegalStateException> {
+            db.transaction {
+                TestTable.insert(TestEntity())
+                throw IllegalStateException("boom")
+            }
+        }
+
+        assertTrue(!fired, "a transaction that throws (rolls back) must not notify")
+    }
+
+    @Test
+    fun multipleTablesAreCollected() {
+        val (db, _) = freshDb()
+        var fired: Set<String>? = null
+        db.writeListeners.add { fired = it }
+
+        db.transaction {
+            TestTable.insert(TestEntity())
+            TestOrders.insert(TestOrderEntity())
+        }
+
+        assertEquals(setOf("products", "orders"), fired)
+    }
+
+    @Test
+    fun removedListenerStopsReceiving() {
+        val (db, _) = freshDb()
+        var count = 0
+        val registration = db.writeListeners.add { count++ }
+
+        db.transaction { TestTable.insert(TestEntity()) }
+        registration.remove()
+        db.transaction { TestTable.insert(TestEntity()) }
+
+        assertEquals(1, count)
+    }
+
+    @Test
+    fun rawExecuteUpdateFiresOnlyWhenInvalidatesDeclared() {
+        val (db, _) = freshDb()
+        var fired: Set<String>? = null
+        db.writeListeners.add { fired = it }
+
+        // Raw SQL with no declared tables: Korm can't know what it touched → no notification.
+        db.transaction { executeUpdate("UPDATE products SET position = 0") }
+        assertEquals(null, fired, "undeclared raw write must not notify")
+
+        // Declaring the affected table opts the raw write into notification.
+        db.transaction { executeUpdate("UPDATE products SET position = 0", invalidates = listOf(TestTable)) }
+        assertEquals(setOf("products"), fired)
+    }
+
+    @Test
+    fun autocommitWriteFires() {
+        val (db, _) = freshDb()
+        var fired: Set<String>? = null
+        db.writeListeners.add { fired = it }
+
+        db.autocommit { TestTable.insert(TestEntity()) }
+
+        assertEquals(setOf("products"), fired)
+    }
+
+    @Test
+    fun suspendTransactionFires() = runTest {
+        val (_, suspendDb) = freshDb()
+        var fired: Set<String>? = null
+        suspendDb.writeListeners.add { fired = it }
+
+        suspendDb.suspendTransaction { TestTable.insert(TestEntity()) }
+
+        assertEquals(setOf("products"), fired)
+    }
+
+    @Test
+    fun disabledRegistryIgnoresListeners() {
+        // A backend that doesn't opt in exposes WriteListeners.Disabled: add is a no-op and
+        // fire never reaches anything (so it stays inert and cheap).
+        var fired = false
+        io.github.kormium.WriteListeners.Disabled.add { fired = true }
+        io.github.kormium.WriteListeners.Disabled.fire(setOf("products"))
+        assertTrue(!fired, "Disabled registry must never deliver to listeners")
+    }
+}

--- a/korm-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/JdbcDatabase.kt
+++ b/korm-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/JdbcDatabase.kt
@@ -10,6 +10,7 @@ import io.github.kormium.SqlExecutor
 import io.github.kormium.SqlParameterSource
 import io.github.kormium.SuspendSqlExecutor
 import io.github.kormium.TypeMapper
+import io.github.kormium.WriteListeners
 import io.github.kormium.database.Database
 import io.github.kormium.database.SuspendDatabase
 import io.github.kormium.resultset.ResultSet
@@ -48,13 +49,16 @@ open class JdbcDatabase(
     username: String? = null,
     password: String? = null,
     poolSize: Int,
-    override val dialect: Dialect,
-    override val typeMapper: TypeMapper,
+    private val dialect: Dialect,
+    private val typeMapper: TypeMapper,
     private val wrap: ResultSetWrapper,
     private val translate: SqlExceptionTranslator = StandardSqlExceptionTranslator,
     connectionInitSql: String? = null,
     override val config: KormConfig = KormConfig(),
 ) : Database<Nothing>, SuspendDatabase<Nothing> {
+
+    // Supports change observation (korm-observe): writes through this database notify here.
+    override val writeListeners: WriteListeners = WriteListeners()
 
     private val ds: HikariDataSource = HikariDataSource(HikariConfig().apply {
         this.jdbcUrl = jdbcUrl
@@ -72,25 +76,6 @@ open class JdbcDatabase(
     }
 
     override fun close() = ds.close()
-
-    // Each pool checkout gets a transient executor bound to that connection; all the
-    // statement logic lives in JdbcExecutor so the pooled and pinned paths share it.
-    private fun executor(conn: Connection) = JdbcExecutor(conn, dialect, typeMapper, wrap, translate)
-
-    override fun <T> execute(sql: String, namedParameters: Map<String, Any?>, handler: (ResultSet) -> T): List<T> =
-        ds.connection.use { executor(it).execute(sql, namedParameters, handler) }
-
-    override fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T> =
-        ds.connection.use { executor(it).execute(sql, paramSource, handler) }
-
-    override fun execute(sql: String, namedParameters: Map<String, Any?>): Long =
-        ds.connection.use { executor(it).execute(sql, namedParameters) }
-
-    override fun execute(sql: String, paramSource: SqlParameterSource): Long =
-        ds.connection.use { executor(it).execute(sql, paramSource) }
-
-    override fun executeUpdate(sql: String, namedParameters: Map<String, Any?>): Long =
-        ds.connection.use { executor(it).executeUpdate(sql, namedParameters) }
 
     override fun <R> usePinned(transactional: Boolean, block: (SqlExecutor) -> R): R =
         pool.runPinned(transactional, block)

--- a/korm-observe/build.gradle.kts
+++ b/korm-observe/build.gradle.kts
@@ -1,0 +1,56 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.android.kotlin.multiplatform.library")
+}
+
+repositories {
+    google()
+    mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.jetbrains.space/public/p/ktor/eap")
+    }
+}
+
+kotlin {
+    jvmToolchain(21)
+
+    jvm {
+        testRuns["test"].executionTask.configure {
+            useJUnitPlatform()
+        }
+    }
+
+    // Compose Multiplatform targets (AGP KMP library plugin's androidLibrary DSL).
+    android {
+        namespace = "io.github.kormium.observe"
+        compileSdk = 36
+        minSdk = 24
+    }
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    linuxX64()
+    macosX64()
+    macosArm64()
+    // mingwX64() // deferred — see the publishing plan
+
+    applyDefaultHierarchyTemplate()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                // Reactive change observation built on core's WriteListener seam. Table/Catalog/
+                // SuspendDatabase appear in the public Flow signatures, so :korm-core is api;
+                // Flow itself comes transitively from korm-core's api coroutines dependency.
+                api(project(":korm-core"))
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+            }
+        }
+    }
+}

--- a/korm-observe/src/commonMain/kotlin/Observe.kt
+++ b/korm-observe/src/commonMain/kotlin/Observe.kt
@@ -1,0 +1,59 @@
+package io.github.kormium.observe
+
+import io.github.kormium.Catalog
+import io.github.kormium.Entity
+import io.github.kormium.QueryBuilder
+import io.github.kormium.SuspendScope
+import io.github.kormium.Table
+import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.suspendAutocommit
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+
+/**
+ * Observes a query as a [Flow]: it emits the result once now, then re-runs [fetch] and emits
+ * again after every committed write (through this database) that touches one of [tables].
+ *
+ * This is the generic building block — most callers use the typed [Table.observe] overload.
+ * Reads run in [suspendAutocommit]. Bursts of writes are conflated, so a flood of commits
+ * collapses into a single re-fetch rather than one emission each.
+ *
+ * Notification covers writes made through this same database handle's API. Writes by another
+ * process, another `Database` instance, or raw SQL that does not name its tables are not seen
+ * (the same default boundary Room has); pass the affected table names explicitly for raw SQL.
+ * Observation only fires on backends whose driver enables it (all shipped drivers do); on a
+ * backend with notification disabled the flow emits the initial value and nothing more.
+ */
+fun <G : Catalog, R> SuspendDatabase<G>.observe(
+    tables: Set<String>,
+    fetch: suspend SuspendScope<G>.() -> R,
+): Flow<R> = channelFlow {
+    // CONFLATED: while a re-fetch is in flight, extra commits collapse into one pending signal.
+    val signals = Channel<Unit>(Channel.CONFLATED)
+    val registration = writeListeners.add { changed ->
+        if (changed.any { it in tables }) signals.trySend(Unit)
+    }
+    try {
+        send(suspendAutocommit(fetch)) // initial value
+        for (signal in signals) {
+            send(suspendAutocommit(fetch))
+        }
+    } finally {
+        registration.remove()
+        signals.close()
+    }
+}
+
+/**
+ * Observes this table as a [Flow] of entity lists, re-querying after every committed write to
+ * the table. `Users.observe(db) { where { Users.age gtEq 18 } }` emits the matching users now
+ * and again whenever the `users` table changes. With no [query] block it observes every row.
+ */
+fun <G : Catalog, T : Entity> Table<G, T>.observe(
+    db: SuspendDatabase<G>,
+    query: QueryBuilder.() -> Unit = {},
+): Flow<List<T>> {
+    val table = this
+    return db.observe(setOf(tableName)) { table.find(query) }
+}

--- a/korm-observe/src/commonTest/kotlin/ObserveTest.kt
+++ b/korm-observe/src/commonTest/kotlin/ObserveTest.kt
@@ -1,0 +1,122 @@
+import io.github.kormium.Catalog
+import io.github.kormium.Column
+import io.github.kormium.Dialect
+import io.github.kormium.Entity
+import io.github.kormium.SqlParameterSource
+import io.github.kormium.StandardDialect
+import io.github.kormium.StandardTypeMapper
+import io.github.kormium.SuspendSqlExecutor
+import io.github.kormium.Table
+import io.github.kormium.TypeMapper
+import io.github.kormium.WriteListeners
+import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.observe.observe
+import io.github.kormium.resultset.ResultSet
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+// A SuspendDatabase that runs the scope block against a no-op executor and exposes a real
+// WriteListeners registry, so we can drive observation by firing it directly (standing in for
+// a committed write). The fetch lambdas in these tests read captured state, not the executor.
+private class FakeDb : SuspendDatabase<Nothing> {
+    override val writeListeners = WriteListeners()
+
+    override suspend fun <R> useConnection(transactional: Boolean, block: suspend (SuspendSqlExecutor) -> R): R =
+        block(NoopExecutor)
+
+    override fun close() {}
+}
+
+private object NoopExecutor : SuspendSqlExecutor {
+    override val dialect: Dialect = StandardDialect
+    override val typeMapper: TypeMapper = StandardTypeMapper
+    override suspend fun <T> execute(sql: String, namedParameters: Map<String, Any?>, handler: (ResultSet) -> T): List<T> = emptyList()
+    override suspend fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T> = emptyList()
+    override suspend fun execute(sql: String, namedParameters: Map<String, Any?>): Long = 0L
+    override suspend fun execute(sql: String, paramSource: SqlParameterSource): Long = 0L
+    override suspend fun executeUpdate(sql: String, namedParameters: Map<String, Any?>): Long = 0L
+}
+
+private object ObserveCatalog : Catalog
+
+private class Widget : Entity() {
+    var id by Widgets.id
+}
+
+private object Widgets : Table<ObserveCatalog, Widget>("widgets", ::Widget) {
+    val id by Column.Int().primaryKey()
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObserveTest {
+
+    @Test
+    fun emitsInitialThenReEmitsOnRelevantWriteOnly() = runTest {
+        val db: SuspendDatabase<ObserveCatalog> = FakeDb()
+        var value = 0
+        val collected = mutableListOf<Int>()
+
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            db.observe(setOf("users")) { value }.collect { collected.add(it) }
+        }
+
+        advanceUntilIdle()
+        assertEquals(listOf(0), collected, "should emit the initial value once")
+
+        value = 1
+        db.writeListeners.fire(setOf("users"))
+        advanceUntilIdle()
+
+        value = 2
+        db.writeListeners.fire(setOf("orders")) // unrelated table → no re-emit
+        advanceUntilIdle()
+
+        value = 3
+        db.writeListeners.fire(setOf("users"))
+        advanceUntilIdle()
+
+        assertEquals(listOf(0, 1, 3), collected)
+        job.cancel()
+    }
+
+    @Test
+    fun tableObserveReQueriesOnTableWrite() = runTest {
+        val db: SuspendDatabase<ObserveCatalog> = FakeDb()
+        var emissions = 0
+
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            Widgets.observe(db).collect { emissions++ }
+        }
+
+        advanceUntilIdle()
+        assertEquals(1, emissions, "initial query result")
+
+        db.writeListeners.fire(setOf("widgets"))
+        advanceUntilIdle()
+        assertEquals(2, emissions)
+
+        db.writeListeners.fire(setOf("gadgets")) // other table → ignored
+        advanceUntilIdle()
+        assertEquals(2, emissions)
+
+        job.cancel()
+    }
+
+    @Test
+    fun listenerIsRemovedAfterCollectionStops() = runTest {
+        val db = FakeDb()
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            db.observe(setOf("users")) { 0 }.collect { }
+        }
+        advanceUntilIdle()
+        job.cancel()
+        advanceUntilIdle()
+
+        assertEquals(false, db.writeListeners.isActive, "the flow must unregister its listener on cancel")
+    }
+}

--- a/korm-postgres/src/commonMain/kotlin/PostgresDriver.kt
+++ b/korm-postgres/src/commonMain/kotlin/PostgresDriver.kt
@@ -2,6 +2,7 @@ package io.github.kormium
 
 import io.github.kormium.database.Database
 import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.WriteListeners
 
 /**
  * A Postgres-backed [Database] (and [SuspendDatabase]). This is the type returned by the
@@ -13,4 +14,8 @@ interface PostgresDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoClos
     // Resolves the config default inherited from both Database and SuspendDatabase; concrete
     // drivers supply it (from the createDatabase config argument).
     override val config: KormConfig
+
+    // Resolves the writeListeners default inherited from both interfaces; concrete drivers
+    // supply a real registry so change observation (korm-observe) works.
+    override val writeListeners: WriteListeners
 }

--- a/korm-postgres/src/jvmTest/kotlin/StabilityTest.kt
+++ b/korm-postgres/src/jvmTest/kotlin/StabilityTest.kt
@@ -1,3 +1,4 @@
+import io.github.kormium.autocommit
 import io.github.kormium.database.createDatabase
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Tag
@@ -26,7 +27,7 @@ class StabilityTest {
             val threads = (1..16).map {
                 Thread {
                     try {
-                        repeat(2_000) { check(driver.execute("SELECT 1") { rs -> rs.getInt(0) }.single() == 1) }
+                        repeat(2_000) { check(driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single() == 1) }
                     } catch (t: Throwable) {
                         errors += t
                     }
@@ -43,7 +44,7 @@ class StabilityTest {
     fun noConnectionLeakUnderManyOps() {
         assumeDocker()
         ItDatabase.newDriver(poolSize = 2).use { driver ->
-            repeat(2_000) { check(driver.execute("SELECT 1") { rs -> rs.getInt(0) }.single() == 1) }
+            repeat(2_000) { check(driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single() == 1) }
         }
     }
 
@@ -64,12 +65,12 @@ class StabilityTest {
                 password = container.password,
                 poolSize = 4,
             ).use { driver ->
-                check(driver.execute("SELECT 1") { rs -> rs.getInt(0) }.single() == 1)
+                check(driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single() == 1)
                 container.dockerClient.restartContainerCmd(container.containerId).exec()
                 val deadline = System.currentTimeMillis() + 60_000
                 var recovered = false
                 while (System.currentTimeMillis() < deadline && !recovered) {
-                    recovered = runCatching { driver.execute("SELECT 1") { rs -> rs.getInt(0) }.single() == 1 }
+                    recovered = runCatching { driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single() == 1 }
                         .getOrDefault(false)
                     if (!recovered) Thread.sleep(500)
                 }

--- a/korm-postgres/src/jvmTest/kotlin/TableIntegrationTest.kt
+++ b/korm-postgres/src/jvmTest/kotlin/TableIntegrationTest.kt
@@ -139,9 +139,9 @@ class TableIntegrationTest {
         assumeDockerAvailable()
         ItDatabase.newDriver(poolSize = 1).use { driver ->
             assertFailsWith<Exception> {
-                driver.execute("SELECT * FROM table_that_does_not_exist") { rs -> rs.getInt(0) }
+                driver.autocommit { execute("SELECT * FROM table_that_does_not_exist") { rs -> rs.getInt(0) } }
             }
-            assertEquals(1, driver.execute("SELECT 1") { rs -> rs.getInt(0) }.single())
+            assertEquals(1, driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single())
         }
     }
 
@@ -152,7 +152,7 @@ class TableIntegrationTest {
         val driver = ItDatabase.newDriver(poolSize = 1)
         driver.close()
         assertFailsWith<Exception> {
-            driver.execute("SELECT 1") { rs -> rs.getInt(0) }
+            driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }
         }
     }
 
@@ -171,7 +171,11 @@ class TableIntegrationTest {
             override val parameterNames get() = values.keys.toTypedArray()
         }
         ItDatabase.newDriver(poolSize = 1).use { driver ->
-            val sum = driver.execute("SELECT :a::int + :b::int AS s", source) { rs -> rs.getInt(0) }
+            // The SqlParameterSource overload lives on the pinned SqlExecutor (Scope exposes only
+            // the Map form), so exercise it through usePinned.
+            val sum = driver.usePinned(transactional = false) { exec ->
+                exec.execute("SELECT :a::int + :b::int AS s", source) { rs -> rs.getInt(0) }
+            }
             assertEquals(12, sum.single())
         }
     }
@@ -356,7 +360,7 @@ class TableIntegrationTest {
         ItDatabase.newDriver(poolSize = 4).use { driver ->
             val threads = (1..8).map {
                 Thread {
-                    repeat(50) { sum.addAndGet(driver.execute("SELECT 1") { rs -> rs.getInt(0) ?: 0 }.single()) }
+                    repeat(50) { sum.addAndGet(driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) ?: 0 } }.single()) }
                 }
             }
             threads.forEach { it.start() }
@@ -576,42 +580,26 @@ object ItDatabase : Database<ItCatalog> {
     )
 
     init {
-        driver.executeUpdate(
-            """
-            CREATE TABLE IF NOT EXISTS public.it_products (
-                id uuid PRIMARY KEY,
-                price numeric NOT NULL,
-                qty int NOT NULL,
-                "displayName" text NOT NULL,
-                note text,
-                rank int
+        driver.autocommit {
+            executeUpdate(
+                """
+                CREATE TABLE IF NOT EXISTS public.it_products (
+                    id uuid PRIMARY KEY,
+                    price numeric NOT NULL,
+                    qty int NOT NULL,
+                    "displayName" text NOT NULL,
+                    note text,
+                    rank int
+                )
+                """.trimIndent()
             )
-            """.trimIndent()
-        )
+        }
     }
-
-    override val dialect get() = driver.dialect
-    override val typeMapper get() = driver.typeMapper
 
     override fun <R> usePinned(transactional: Boolean, block: (io.github.kormium.SqlExecutor) -> R): R =
         driver.usePinned(transactional, block)
 
     override fun close() = driver.close()
-
-    override fun <T> execute(sql: String, namedParameters: Map<String, Any?>, handler: (ResultSet) -> T): List<T> =
-        driver.execute(sql, namedParameters, handler)
-
-    override fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T> =
-        driver.execute(sql, paramSource, handler)
-
-    override fun execute(sql: String, namedParameters: Map<String, Any?>): Long =
-        driver.execute(sql, namedParameters)
-
-    override fun execute(sql: String, paramSource: SqlParameterSource): Long =
-        driver.execute(sql, paramSource)
-
-    override fun executeUpdate(sql: String, namedParameters: Map<String, Any?>): Long =
-        driver.executeUpdate(sql, namedParameters)
 }
 
 // Raw schema DDL for tests (Korm no longer owns createTable). Postgres types.

--- a/korm-postgres/src/nativeMain/kotlin/io/github/moreirasantos/pgkn/PostgresDriver.kt
+++ b/korm-postgres/src/nativeMain/kotlin/io/github/moreirasantos/pgkn/PostgresDriver.kt
@@ -17,6 +17,7 @@ import io.github.kormium.ConnectionPool
 import io.github.kormium.Dialect
 import io.github.kormium.KormConfig
 import io.github.kormium.PinnedConnection
+import io.github.kormium.WriteListeners
 import io.github.kormium.PostgresDialect
 import io.github.kormium.PostgresDriver
 import io.github.kormium.SqlExecutor
@@ -66,8 +67,9 @@ private class PostgresDriverImpl(
         require(poolSize >= 1) { "poolSize must be >= 1, was $poolSize" }
     }
 
-    override val dialect: Dialect = PostgresDialect
-    override val typeMapper: TypeMapper = StandardTypeMapper
+    private val dialect: Dialect = PostgresDialect
+    private val typeMapper: TypeMapper = StandardTypeMapper
+    override val writeListeners: WriteListeners = WriteListeners()
 
     // A single libpq connection is not thread-safe: it runs one command at a time
     // and concurrent use is undefined behaviour. We therefore keep a fixed set of
@@ -86,22 +88,6 @@ private class PostgresDriverImpl(
     // Held terminally by the first close() caller so the pool is torn down once.
     private val closeLock = Mutex()
 
-    private inline fun <T> withConnection(block: (CPointer<PGconn>) -> T): T {
-        // Fast path: take a free connection without spinning up a runBlocking loop.
-        val connection = pool.tryReceive().getOrNull() ?: try {
-            runBlocking { pool.receive() }
-        } catch (_: ClosedReceiveChannelException) {
-            throw ConnectionClosedException()
-        }
-        try {
-            ensureAlive(connection)
-            return block(connection)
-        } finally {
-            // Capacity == poolSize, so a borrowed connection always fits back in.
-            pool.trySend(connection)
-        }
-    }
-
     // libpq marks a connection CONNECTION_BAD once it dies (e.g. the server restarts or
     // the network drops). Reset it before reuse so a transient outage doesn't permanently
     // poison the pooled connection. PQstatus is local (no round-trip); PQreset reconnects.
@@ -113,22 +99,6 @@ private class PostgresDriverImpl(
             throw QueryExecutionException(message.ifEmpty { "Postgres connection is down and could not be reset" })
         }
     }
-
-    override fun <T> execute(sql: String, namedParameters: Map<String, Any?>, handler: (ResultSet) -> T): List<T> =
-        withConnection { conn -> runQuery(conn, sql, namedParameters).handleResults(handler) }
-
-    override fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T> =
-        withConnection { conn -> doExecute(conn, sql, paramSource).handleResults(handler) }
-
-    override fun execute(sql: String, namedParameters: Map<String, Any?>): Long =
-        withConnection { conn -> runQuery(conn, sql, namedParameters).returnCount() }
-
-    override fun execute(sql: String, paramSource: SqlParameterSource): Long =
-        withConnection { conn -> doExecute(conn, sql, paramSource).returnCount() }
-
-    override fun executeUpdate(sql: String, namedParameters: Map<String, Any?>): Long =
-        // returnCount() reads PQcmdTuples and PQclears the result, so nothing leaks.
-        withConnection { conn -> runQuery(conn, sql, namedParameters).returnCount() }
 
     // One pool, two entry points (blocking usePinned + suspend useConnection). acquire mirrors
     // withConnection's borrow + liveness check; acquireSuspending overrides the default to take

--- a/korm-postgres/src/nativeTest/kotlin/NativeTableIntegrationTest.kt
+++ b/korm-postgres/src/nativeTest/kotlin/NativeTableIntegrationTest.kt
@@ -90,10 +90,10 @@ class NativeTableIntegrationTest {
         }
         nativeDriver(poolSize = 1).use { driver ->
             assertFailsWith<Exception> {
-                driver.execute("SELECT * FROM table_that_does_not_exist") { rs -> rs.getInt(0) }
+                driver.autocommit { execute("SELECT * FROM table_that_does_not_exist") { rs -> rs.getInt(0) } }
             }
             // Same single connection must still be usable after the error above.
-            assertEquals(1, driver.execute("SELECT 1") { rs -> rs.getInt(0) }.single())
+            assertEquals(1, driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single())
         }
     }
 
@@ -107,7 +107,7 @@ class NativeTableIntegrationTest {
         val driver = nativeDriver(poolSize = 1)
         driver.close()
         assertFailsWith<Exception> {
-            driver.execute("SELECT 1") { rs -> rs.getInt(0) }
+            driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }
         }
     }
 
@@ -175,7 +175,7 @@ class NativeTableIntegrationTest {
             val futures = workers.map { worker ->
                 worker.execute(TransferMode.SAFE, { driver }) { db ->
                     var ok = 0
-                    repeat(2_000) { if (db.execute("SELECT 1") { rs -> rs.getInt(0) ?: 0 }.single() == 1) ok++ }
+                    repeat(2_000) { if (db.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) ?: 0 } }.single() == 1) ok++ }
                     ok
                 }
             }
@@ -197,7 +197,7 @@ class NativeTableIntegrationTest {
             val futures = workers.map { worker ->
                 worker.execute(TransferMode.SAFE, { driver }) { db ->
                     var sum = 0
-                    repeat(50) { sum += db.execute("SELECT 1") { rs -> rs.getInt(0) ?: 0 }.single() }
+                    repeat(50) { sum += db.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) ?: 0 } }.single() }
                     sum
                 }
             }
@@ -242,40 +242,24 @@ object NativeDatabase : Database<NativeCatalog> {
     )
 
     init {
-        driver.executeUpdate(
-            """
-            CREATE TABLE IF NOT EXISTS public.native_products (
-                id uuid PRIMARY KEY,
-                price numeric NOT NULL,
-                qty int NOT NULL,
-                "displayName" text NOT NULL,
-                note text,
-                rank int
+        driver.autocommit {
+            executeUpdate(
+                """
+                CREATE TABLE IF NOT EXISTS public.native_products (
+                    id uuid PRIMARY KEY,
+                    price numeric NOT NULL,
+                    qty int NOT NULL,
+                    "displayName" text NOT NULL,
+                    note text,
+                    rank int
+                )
+                """.trimIndent()
             )
-            """.trimIndent()
-        )
+        }
     }
-
-    override val dialect get() = driver.dialect
-    override val typeMapper get() = driver.typeMapper
 
     override fun <R> usePinned(transactional: Boolean, block: (io.github.kormium.SqlExecutor) -> R): R =
         driver.usePinned(transactional, block)
 
     override fun close() = driver.close()
-
-    override fun <T> execute(sql: String, namedParameters: Map<String, Any?>, handler: (ResultSet) -> T): List<T> =
-        driver.execute(sql, namedParameters, handler)
-
-    override fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T> =
-        driver.execute(sql, paramSource, handler)
-
-    override fun execute(sql: String, namedParameters: Map<String, Any?>): Long =
-        driver.execute(sql, namedParameters)
-
-    override fun execute(sql: String, paramSource: SqlParameterSource): Long =
-        driver.execute(sql, paramSource)
-
-    override fun executeUpdate(sql: String, namedParameters: Map<String, Any?>): Long =
-        driver.executeUpdate(sql, namedParameters)
 }

--- a/korm-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/R2dbcDatabase.kt
+++ b/korm-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/R2dbcDatabase.kt
@@ -6,6 +6,7 @@ import io.github.kormium.PostgresDialect
 import io.github.kormium.StandardTypeMapper
 import io.github.kormium.SuspendSqlExecutor
 import io.github.kormium.TypeMapper
+import io.github.kormium.WriteListeners
 import io.github.kormium.database.SuspendDatabase
 import io.r2dbc.pool.ConnectionPool
 import io.r2dbc.pool.ConnectionPoolConfiguration
@@ -31,6 +32,9 @@ class R2dbcDatabase internal constructor(
     private val typeMapper: TypeMapper,
     override val config: KormConfig = KormConfig(),
 ) : SuspendDatabase<Nothing> {
+
+    // Supports change observation (korm-observe): writes through this database notify here.
+    override val writeListeners: WriteListeners = WriteListeners()
 
     override suspend fun <R> useConnection(transactional: Boolean, block: suspend (SuspendSqlExecutor) -> R): R {
         val connection = pool.create().awaitSingle()

--- a/korm-sqlite/build.gradle.kts
+++ b/korm-sqlite/build.gradle.kts
@@ -122,6 +122,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
+                implementation(project(":korm-observe"))
                 implementation("com.ionspin.kotlin:bignum:0.3.10")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")

--- a/korm-sqlite/src/androidMain/kotlin/CreateSqliteDatabase.android.kt
+++ b/korm-sqlite/src/androidMain/kotlin/CreateSqliteDatabase.android.kt
@@ -38,8 +38,9 @@ private class SqliteAndroidDriver(path: String, private val poolSize: Int, overr
         }
     }
 
-    override val dialect: Dialect = SqliteDialect
-    override val typeMapper: TypeMapper = StandardTypeMapper
+    private val dialect: Dialect = SqliteDialect
+    private val typeMapper: TypeMapper = StandardTypeMapper
+    override val writeListeners: WriteListeners = WriteListeners()
 
     private val isMemory = path == ":memory:"
     private val driver = BundledSQLiteDriver()
@@ -55,34 +56,6 @@ private class SqliteAndroidDriver(path: String, private val poolSize: Int, overr
     }
 
     private val closeLock = Mutex()
-
-    private inline fun <T> withConnection(block: (SQLiteConnection) -> T): T {
-        val connection = pool.tryReceive().getOrNull() ?: try {
-            runBlocking { pool.receive() }
-        } catch (_: ClosedReceiveChannelException) {
-            throw QueryException("SQLite connection pool is closed")
-        }
-        try {
-            return block(connection)
-        } finally {
-            pool.trySend(connection)
-        }
-    }
-
-    override fun <T> execute(sql: String, namedParameters: Map<String, Any?>, handler: (ResultSet) -> T): List<T> =
-        withConnection { conn -> query(conn, sql, mapBinder(namedParameters)).handleResults(handler) }
-
-    override fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T> =
-        withConnection { conn -> query(conn, sql, sourceBinder(paramSource)).handleResults(handler) }
-
-    override fun execute(sql: String, namedParameters: Map<String, Any?>): Long =
-        withConnection { conn -> updateOrCount(conn, sql, mapBinder(namedParameters)) }
-
-    override fun execute(sql: String, paramSource: SqlParameterSource): Long =
-        withConnection { conn -> updateOrCount(conn, sql, sourceBinder(paramSource)) }
-
-    override fun executeUpdate(sql: String, namedParameters: Map<String, Any?>): Long =
-        withConnection { conn -> updateOrCount(conn, sql, mapBinder(namedParameters)) }
 
     // One pool, two entry points (blocking usePinned + suspend useConnection). acquire mirrors
     // withConnection's borrow; acquireSuspending overrides the default to take the Channel's

--- a/korm-sqlite/src/commonMain/kotlin/SqliteDriver.kt
+++ b/korm-sqlite/src/commonMain/kotlin/SqliteDriver.kt
@@ -2,6 +2,7 @@ package io.github.kormium
 
 import io.github.kormium.database.Database
 import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.WriteListeners
 
 /**
  * A SQLite-backed [Database] (and [SuspendDatabase]). This is the type returned by
@@ -13,4 +14,8 @@ interface SqliteDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoClosea
     // Resolves the config default inherited from both Database and SuspendDatabase; concrete
     // drivers supply it (from the createSqliteDatabase config argument).
     override val config: KormConfig
+
+    // Resolves the writeListeners default inherited from both interfaces; concrete drivers
+    // supply a real registry so change observation (korm-observe) works.
+    override val writeListeners: WriteListeners
 }

--- a/korm-sqlite/src/commonTest/kotlin/SqliteObserveTest.kt
+++ b/korm-sqlite/src/commonTest/kotlin/SqliteObserveTest.kt
@@ -1,0 +1,66 @@
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import io.github.kormium.createSqliteDatabase
+import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.eq
+import io.github.kormium.observe.observe
+import io.github.kormium.suspendTransaction
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+/**
+ * End-to-end test of korm-observe over a real SQLite backend (JVM + Native): a write committed
+ * through [suspendTransaction] must drive the observed [io.github.kormium.observe.observe] flow
+ * to re-query and emit the new state. This exercises the whole chain — Scope dirty-table
+ * tracking → WriteListeners.fire on commit → the flow's re-fetch.
+ *
+ * The query is filtered to a unique id so it is robust against the shared-cache `:memory:`
+ * database other tests also use.
+ */
+class SqliteObserveTest {
+
+    @Test
+    fun observeReEmitsAfterRealCommit() = runBlocking {
+        val db: SuspendDatabase<SqCatalog> = createSqliteDatabase(":memory:")
+        db.suspendTransaction { Products.execSql(productsDdl) }
+        val myId = Uuid.random()
+
+        val emissions = Channel<List<Product>>(Channel.UNLIMITED)
+        val job = launch(Dispatchers.Default) {
+            Products.observe(db) { where { Products.id eq myId } }.collect { emissions.send(it) }
+        }
+
+        // Wait for the initial emission, which also guarantees the listener is registered
+        // before we write (registration happens before the flow's first emit).
+        val initial = withTimeout(5_000) { emissions.receive() }
+        assertEquals(0, initial.size, "no row with this id yet")
+
+        db.suspendTransaction {
+            Products.insert(Product().apply {
+                id = myId
+                price = BigDecimal.fromInt(7)
+                qty = 1
+                displayName = "observed"
+                note = null
+                rank = null
+            })
+        }
+
+        // After the commit fires the write listener, the flow must re-query and surface our row.
+        val seen = withTimeout(5_000) {
+            var latest: List<Product> = initial
+            while (latest.none { it.id == myId }) latest = emissions.receive()
+            latest
+        }
+        assertEquals("observed", seen.single { it.id == myId }.displayName)
+
+        job.cancelAndJoin()
+        db.close()
+    }
+}

--- a/korm-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
+++ b/korm-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
@@ -41,8 +41,9 @@ private class SqliteNativeDriver(path: String, private val poolSize: Int, overri
         require(poolSize >= 1) { "poolSize must be >= 1, was $poolSize" }
     }
 
-    override val dialect: Dialect = SqliteDialect
-    override val typeMapper: TypeMapper = StandardTypeMapper
+    private val dialect: Dialect = SqliteDialect
+    private val typeMapper: TypeMapper = StandardTypeMapper
+    override val writeListeners: WriteListeners = WriteListeners()
 
     private val isMemory = path == ":memory:"
 
@@ -61,34 +62,6 @@ private class SqliteNativeDriver(path: String, private val poolSize: Int, overri
     }
 
     private val closeLock = Mutex()
-
-    private inline fun <T> withConnection(block: (CPointer<sqlite3>) -> T): T {
-        val connection = pool.tryReceive().getOrNull() ?: try {
-            runBlocking { pool.receive() }
-        } catch (_: ClosedReceiveChannelException) {
-            throw QueryException("SQLite connection pool is closed")
-        }
-        try {
-            return block(connection)
-        } finally {
-            pool.trySend(connection)
-        }
-    }
-
-    override fun <T> execute(sql: String, namedParameters: Map<String, Any?>, handler: (ResultSet) -> T): List<T> =
-        withConnection { conn -> query(conn, sql, mapBinder(namedParameters)).handleResults(handler) }
-
-    override fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T> =
-        withConnection { conn -> query(conn, sql, sourceBinder(paramSource)).handleResults(handler) }
-
-    override fun execute(sql: String, namedParameters: Map<String, Any?>): Long =
-        withConnection { conn -> updateOrCount(conn, sql, mapBinder(namedParameters)) }
-
-    override fun execute(sql: String, paramSource: SqlParameterSource): Long =
-        withConnection { conn -> updateOrCount(conn, sql, sourceBinder(paramSource)) }
-
-    override fun executeUpdate(sql: String, namedParameters: Map<String, Any?>): Long =
-        withConnection { conn -> updateOrCount(conn, sql, mapBinder(namedParameters)) }
 
     // One pool, two entry points (blocking usePinned + suspend useConnection). acquire mirrors
     // withConnection's borrow; acquireSuspending overrides the default to take the Channel's

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,8 @@ val adults = db.autocommit {
   r2dbc gives a true async PostgreSQL option on JVM.
 - **SQLite for apps, tests and caches.** JVM uses sqlite-jdbc, Native uses sqlite3
   cinterop, Android uses AndroidX SQLite.
+- **Reactive queries.** `korm-observe` turns a query into a `Flow` that re-emits when the
+  tables it reads change — for Compose Multiplatform and Android UIs.
 - **Server integration.** Ktor helpers are split into DI-agnostic, Ktor DI and Koin
   artifacts.
 
@@ -79,6 +81,8 @@ dependencies {
     implementation("io.github.kormium:korm-postgres") // PostgreSQL, JVM + Native
     // implementation("io.github.kormium:korm-sqlite")   // SQLite, JVM + Native + Android
     // implementation("io.github.kormium:korm-r2dbc")    // async PostgreSQL, JVM only
+
+    // implementation("io.github.kormium:korm-observe")  // reactive Flow queries
 
     // optional Ktor integration
     // implementation("io.github.kormium:korm-ktor")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 
 rootProject.name = "korm"
 include("korm-core", "korm-postgres", "korm-jdbc", "korm-sqlite", "korm-r2dbc", "benchmarks")
+include("korm-observe")
 include("korm-ktor", "korm-ktor-di", "korm-ktor-koin")
 include("korm-bom")
 include(


### PR DESCRIPTION
## What

Room-parity **observable queries** without adopting Room's annotation-processor / SQL-string model — we keep the runtime type-safe DSL.

### Reactive queries (`korm-observe`, new module)
```kotlin
val adults: Flow<List<User>> = Users.observe(db) { where { Users.age gtEq 18 } }
```
Emits the result now, then re-emits after every committed write to the table. Conflated. Generic `SuspendDatabase.observe(tables) { … }` covers joins/custom fetches.

### Generic commit hook (`korm-core`)
`WriteListener` / `WriteListeners` on `Database`/`SuspendDatabase`: after a `transaction`/`autocommit` (or suspend) commits, listeners get the set of written tables. A rolled-back tx notifies nothing. Backs `korm-observe`, but is equally usable for **cache invalidation, audit, metrics**. Backends opt in (jdbc, native pg, sqlite jvm/native/android, r2dbc); the default `WriteListeners.Disabled` is a no-op.

### Raw SQL invalidation
`Scope.execute`/`executeUpdate` gain `invalidates: List<Table<G,*>>` to declare tables raw SQL writes — the analog of Room's `@RawQuery(observedEntities)`.

## Breaking

**`Database` no longer extends `SqlExecutor`.** The pooled, scope-less `db.execute(...)`/`db.executeUpdate(...)` is removed (it bypassed transactions *and* notification — a historical wart). Run one-off statements via `db.autocommit { execute(...) }`. `SuspendDatabase` was never an executor. `SqlParameterSource` overloads now live only on the pinned `SqlExecutor` inside a scope. Pre-1.0, so this bumps the minor: **0.2.0 → 0.3.0**.

## Boundaries (Tier 1)

Sees writes through this database handle's API — not other processes/instances, undeclared raw SQL, or trigger/cascade effects (same default boundary as Room). DB-level detection (`update_hook`, `LISTEN/NOTIFY`) is a later tier on the same hook.

## Tests / docs

- `WriteListenerTest` (core), `ObserveTest` (jvm+native), `SqliteObserveTest` end-to-end vs real SQLite (jvm+native).
- New `docs/observe.md`; CHANGELOG `[0.3.0]`; observability/design/roadmap/installation/readme updated.
- All modules + benchmarks(jmh) compile (jvm + native + android); core/observe/sqlite test suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)