### PR TITLE
Repository pattern sample (V5: sample, not library API)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         run: >-
           ./gradlew
           :samples:crud-sqlite:jvmTest :samples:crud-sqlite:nativeTest
+          :samples:repository:jvmTest :samples:repository:nativeTest
           :samples:sharding:jvmTest :samples:sharding:nativeTest
           --console=plain
 

--- a/docs/api-cookbook.md
+++ b/docs/api-cookbook.md
@@ -275,3 +275,41 @@ routing {
 ```
 
 Use `SuspendDatabase` in server routes so the route body can suspend naturally.
+
+## A Repository
+
+Korm does not ship a `Repository` type — like Exposed, you call table operations inside
+`suspendTransaction { }` / `suspendAutocommit { }`. When you want a Room-style home for a table's
+queries, this small base is the recommended pattern; copy it and adapt it (it is yours to change):
+
+```kotlin
+abstract class Repository<G : Catalog, T : Entity>(
+    protected val db: SuspendDatabase<G>,
+    protected val table: Table<G, T>,
+) {
+    suspend fun findById(id: Any) = db.suspendAutocommit { table.findById(id) }
+    suspend fun all() = db.suspendAutocommit { table.all() }
+    suspend fun insert(entity: T) = db.suspendTransaction { table.insert(entity) }
+    fun observeAll(): Flow<List<T>> = table.observe(db)                 // needs korm-observe
+    protected suspend fun <R> read(block: suspend SuspendScope<G>.() -> R) = db.suspendAutocommit(block)
+    protected suspend fun <R> write(block: suspend SuspendScope<G>.() -> R) = db.suspendTransaction(block)
+}
+
+class UserRepository(db: SuspendDatabase<App>) : Repository<App, User>(db, Users) {
+    suspend fun adults() = read { Users.find { where { Users.age gtEq 18 } } }
+    fun observeAdults() = Users.observe(db) { where { Users.age gtEq 18 } }
+}
+```
+
+Each method is its own transaction. To make several repository operations atomic, wrap their
+table operations in one outer `suspendTransaction { }` (the Unit of Work lives in your service):
+
+```kotlin
+db.suspendTransaction {
+    Users.insert(user)
+    Orders.insert(order)
+}
+```
+
+For unit-testing services without a database, depend on a domain interface and implement it via
+this base, then pass a fake in tests. See the runnable [repository sample](../samples/repository).

--- a/samples/README.md
+++ b/samples/README.md
@@ -9,6 +9,7 @@ Each subdirectory is a focused, runnable sample. Run gradle commands from the re
 | [r2dbc](r2dbc) | Postgres (async) | yes (compose) | Same Ktor CRUD on the non-blocking r2dbc driver (JVM only) |
 | [sqlite-cache](sqlite-cache) | Postgres + SQLite | yes (compose) | SQLite as a read-through cache in front of Postgres |
 | [crud-sqlite](crud-sqlite) | SQLite | no | Standalone CRUD + migrations (JVM + native) |
+| [repository](repository) | SQLite | no | A copyable Repository pattern: CRUD, custom queries, observe, cross-repo transactions |
 | [sharding](sharding) | SQLite | no | Multiple catalogs (compile-time safety) + sharding |
 
 The Postgres samples ship a `docker-compose.yml` matching their connection settings:

--- a/samples/repository/README.md
+++ b/samples/repository/README.md
@@ -1,0 +1,31 @@
+# Sample: repository
+
+A standalone console app — **no server, no external database** — over **SQLite**, running the
+same `commonMain` code on JVM and Kotlin/Native.
+
+Korm intentionally does **not** ship a `Repository` type (like Exposed, you call table operations
+inside `suspendTransaction { }` / `suspendAutocommit { }`). This sample shows the recommended
+pattern when you want a Room-style "home" for a table's queries: a small `Repository<G, T>` base
+([`Repository.kt`](src/commonMain/kotlin/Repository.kt)) that you **copy into your project** and
+adapt — it is ~25 lines and yours to change.
+
+Shows:
+- a copyable `Repository` base with `findById` / `all` / `insert` / `deleteWhere` and `observeAll()`;
+- a subclass (`UserRepository`) adding a custom query (`adults()`) and a reactive
+  `observeAdults(): Flow<List<User>>` via `korm-observe`;
+- a cross-repository **transaction** (`ShopService.register`) wrapping two writes in one
+  `suspendTransaction { }` so they commit atomically.
+
+## Run
+
+Run from the repository root. No Docker needed.
+
+```sh
+# JVM ...
+./gradlew :samples:repository:runJvm
+# ... or native
+./gradlew :samples:repository:runDebugExecutableNative
+```
+
+The run prints a `findById`, the custom `adults()` query, the observed Flow re-emitting after an
+insert (`[[Alice], [Alice, Carol]]`), and the order written by the cross-repository transaction.

--- a/samples/repository/build.gradle.kts
+++ b/samples/repository/build.gradle.kts
@@ -1,0 +1,58 @@
+@file:Suppress("DEPRECATION") // legacy custom-named native target (e.g. macosX64("native"))
+
+plugins {
+    kotlin("multiplatform")
+}
+
+repositories {
+    mavenCentral()
+}
+
+group = "io.github.kormium.samples.repository"
+version = "1.0"
+
+kotlin {
+    val hostOs = System.getProperty("os.name")
+    if (!hostOs.contains("windows", ignoreCase = true)) {
+        val arch = System.getProperty("os.arch")
+        val nativeTarget = when {
+            hostOs == "Mac OS X" && arch == "x86_64" -> macosX64("native")
+            hostOs == "Mac OS X" && arch == "aarch64" -> macosArm64("native")
+            hostOs == "Linux" -> linuxX64("native")
+            else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
+        }
+        nativeTarget.apply {
+            binaries {
+                executable {
+                    entryPoint = "io.github.kormium.samples.repository.main"
+                }
+            }
+        }
+    }
+
+    jvmToolchain(21)
+    jvm {
+        binaries {
+            executable {
+                mainClass.set("io.github.kormium.samples.repository.MainKt")
+            }
+        }
+        testRuns["test"].executionTask.configure { useJUnitPlatform() }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                // SQLite (self-contained, JVM + native) + korm-observe for reactive Flow queries.
+                implementation(project(":korm-sqlite"))
+                implementation(project(":korm-observe"))
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+            }
+        }
+    }
+}

--- a/samples/repository/src/commonMain/kotlin/Main.kt
+++ b/samples/repository/src/commonMain/kotlin/Main.kt
@@ -1,0 +1,104 @@
+package io.github.kormium.samples.repository
+
+import io.github.kormium.Catalog
+import io.github.kormium.Column
+import io.github.kormium.Entity
+import io.github.kormium.Table
+import io.github.kormium.createSqliteDatabase
+import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.gtEq
+import io.github.kormium.observe.observe
+import io.github.kormium.suspendTransaction
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+// ---- schema + entities (owned by the app: raw DDL, not Korm) ----
+
+object Shop : Catalog
+
+object Users : Table<Shop, User>("users", ::User) {
+    val id by Column.Int().primaryKey()
+    val name by Column.Text()
+    val age by Column.Int()
+}
+
+class User : Entity() {
+    var id by Users.id
+    var name by Users.name
+    var age by Users.age
+}
+
+object Orders : Table<Shop, Order>("orders", ::Order) {
+    val id by Column.Int().primaryKey()
+    val userId by Column.Int()
+    val total by Column.Int()
+}
+
+class Order : Entity() {
+    var id by Orders.id
+    var userId by Orders.userId
+    var total by Orders.total
+}
+
+internal val usersDdl =
+    """CREATE TABLE IF NOT EXISTS "users" ("id" INTEGER NOT NULL, "name" TEXT NOT NULL, "age" INTEGER NOT NULL, PRIMARY KEY ("id"))"""
+internal val ordersDdl =
+    """CREATE TABLE IF NOT EXISTS "orders" ("id" INTEGER NOT NULL, "userId" INTEGER NOT NULL, "total" INTEGER NOT NULL, PRIMARY KEY ("id"))"""
+
+// ---- repositories (extend the copied Repository base, add domain queries) ----
+
+class UserRepository(db: SuspendDatabase<Shop>) : Repository<Shop, User>(db, Users) {
+    suspend fun adults(): List<User> = read { Users.find { where { Users.age gtEq 18 } } }
+    fun observeAdults(): Flow<List<User>> = Users.observe(db) { where { Users.age gtEq 18 } }
+}
+
+class OrderRepository(db: SuspendDatabase<Shop>) : Repository<Shop, Order>(db, Orders)
+
+// ---- a service that needs a cross-repository transaction ----
+
+class ShopService(
+    private val db: SuspendDatabase<Shop>,
+    val users: UserRepository,
+    val orders: OrderRepository,
+) {
+    // Repository methods each open their own transaction, so to make two writes atomic we wrap
+    // the table operations in ONE outer transaction (the Unit of Work lives in the service).
+    suspend fun register(user: User, firstOrder: Order) = db.suspendTransaction {
+        Users.insert(user)
+        Orders.insert(firstOrder)
+    }
+}
+
+internal fun user(id: Int, name: String, age: Int) = User().apply { this.id = id; this.name = name; this.age = age }
+internal fun order(id: Int, userId: Int, total: Int) = Order().apply { this.id = id; this.userId = userId; this.total = total }
+
+fun main() = runBlocking {
+    val db: SuspendDatabase<Shop> = createSqliteDatabase()
+    db.use {
+        db.suspendTransaction { Users.execSql(usersDdl); Orders.execSql(ordersDdl) }
+
+        val users = UserRepository(db)
+        val orders = OrderRepository(db)
+        val shop = ShopService(db, users, orders)
+
+        users.insert(user(1, "Alice", 30))
+        users.insert(user(2, "Bob", 16))
+        println("findById(1) = ${users.findById(1)?.name}")
+        println("adults      = ${users.adults().map { it.name }}")
+
+        // Reactive query: the Flow re-emits whenever the users table changes.
+        val seen = mutableListOf<List<String>>()
+        val watcher = launch { users.observeAdults().collect { seen += it.map { u -> u.name } } }
+        delay(100)                                   // let the initial value arrive
+        users.insert(user(3, "Carol", 41))           // an adult -> the Flow re-emits
+        delay(100)
+        watcher.cancel()
+        println("observed    = $seen")               // [[Alice], [Alice, Carol]]
+
+        // Cross-repository transaction: both writes commit together.
+        shop.register(user(4, "Dave", 22), order(100, userId = 4, total = 50))
+        println("orders      = ${orders.all().map { "#${it.id}:${it.total}" }}")
+    }
+}

--- a/samples/repository/src/commonMain/kotlin/Repository.kt
+++ b/samples/repository/src/commonMain/kotlin/Repository.kt
@@ -1,0 +1,51 @@
+package io.github.kormium.samples.repository
+
+import io.github.kormium.Catalog
+import io.github.kormium.Entity
+import io.github.kormium.QueryBuilder
+import io.github.kormium.SuspendScope
+import io.github.kormium.Table
+import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.observe.observe
+import io.github.kormium.suspendAutocommit
+import io.github.kormium.suspendTransaction
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Korm intentionally does NOT ship a Repository type — like Exposed, you call table operations
+ * inside `suspendTransaction { }` / `suspendAutocommit { }`. This little base is the recommended
+ * pattern when you want a Room-style "home" for a table's queries; copy it into your project and
+ * adapt it. It is ~25 lines and yours to change.
+ *
+ * Each method runs in its own scope (so it is its own transaction). To make several repository
+ * operations atomic, wrap their table operations in one outer `suspendTransaction { }` instead —
+ * see [ShopService.register].
+ */
+abstract class Repository<G : Catalog, T : Entity>(
+    protected val db: SuspendDatabase<G>,
+    protected val table: Table<G, T>,
+) {
+    suspend fun findById(id: Any): T? = read { table.findById(id) }
+    suspend fun all(): List<T> = read { table.all() }
+    suspend fun insert(entity: T): T? = write { table.insert(entity) }
+    suspend fun deleteWhere(block: QueryBuilder.() -> Unit): Long = write { table.deleteWhere(block) }
+
+    /** A Flow that emits the current rows now and again after every committed write to the table. */
+    fun observeAll(): Flow<List<T>> = table.observe(db)
+
+    /** Run a read on this database (no transaction). Use in subclasses for custom queries. */
+    protected suspend fun <R> read(block: suspend SuspendScope<G>.() -> R): R = db.suspendAutocommit(block)
+
+    /** Run a write in a transaction on this database. Use in subclasses for custom mutations. */
+    protected suspend fun <R> write(block: suspend SuspendScope<G>.() -> R): R = db.suspendTransaction(block)
+}
+
+// For unit-testing services against an interface (mocking), declare a domain interface your
+// service depends on and implement it via this base, e.g.:
+//
+//   interface UserRepo { suspend fun adults(): List<User> }
+//   class DbUserRepo(db) : UserRepo, Repository<Shop, User>(db, Users) {
+//       override suspend fun adults() = read { Users.find { where { Users.age gtEq 18 } } }
+//   }
+//
+// Then a service takes `UserRepo` and tests pass a fake. This sample keeps it concrete for brevity.

--- a/samples/repository/src/commonTest/kotlin/RepositoryTest.kt
+++ b/samples/repository/src/commonTest/kotlin/RepositoryTest.kt
@@ -1,0 +1,72 @@
+package io.github.kormium.samples.repository
+
+import io.github.kormium.createSqliteDatabase
+import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.suspendTransaction
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Runs on JVM and native (SQLite is self-contained). */
+class RepositoryTest {
+
+    // The default :memory: database is shared across this module's test run, so each test
+    // sets up the schema and clears the tables to stay independent.
+    private suspend fun freshDb(): SuspendDatabase<Shop> {
+        val db: SuspendDatabase<Shop> = createSqliteDatabase()
+        db.suspendTransaction {
+            Users.execSql(usersDdl); Orders.execSql(ordersDdl)
+            Users.deleteWhere { }; Orders.deleteWhere { }
+        }
+        return db
+    }
+
+    @Test
+    fun crudCustomQueryAndCrossRepoTransaction() = runBlocking {
+        val db = freshDb()
+        val users = UserRepository(db)
+        val orders = OrderRepository(db)
+
+        users.insert(user(1, "Alice", 30))
+        users.insert(user(2, "Bob", 16))
+
+        assertEquals("Alice", users.findById(1)?.name)
+        assertEquals(listOf("Alice"), users.adults().map { it.name })   // custom query
+
+        ShopService(db, users, orders).register(user(4, "Dave", 22), order(100, userId = 4, total = 50))
+        assertEquals(listOf(100), orders.all().map { it.id })           // cross-repo tx committed
+        assertEquals(setOf("Alice", "Dave"), users.adults().map { it.name }.toSet())
+    }
+
+    @Test
+    fun observeAdultsReEmitsOnInsert() = runBlocking {
+        val db = freshDb()
+        val users = UserRepository(db)
+        users.insert(user(1, "Alice", 30))
+
+        val emissions = Channel<List<String>>(Channel.UNLIMITED)
+        val watcher = launch(Dispatchers.Default) {
+            users.observeAdults().collect { emissions.send(it.map { u -> u.name }) }
+        }
+
+        // Initial value (also guarantees the observer is registered before we write).
+        assertEquals(listOf("Alice"), withTimeout(5_000) { emissions.receive() })
+
+        users.insert(user(2, "Carol", 41))   // an adult -> the Flow must re-emit
+
+        val withCarol = withTimeout(5_000) {
+            var latest = listOf<String>()
+            while (!latest.contains("Carol")) latest = emissions.receive()
+            latest
+        }
+        assertEquals(setOf("Alice", "Carol"), withCarol.toSet())
+
+        watcher.cancelAndJoin()
+        db.close()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ include(
     "samples:ktor-di",
     "samples:ktor-koin",
     "samples:crud-sqlite",
+    "samples:repository",
     "samples:sharding",
     "samples:sqlite-cache",
     "samples:r2dbc",


### PR DESCRIPTION
## What

Korm intentionally does **not** ship a `Repository` type — like Exposed, you call table ops inside `suspendTransaction { }` / `suspendAutocommit { }`. This adds the recommended pattern as a **runnable sample** (and a cookbook recipe), not library surface — keeping the library lean.

`samples/repository` (SQLite, JVM + native, self-contained) shows:
- a ~25-line `Repository<G, T>` base you **copy and adapt** (`findById`/`all`/`insert`/`deleteWhere`/`observeAll`, with `read{}`/`write{}` helpers for custom queries);
- a subclass `UserRepository` with a custom `adults()` and a reactive `observeAdults(): Flow<List<User>>` (via `korm-observe`);
- a cross-repository **transaction** (`ShopService.register`) — two writes committed atomically in one outer `suspendTransaction { }`.

Running it prints the Flow re-emitting on insert: `observed = [[Alice], [Alice, Carol]]`.

## Tests / docs

- `RepositoryTest` (JVM + native): CRUD + custom query + cross-repo tx, and a deterministic observe re-emit test.
- Docs: sample `README.md`, samples index, `docs/api-cookbook.md` "A Repository" recipe. CI runs the sample on JVM + native.

No library code changes; additive sample only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)