### PR TITLE
Open ColumnType system (enum / json / custom converters)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,19 @@ All notable changes to korm are documented here. The format is based on
 - **`invalidates` argument** on the raw `Scope.execute` / `executeUpdate` (and suspend
   counterparts): declare the tables a raw statement writes so observers are notified — the
   analog of Room's `@RawQuery(observedEntities = …)`.
+- **Open column-type system.** Column types are now an extensible `ColumnType<T>` interface
+  instead of a fixed list. New built-ins `Column.enum<E>()` (enum by name) and
+  `Column.json<T>()` (`@Serializable` value as JSON), a `ColumnType<S>.convert(to, from)`
+  helper for custom types over an existing one (replacing Room's `@TypeConverter`), and
+  `Column.of(type)` to declare a column of any `ColumnType`. The 14 built-in types are
+  unchanged in behaviour. Conversion applies on insert, update and in predicates.
 
 ### Changed
+- **Breaking (internal extension point): the column-type representation changed.**
+  `Column.ColumnNameEnum` is removed and `TypeMapper.fromResult(...)` is gone (reading is now
+  `ColumnType.read`); `Column.columnType` is a `ColumnType<Z>`. Ordinary table/query/insert
+  code is unaffected and behaves identically — only custom `TypeMapper`s or code referencing
+  `ColumnNameEnum` need migration (nothing in Korm itself did).
 - **Breaking: `Database` no longer extends `SqlExecutor`.** The pooled, scope-less
   `db.execute(...)` / `db.executeUpdate(...)` is removed — run one-off statements through a
   scope instead: `db.autocommit { execute(...) }`. This makes every write transactional and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,6 +14,7 @@ Shipped today:
 - SQLite on JVM, Kotlin/Native and Android;
 - JVM-only async PostgreSQL through r2dbc;
 - typed table/entity DSL;
+- an open `ColumnType` system (built-ins + `enum`/`json` + custom converters);
 - typed predicates, joins and aggregations;
 - transactions, savepoints, suspend scopes and migrations;
 - reactive `Flow` queries (`korm-observe`) over a `WriteListener` commit hook;

--- a/docs/tables-and-entities.md
+++ b/docs/tables-and-entities.md
@@ -75,6 +75,9 @@ Supported column types:
 | `Column.LocalDateTime` | `kotlinx.datetime.LocalDateTime` |
 | `Column.Json` | `kotlinx.serialization.json.JsonElement` |
 
+These are the built-ins; the type list is open — see [Custom column types](#custom-column-types)
+for enums, JSON-mapped values and your own types.
+
 Every column accepts:
 
 ```kotlin
@@ -85,6 +88,34 @@ Column.UUID().primaryKey()
 `findById` uses a single explicit primary key. If none is marked, it falls back to a column
 named `id`. For composite primary keys, use `find { ... }` or `find(Query(...))` instead
 of `findById`.
+
+## Custom Column Types
+
+The type list is open. Two ready-made helpers cover the common cases:
+
+```kotlin
+val role  by Column.enum<Role>()    // enum stored by name (text)
+val prefs by Column.json<Prefs>()   // @Serializable value stored as JSON (jsonb on Postgres)
+```
+
+For any other type, derive one from an existing column type with `convert` — you only map the
+value both ways (the storage, reading and any dialect casts are inherited). This replaces
+Room's `@TypeConverter`, type-safe and without annotations:
+
+```kotlin
+val color by Column.of(
+    TextColumnType.convert<Color, String>(
+        toStored   = { it.hex },
+        fromStored = { Color(it) },
+    ),
+)
+```
+
+A column type is just three pieces — `read` and an optional `toParam` (the entity property
+type and any conversion). Implement `ColumnType<T>` directly only when you need a genuinely
+new storage type; most custom types are a `convert` over `TextColumnType` / `JsonColumnType` /
+`IntColumnType`. Conversion applies on insert, update and in predicates, so
+`where { Users.role eq Role.ADMIN }` binds the stored form automatically.
 
 ## Entities
 

--- a/korm-core/src/commonMain/kotlin/Column.kt
+++ b/korm-core/src/commonMain/kotlin/Column.kt
@@ -35,7 +35,7 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
     /** Rendered SQL column identifier. Equals [fieldKey] unless a custom name was supplied. */
     open var name: String,
     open var nullable: kotlin.Boolean,
-    val columnType: ColumnNameEnum,
+    val columnType: ColumnType<Z>,
 ) : Expression, Selectable<Z> {
 
     open fun init() {
@@ -56,16 +56,21 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
     /** Whether this column is part of the table's primary key. */
     internal var isPrimaryKey: kotlin.Boolean = false
 
-    // As a selectable, read its value via the type mapper (its toSql is the SELECT SQL).
-    @Suppress("UNCHECKED_CAST")
+    // As a selectable, read its value via its column type (its toSql is the SELECT SQL).
     override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Z? =
-        typeMapper.fromResult(rs, index, columnType) as Z?
+        columnType.read(rs, index)
+
+    // Converts a domain value to its bound form (e.g. enum -> name, @Serializable -> JsonElement)
+    // before it reaches the ParamBuilder. Null passes through; built-in types are identity.
+    @Suppress("UNCHECKED_CAST")
+    internal fun bindParam(value: Any?): Any? =
+        if (value == null) null else (columnType as ColumnType<Any?>).toParam(value)
 
     /**
      * A non-null column. Its entity property is `Z`: assigning `null` is a compile error, and
      * reading a field that was never assigned (or that the database returned as `NULL`) throws.
      */
-    class NotNullColumn<Z, T: Table<*, N>, N: Entity>(table: T, fieldKey: String, name: String, columnType: ColumnNameEnum)
+    class NotNullColumn<Z, T: Table<*, N>, N: Entity>(table: T, fieldKey: String, name: String, columnType: ColumnType<Z>)
         : Column<Z, T, N>(table, fieldKey, name, nullable = false, columnType) {
         operator fun getValue(n: N, property: KProperty<*>): Z {
             logger.trace { "Get value $fieldKey" }
@@ -81,7 +86,7 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
     }
 
     /** A nullable column. Its entity property is `Z?`: an absent field reads back as `null`. */
-    class NullableColumn<Z, T: Table<*, N>, N: Entity>(table: T, fieldKey: String, name: String, columnType: ColumnNameEnum)
+    class NullableColumn<Z, T: Table<*, N>, N: Entity>(table: T, fieldKey: String, name: String, columnType: ColumnType<Z>)
         : Column<Z, T, N>(table, fieldKey, name, nullable = true, columnType) {
         @Suppress("UNCHECKED_CAST")
         operator fun getValue(n: N, property: KProperty<*>): Z? {
@@ -95,21 +100,15 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
         }
     }
 
-    enum class ColumnNameEnum {
-        BigDecimal,
-        UUID,
-        Double,
-        Int,
-        Boolean,
-        String,
-        Instant,
-        Json,
-        Long,
-        Float,
-        Short,
-        LocalDate,
-        LocalTime,
-        LocalDateTime
+    companion object {
+        /** Declares a column of any [ColumnType] — the open extension point. */
+        fun <Z> of(type: ColumnType<Z>, name: String? = null): Spec<Z> = Spec(name, type)
+
+        /** A column storing the enum [E] by name (text). */
+        inline fun <reified E : Enum<E>> enum(name: String? = null): Spec<E> = of(enumColumnType<E>(), name)
+
+        /** A column storing the `@Serializable` value [T] as JSON. */
+        inline fun <reified T> json(name: String? = null): Spec<T> = of(jsonColumnType<T>(), name)
     }
 
     // ---- column specs (the public declaration builders) ----
@@ -119,7 +118,7 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
      * [nullable] or [primaryKey] (mutually exclusive — a nullable primary key cannot be
      * expressed).
      */
-    sealed class Spec<Z>(private val name: String?, private val columnType: ColumnNameEnum) {
+    open class Spec<Z>(private val name: String?, private val columnType: ColumnType<Z>) {
         operator fun <T: Table<*, N>, N: Entity> provideDelegate(table: T, property: KProperty<*>): ReadOnlyProperty<T, NotNullColumn<Z, T, N>> {
             val column = NotNullColumn<Z, T, N>(table, property.name, name ?: property.name, columnType).also { it.init() }
             return ReadOnlyProperty { _, _ -> column }
@@ -133,7 +132,7 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
     }
 
     /** Spec for a nullable column. Has no [primaryKey] — nullable primary keys are not allowed. */
-    class NullableSpec<Z> internal constructor(private val name: String?, private val columnType: ColumnNameEnum) {
+    class NullableSpec<Z> internal constructor(private val name: String?, private val columnType: ColumnType<Z>) {
         operator fun <T: Table<*, N>, N: Entity> provideDelegate(table: T, property: KProperty<*>): ReadOnlyProperty<T, NullableColumn<Z, T, N>> {
             val column = NullableColumn<Z, T, N>(table, property.name, name ?: property.name, columnType).also { it.init() }
             return ReadOnlyProperty { _, _ -> column }
@@ -141,7 +140,7 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
     }
 
     /** Spec for a primary-key column. Has no [nullable] — nullable primary keys are not allowed. */
-    class PrimaryKeySpec<Z> internal constructor(private val name: String?, private val columnType: ColumnNameEnum) {
+    class PrimaryKeySpec<Z> internal constructor(private val name: String?, private val columnType: ColumnType<Z>) {
         operator fun <T: Table<*, N>, N: Entity> provideDelegate(table: T, property: KProperty<*>): ReadOnlyProperty<T, NotNullColumn<Z, T, N>> {
             val column = NotNullColumn<Z, T, N>(table, property.name, name ?: property.name, columnType)
                 .also { it.isPrimaryKey = true; it.init() }
@@ -151,18 +150,18 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
 
     // ---- the 14 typed column declarations ----
 
-    class UUID(name: String? = null) : Spec<kotlin.uuid.Uuid>(name, ColumnNameEnum.UUID)
-    class BigDecimal(name: String? = null) : Spec<com.ionspin.kotlin.bignum.decimal.BigDecimal>(name, ColumnNameEnum.BigDecimal)
-    class Double(name: String? = null) : Spec<kotlin.Double>(name, ColumnNameEnum.Double)
-    class Int(name: String? = null) : Spec<kotlin.Int>(name, ColumnNameEnum.Int)
-    class Boolean(name: String? = null) : Spec<kotlin.Boolean>(name, ColumnNameEnum.Boolean)
-    class Text(name: String? = null) : Spec<kotlin.String>(name, ColumnNameEnum.String)
-    class Instant(name: String? = null) : Spec<kotlinx.datetime.Instant>(name, ColumnNameEnum.Instant)
-    class Json(name: String? = null) : Spec<JsonElement>(name, ColumnNameEnum.Json)
-    class Long(name: String? = null) : Spec<kotlin.Long>(name, ColumnNameEnum.Long)
-    class Float(name: String? = null) : Spec<kotlin.Float>(name, ColumnNameEnum.Float)
-    class Short(name: String? = null) : Spec<kotlin.Short>(name, ColumnNameEnum.Short)
-    class LocalDate(name: String? = null) : Spec<kotlinx.datetime.LocalDate>(name, ColumnNameEnum.LocalDate)
-    class LocalTime(name: String? = null) : Spec<kotlinx.datetime.LocalTime>(name, ColumnNameEnum.LocalTime)
-    class LocalDateTime(name: String? = null) : Spec<kotlinx.datetime.LocalDateTime>(name, ColumnNameEnum.LocalDateTime)
+    class UUID(name: String? = null) : Spec<kotlin.uuid.Uuid>(name, UuidColumnType)
+    class BigDecimal(name: String? = null) : Spec<com.ionspin.kotlin.bignum.decimal.BigDecimal>(name, BigDecimalColumnType)
+    class Double(name: String? = null) : Spec<kotlin.Double>(name, DoubleColumnType)
+    class Int(name: String? = null) : Spec<kotlin.Int>(name, IntColumnType)
+    class Boolean(name: String? = null) : Spec<kotlin.Boolean>(name, BooleanColumnType)
+    class Text(name: String? = null) : Spec<kotlin.String>(name, TextColumnType)
+    class Instant(name: String? = null) : Spec<kotlinx.datetime.Instant>(name, InstantColumnType)
+    class Json(name: String? = null) : Spec<JsonElement>(name, JsonColumnType)
+    class Long(name: String? = null) : Spec<kotlin.Long>(name, LongColumnType)
+    class Float(name: String? = null) : Spec<kotlin.Float>(name, FloatColumnType)
+    class Short(name: String? = null) : Spec<kotlin.Short>(name, ShortColumnType)
+    class LocalDate(name: String? = null) : Spec<kotlinx.datetime.LocalDate>(name, LocalDateColumnType)
+    class LocalTime(name: String? = null) : Spec<kotlinx.datetime.LocalTime>(name, LocalTimeColumnType)
+    class LocalDateTime(name: String? = null) : Spec<kotlinx.datetime.LocalDateTime>(name, LocalDateTimeColumnType)
 }

--- a/korm-core/src/commonMain/kotlin/ColumnType.kt
+++ b/korm-core/src/commonMain/kotlin/ColumnType.kt
@@ -1,0 +1,86 @@
+package io.github.kormium
+
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import io.github.kormium.resultset.ResultSet
+import io.github.kormium.sql.getBigDecimal
+import io.github.kormium.sql.getJson
+import io.github.kormium.sql.getUUID
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.serializer
+import kotlin.uuid.Uuid
+
+/**
+ * How a column's Kotlin type [T] is read from a result row and turned into a bound parameter.
+ * The set of types is open: the built-ins below are ordinary [ColumnType]s, and you add your
+ * own either by [convert]ing an existing one (the common case — map onto text/json/int/...) or
+ * by implementing this interface directly.
+ *
+ * Note there is no DDL here — Korm does not own schema (`CREATE TABLE` is raw SQL / migrations),
+ * so a column type only describes value conversion, not the SQL column type.
+ */
+interface ColumnType<T> {
+    /** Reads the value at [index] (1-based per [ResultSet]) from [rs], or null for SQL NULL. */
+    fun read(rs: ResultSet, index: Int): T?
+
+    /**
+     * Converts a domain value into what gets bound as a parameter. The result still flows
+     * through the backend's [TypeMapper.toParameter] and the dialect's bind rendering (so e.g.
+     * a returned [JsonElement] is cast to `::jsonb` on Postgres). The default is identity.
+     */
+    fun toParam(value: T): Any? = value
+}
+
+/**
+ * Derives a [ColumnType] for [Domain] from this one for [Stored] by mapping values both ways —
+ * the lightweight path for custom types (Exposed's `transform`, Hibernate's `AttributeConverter`).
+ * Storage, reading and any dialect casts are inherited; you only translate the value.
+ */
+fun <Domain, Stored> ColumnType<Stored>.convert(
+    toStored: (Domain) -> Stored,
+    fromStored: (Stored) -> Domain,
+): ColumnType<Domain> = object : ColumnType<Domain> {
+    override fun read(rs: ResultSet, index: Int): Domain? = this@convert.read(rs, index)?.let(fromStored)
+    override fun toParam(value: Domain): Any? = this@convert.toParam(toStored(value))
+}
+
+// ---- built-in column types (the 14 Korm ships) ----
+
+object UuidColumnType : ColumnType<Uuid> { override fun read(rs: ResultSet, index: Int) = rs.getUUID(index) }
+object BigDecimalColumnType : ColumnType<BigDecimal> { override fun read(rs: ResultSet, index: Int) = rs.getBigDecimal(index) }
+object DoubleColumnType : ColumnType<Double> { override fun read(rs: ResultSet, index: Int) = rs.getDouble(index) }
+object IntColumnType : ColumnType<Int> { override fun read(rs: ResultSet, index: Int) = rs.getInt(index) }
+object BooleanColumnType : ColumnType<Boolean> { override fun read(rs: ResultSet, index: Int) = rs.getBoolean(index) }
+object TextColumnType : ColumnType<String> { override fun read(rs: ResultSet, index: Int) = rs.getString(index) }
+object InstantColumnType : ColumnType<Instant> { override fun read(rs: ResultSet, index: Int) = rs.getInstant(index) }
+object JsonColumnType : ColumnType<JsonElement> { override fun read(rs: ResultSet, index: Int) = rs.getJson(index) }
+object LongColumnType : ColumnType<Long> { override fun read(rs: ResultSet, index: Int) = rs.getLong(index) }
+object FloatColumnType : ColumnType<Float> { override fun read(rs: ResultSet, index: Int) = rs.getFloat(index) }
+object ShortColumnType : ColumnType<Short> { override fun read(rs: ResultSet, index: Int) = rs.getShort(index) }
+object LocalDateColumnType : ColumnType<LocalDate> { override fun read(rs: ResultSet, index: Int) = rs.getDate(index) }
+object LocalTimeColumnType : ColumnType<LocalTime> { override fun read(rs: ResultSet, index: Int) = rs.getTime(index) }
+object LocalDateTimeColumnType : ColumnType<LocalDateTime> { override fun read(rs: ResultSet, index: Int) = rs.getLocalDateTime(index) }
+
+// ---- ready-made custom types built on [convert] ----
+
+/** Stores an enum by its [Enum.name] in a text column. */
+inline fun <reified E : Enum<E>> enumColumnType(): ColumnType<E> {
+    val byName = enumValues<E>().associateBy { it.name }
+    return TextColumnType.convert(
+        toStored = { e: E -> e.name },
+        fromStored = { s: String -> byName[s] ?: error("Unknown ${E::class.simpleName} value: $s") },
+    )
+}
+
+/** Stores a `@Serializable` value [T] as JSON (jsonb on Postgres, text on SQLite). */
+inline fun <reified T> jsonColumnType(json: Json = Json.Default): ColumnType<T> {
+    val ser = serializer<T>()
+    return JsonColumnType.convert(
+        toStored = { value: T -> json.encodeToJsonElement(ser, value) },
+        fromStored = { element: JsonElement -> json.decodeFromJsonElement(ser, element) },
+    )
+}

--- a/korm-core/src/commonMain/kotlin/Expression.kt
+++ b/korm-core/src/commonMain/kotlin/Expression.kt
@@ -85,37 +85,37 @@ abstract class ComparisonOp(
 class EqOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "=")
 
 infix fun <T : Expression, T2 : Expression> T.eq(other: T2): Expression = EqOp(this, other)
-infix fun <Z> Column<Z, *, *>.eq(value: Z): Expression = EqOp(this, Value(value))
+infix fun <Z> Column<Z, *, *>.eq(value: Z): Expression = EqOp(this, Value(bindParam(value)))
 
 /** Checks that the operands are not equal. */
 class NeqOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "<>")
 
 infix fun <T : Expression, T2 : Expression> T.neq(other: T2): Expression = NeqOp(this, other)
-infix fun <Z> Column<Z, *, *>.neq(value: Z): Expression = NeqOp(this, Value(value))
+infix fun <Z> Column<Z, *, *>.neq(value: Z): Expression = NeqOp(this, Value(bindParam(value)))
 
 /** Checks that the left operand is less than the right. */
 class LessOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "<")
 
 infix fun <T : Expression, T2 : Expression> T.less(other: T2): Expression = LessOp(this, other)
-infix fun <Z> Column<Z, *, *>.less(value: Z): Expression = LessOp(this, Value(value))
+infix fun <Z> Column<Z, *, *>.less(value: Z): Expression = LessOp(this, Value(bindParam(value)))
 
 /** Checks that the left operand is less than or equal to the right. */
 class LessEqOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "<=")
 
 infix fun <T : Expression, T2 : Expression> T.lessEq(other: T2): Expression = LessEqOp(this, other)
-infix fun <Z> Column<Z, *, *>.lessEq(value: Z): Expression = LessEqOp(this, Value(value))
+infix fun <Z> Column<Z, *, *>.lessEq(value: Z): Expression = LessEqOp(this, Value(bindParam(value)))
 
 /** Checks that the left operand is greater than the right. */
 class GreaterOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, ">")
 
 infix fun <T : Expression, T2 : Expression> T.gt(other: T2): Expression = GreaterOp(this, other)
-infix fun <Z> Column<Z, *, *>.gt(value: Z): Expression = GreaterOp(this, Value(value))
+infix fun <Z> Column<Z, *, *>.gt(value: Z): Expression = GreaterOp(this, Value(bindParam(value)))
 
 /** Checks that the left operand is greater than or equal to the right. */
 class GreaterEqOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, ">=")
 
 infix fun <T : Expression, T2 : Expression> T.gtEq(other: T2): Expression = GreaterEqOp(this, other)
-infix fun <Z> Column<Z, *, *>.gtEq(value: Z): Expression = GreaterEqOp(this, Value(value))
+infix fun <Z> Column<Z, *, *>.gtEq(value: Z): Expression = GreaterEqOp(this, Value(bindParam(value)))
 
 /** `column IN (v1, v2, ...)`. An empty list renders to `FALSE` (matches nothing). */
 class InListOp(private val column: Expression, private val values: List<*>) : Expression {
@@ -124,7 +124,7 @@ class InListOp(private val column: Expression, private val values: List<*>) : Ex
         else "${column.toSql(builder)} IN (${values.joinToString(", ") { builder.bind(it) }})"
 }
 
-infix fun <Z> Column<Z, *, *>.inList(values: List<Z>): Expression = InListOp(this, values)
+infix fun <Z> Column<Z, *, *>.inList(values: List<Z>): Expression = InListOp(this, values.map { bindParam(it) })
 
 /** `column LIKE pattern` (text columns only). */
 class LikeOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "LIKE")

--- a/korm-core/src/commonMain/kotlin/Table.kt
+++ b/korm-core/src/commonMain/kotlin/Table.kt
@@ -53,7 +53,7 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         val fields = HashMap<String, Any?>(fieldDisplayName.size * 2)
         var index = 0
         for ((fieldName, column) in fieldDisplayName) {
-            fields[fieldName] = typeMapper.fromResult(rs, index, column.columnType)
+            fields[fieldName] = column.columnType.read(rs, index)
             index++
         }
         return hydrate(fields)
@@ -63,7 +63,7 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
     // so update() can tell "leave untouched" (absent) from "set to NULL" (present and null).
     private fun generatePresentFields(dao: T): List<Pair<String, Any?>> {
         return this.fieldDisplayName.filter { dao.fields.containsKey(it.key) }.map {
-            it.value.name to dao.fields[it.key]
+            it.value.name to it.value.bindParam(dao.fields[it.key])
         }
     }
 
@@ -165,7 +165,7 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
                 val colSql = group.columns.joinToString(", ") { dialect.quoteIdentifier(it.name) }
                 val tuples = group.entityIndices.joinToString(", ") { idx ->
                     val entity = entities[idx]
-                    "(${group.columns.joinToString(", ") { col -> builder.bind(entity.fields[col.fieldKey]) }})"
+                    "(${group.columns.joinToString(", ") { col -> builder.bind(col.bindParam(entity.fields[col.fieldKey])) }})"
                 }
                 statements += BatchStatement(
                     "INSERT INTO ${qualifiedTableName(dialect)} ($colSql) VALUES $tuples$returningSuffix",

--- a/korm-core/src/commonMain/kotlin/TypeMapper.kt
+++ b/korm-core/src/commonMain/kotlin/TypeMapper.kt
@@ -1,44 +1,19 @@
 package io.github.kormium
 
-import io.github.kormium.resultset.ResultSet
-import io.github.kormium.sql.getBigDecimal
-import io.github.kormium.sql.getJson
-import io.github.kormium.sql.getUUID
-
-/** Backend-specific conversion of column values to/from the driver's wire form. */
+/** Backend-specific conversion of a bound value to the driver's wire form. */
 interface TypeMapper {
     /** Converts [value] to the form bound as a parameter (e.g. UUID/BigDecimal → text). */
     fun toParameter(value: Any?): Any?
-
-    /** Reads the column value of [type] at [index] from [rs]. */
-    fun fromResult(rs: ResultSet, index: Int, type: Column.ColumnNameEnum): Any?
 }
 
 /**
- * Text-based mapping shared by drivers that bind and return values as text (libpq,
- * and JDBC with `stringtype=unspecified`). Non-primitive values are sent through
- * toString(); each column type is read via the matching [ResultSet] getter.
+ * Text-based mapping shared by drivers that bind values as text (libpq, and JDBC with
+ * `stringtype=unspecified`). Non-primitive values are sent through toString(). Reading is
+ * handled per column by [ColumnType.read], not here.
  */
 object StandardTypeMapper : TypeMapper {
     override fun toParameter(value: Any?): Any? = when (value) {
         null, is Boolean, is Int, is Long, is Double, is String -> value
         else -> value.toString()
-    }
-
-    override fun fromResult(rs: ResultSet, index: Int, type: Column.ColumnNameEnum): Any? = when (type) {
-        Column.ColumnNameEnum.UUID -> rs.getUUID(index)
-        Column.ColumnNameEnum.BigDecimal -> rs.getBigDecimal(index)
-        Column.ColumnNameEnum.Double -> rs.getDouble(index)
-        Column.ColumnNameEnum.Int -> rs.getInt(index)
-        Column.ColumnNameEnum.Boolean -> rs.getBoolean(index)
-        Column.ColumnNameEnum.String -> rs.getString(index)
-        Column.ColumnNameEnum.Instant -> rs.getInstant(index)
-        Column.ColumnNameEnum.Json -> rs.getJson(index)
-        Column.ColumnNameEnum.Long -> rs.getLong(index)
-        Column.ColumnNameEnum.Float -> rs.getFloat(index)
-        Column.ColumnNameEnum.Short -> rs.getShort(index)
-        Column.ColumnNameEnum.LocalDate -> rs.getDate(index)
-        Column.ColumnNameEnum.LocalTime -> rs.getTime(index)
-        Column.ColumnNameEnum.LocalDateTime -> rs.getLocalDateTime(index)
     }
 }

--- a/korm-core/src/commonTest/kotlin/ColumnTypeTest.kt
+++ b/korm-core/src/commonTest/kotlin/ColumnTypeTest.kt
@@ -1,0 +1,67 @@
+import io.github.kormium.TextColumnType
+import io.github.kormium.convert
+import io.github.kormium.enumColumnType
+import io.github.kormium.jsonColumnType
+import io.github.kormium.resultset.ResultSet
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Serializable
+private data class Prefs(val theme: String, val pushes: Boolean)
+
+private enum class Role { ADMIN, USER }
+
+// A ResultSet that returns one fixed String for every column (enough to drive the
+// text-based getters getString/getJson/getUUID used by these column types).
+private class StringRs(private val value: String?) : ResultSet {
+    override val columns = arrayOf("c")
+    override fun next() = true
+    override fun getString(columnIndex: Int) = value
+    override fun getBoolean(columnIndex: Int): Boolean? = null
+    override fun getShort(columnIndex: Int): Short? = null
+    override fun getInt(columnIndex: Int): Int? = null
+    override fun getLong(columnIndex: Int): Long? = null
+    override fun getFloat(columnIndex: Int): Float? = null
+    override fun getDouble(columnIndex: Int): Double? = null
+    override fun getBytes(columnIndex: Int): ByteArray? = null
+    override fun getDate(columnIndex: Int): LocalDate? = null
+    override fun getTime(columnIndex: Int): LocalTime? = null
+    override fun getLocalDateTime(columnIndex: Int): LocalDateTime? = null
+    override fun getInstant(columnIndex: Int): Instant? = null
+}
+
+class ColumnTypeTest {
+
+    @Test
+    fun enumStoresAndReadsByName() {
+        val type = enumColumnType<Role>()
+        assertEquals("ADMIN", type.toParam(Role.ADMIN))
+        assertEquals(Role.ADMIN, type.read(StringRs("ADMIN"), 0))
+        assertEquals(null, type.read(StringRs(null), 0))
+    }
+
+    @Test
+    fun jsonEncodesToElementAndDecodesBack() {
+        val type = jsonColumnType<Prefs>()
+        val prefs = Prefs("dark", pushes = true)
+        val param = type.toParam(prefs)
+        assertTrue(param is JsonElement, "json column binds a JsonElement (so Postgres casts ::jsonb)")
+        // The JsonElement renders to JSON text; reading parses it back into the value.
+        assertEquals(prefs, type.read(StringRs(param.toString()), 0))
+    }
+
+    @Test
+    fun customConverterMapsBothWays() {
+        // Store an Int as a hex string on top of the text column type.
+        val hex = TextColumnType.convert<Int, String>(toStored = { it.toString(16) }, fromStored = { it.toInt(16) })
+        assertEquals("ff", hex.toParam(255))
+        assertEquals(255, hex.read(StringRs("ff"), 0))
+    }
+}

--- a/korm-sqlite/src/commonTest/kotlin/SqliteColumnTypeTest.kt
+++ b/korm-sqlite/src/commonTest/kotlin/SqliteColumnTypeTest.kt
@@ -1,0 +1,64 @@
+import io.github.kormium.Column
+import io.github.kormium.Entity
+import io.github.kormium.Table
+import io.github.kormium.TextColumnType
+import io.github.kormium.convert
+import io.github.kormium.createSqliteDatabase
+import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.eq
+import io.github.kormium.suspendAutocommit
+import io.github.kormium.suspendTransaction
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+private enum class Grade { A, B, C }
+
+private class Item : Entity() {
+    var id by Items.id
+    var grade by Items.grade
+    var hex by Items.hex
+}
+
+private object Items : Table<SqCatalog, Item>("items", ::Item) {
+    val id by Column.UUID().primaryKey()
+    val grade by Column.enum<Grade>()                                  // enum -> text
+    val hex by Column.of(TextColumnType.convert<Int, String>(          // custom converter -> text
+        toStored = { it.toString(16) },
+        fromStored = { it.toInt(16) },
+    ))
+
+    init { id; grade; hex }
+}
+
+private val itemsDdl =
+    """CREATE TABLE IF NOT EXISTS "items" ("id" TEXT NOT NULL, "grade" TEXT NOT NULL, "hex" TEXT NOT NULL, PRIMARY KEY ("id"))"""
+
+/** End-to-end (JVM + Native, real SQLite) for the open column-type system: an enum column and a
+ *  user-defined converter round-trip through insert/read, and an enum predicate filters correctly. */
+class SqliteColumnTypeTest {
+
+    @Test
+    fun enumAndConverterRoundTrip() = runTest {
+        val db: SuspendDatabase<SqCatalog> = createSqliteDatabase(":memory:")
+        db.suspendTransaction { Items.execSql(itemsDdl) }
+        val id = Uuid.random()
+
+        db.suspendTransaction {
+            Items.insert(Item().apply {
+                this.id = id
+                grade = Grade.B
+                hex = 255
+            })
+        }
+
+        val item = db.suspendAutocommit { Items.findById(id) }!!
+        assertEquals(Grade.B, item.grade)
+        assertEquals(255, item.hex)   // stored as "ff", read back as Int
+
+        // Predicate on the enum column binds the stored name ("B"), so it matches.
+        val bs = db.suspendAutocommit { Items.find { where { Items.grade eq Grade.B } } }
+        assertEquals(listOf(id), bs.map { it.id })
+    }
+}


### PR DESCRIPTION
## What

Replaces the **closed** 14-type column system (a `ColumnNameEnum` + an exhaustive `when` in the type mapper) with an **extensible `ColumnType<T>`** — the model of Exposed's `ColumnType` / Hibernate's `UserType`+`AttributeConverter`.

```kotlin
val role  by Column.enum<Role>()    // enum by name (text)
val prefs by Column.json<Prefs>()   // @Serializable as JSON (jsonb on Postgres)
val color by Column.of(TextColumnType.convert<Color, String>({ it.hex }, { Color(it) }))  // your own type
```

Two tiers, like the big ORMs:
- **`convert(toStored, fromStored)`** — derive a typed column over an existing one (the 90% case; replaces Room `@TypeConverter`, type-safe, no annotations).
- **implement `ColumnType<T>`** — for a genuinely new storage type.

Conversion applies on insert, batch-insert, update and in the typed predicate operators, so `where { Users.role eq Role.ADMIN }` binds the stored form. Reading routes through `ColumnType.read`; dialect casts (`::uuid`/`::jsonb`) still key off the resulting runtime value, so `json<T>` → `JsonElement` → `::jsonb` works.

## Compatibility

Ordinary table/query/insert code is **source- and behaviour-compatible** — the 14 built-ins are reimplemented as identity-conversion `ColumnType`s, and the existing core/sqlite/observe suites pass unchanged.

**Breaking only at the internal extension point:** `Column.ColumnNameEnum` removed; `TypeMapper.fromResult` removed (reading moved to `ColumnType.read`); `Column.columnType` is now `ColumnType<Z>`. Nothing outside Korm's own internals used these. Folded into the unreleased **0.3.0**.

## Tests / docs

- `ColumnTypeTest` (core: enum/json/convert logic), `SqliteColumnTypeTest` (enum + custom converter end-to-end vs real SQLite, **jvm + native**).
- All modules + benchmarks + samples compile.
- Docs: `tables-and-entities.md` (Custom column types), CHANGELOG, roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)