### PR TITLE
createX { } configuration builders (config + beforeStart)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+.kotlin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ All notable changes to korm are documented here. The format is based on
 - **`invalidates` argument** on the raw `Scope.execute` / `executeUpdate` (and suspend
   counterparts): declare the tables a raw statement writes so observers are notified — the
   analog of Room's `@RawQuery(observedEntities = …)`.
+- **`createX { }` configuration builders.** `createSqliteDatabase("app.db") { config { … };
+  beforeStart { … } }` and the same for `createDatabase(...)` (PostgreSQL). `config { }` is a
+  mutable view of `KormConfig`; `beforeStart { }` runs once before the database is returned —
+  the place to run migrations (your own package, or Flyway/Liquibase), which the builder does
+  not own. The existing `config: KormConfig` factory overloads are unchanged.
 - **Open column-type system.** Column types are now an extensible `ColumnType<T>` interface
   instead of a fixed list. New built-ins `Column.enum<E>()` (enum by name) and
   `Column.json<T>()` (`@Serializable` value as JSON), a `ColumnType<S>.convert(to, from)`

--- a/docs/api-cookbook.md
+++ b/docs/api-cookbook.md
@@ -235,6 +235,24 @@ db.migrate(
 Migration IDs are permanent. Do not edit an already-applied migration in a released
 application; add a new migration instead.
 
+## Configure a Database with a Builder
+
+`createSqliteDatabase { }` / `createDatabase { }` take an optional configuration block. `config { }`
+sets `KormConfig`; `beforeStart { }` runs once before the database is returned — the place to run
+migrations (Korm's `migrate`, or Flyway/Liquibase). The receiver is the database, so a migration
+list resolves its own catalog:
+
+```kotlin
+val db: Database<App> = createSqliteDatabase("app.db") {
+    config { batchInsertMode = BatchInsertMode.UnionNulls }
+    beforeStart { migrate(appMigrations) }
+}
+```
+
+Migrations are not a built-in concern of the builder — `beforeStart` is a generic startup hook, so
+you can run any tool there (e.g. `Flyway.configure().dataSource(url, user, pw).load().migrate()`).
+Seed data belongs in a migration, not in `beforeStart`.
+
 ## Use SQLite in Tests
 
 ```kotlin

--- a/korm-core/src/commonMain/kotlin/KormBuilder.kt
+++ b/korm-core/src/commonMain/kotlin/KormBuilder.kt
@@ -1,0 +1,51 @@
+package io.github.kormium
+
+import io.github.kormium.database.Database
+
+/**
+ * Mutable form of [KormConfig], used by the `createX { }` builders. It starts from an existing
+ * config and produces a new one via `copy`, so adding a field to [KormConfig] only needs a
+ * matching `var` here (no default is duplicated). See [KormBuilder.config].
+ */
+class KormConfigBuilder internal constructor(private val base: KormConfig) {
+    /** See [KormConfig.batchInsertMode]. */
+    var batchInsertMode: BatchInsertMode = base.batchInsertMode
+
+    internal fun build(): KormConfig = base.copy(
+        batchInsertMode = batchInsertMode,
+    )
+}
+
+/**
+ * Receiver of the `createX { }` builder block. Configures the database and registers a
+ * [beforeStart] hook that runs once, after the connection pool is up but before the database
+ * is returned — the place to run migrations (your own package, or Flyway/Liquibase). Migrations
+ * are intentionally NOT a built-in concern of this builder.
+ */
+class KormBuilder {
+    private var config: KormConfig = KormConfig()
+    private var beforeStart: (Database<Nothing>.() -> Unit)? = null
+
+    /** Configures the [KormConfig] carried by the database. Calls accumulate. */
+    fun config(block: KormConfigBuilder.() -> Unit) {
+        config = KormConfigBuilder(config).apply(block).build()
+    }
+
+    /**
+     * Runs [block] once at startup, before the database is returned. Use it to run migrations:
+     * the receiver is the database, so a migration list resolves its own catalog, e.g.
+     * `beforeStart { migrate(appMigrations) }`. For Flyway/Liquibase, configure them here with
+     * your connection settings (they manage their own JDBC connection). Seed data belongs in a
+     * migration, not here.
+     */
+    fun beforeStart(block: Database<Nothing>.() -> Unit) {
+        beforeStart = block
+    }
+
+    /**
+     * Builds the database with [create] (passing the configured [KormConfig]), then runs the
+     * [beforeStart] hook on it. Called by the `createX { }` factory overloads.
+     */
+    fun <D : Database<Nothing>> finish(create: (KormConfig) -> D): D =
+        create(config).also { driver -> beforeStart?.invoke(driver) }
+}

--- a/korm-postgres/src/commonMain/kotlin/database/CreateDatabase.kt
+++ b/korm-postgres/src/commonMain/kotlin/database/CreateDatabase.kt
@@ -1,5 +1,6 @@
 package io.github.kormium.database
 
+import io.github.kormium.KormBuilder
 import io.github.kormium.KormConfig
 import io.github.kormium.PostgresDriver
 
@@ -12,3 +13,19 @@ expect fun createDatabase(
     poolSize: Int = 10,
     config: KormConfig = KormConfig(),
 ): PostgresDriver
+
+/**
+ * Opens a PostgreSQL database with a configuration block: `createDatabase(host = …, …) {`
+ * `config { … }; beforeStart { migrate(appMigrations) } }`. See [KormBuilder].
+ */
+fun createDatabase(
+    host: String,
+    port: Int = 5432,
+    database: String,
+    user: String,
+    password: String,
+    poolSize: Int = 10,
+    block: KormBuilder.() -> Unit,
+): PostgresDriver = KormBuilder().apply(block).finish {
+    createDatabase(host, port, database, user, password, poolSize, it)
+}

--- a/korm-sqlite/src/commonMain/kotlin/CreateSqliteDatabase.kt
+++ b/korm-sqlite/src/commonMain/kotlin/CreateSqliteDatabase.kt
@@ -19,3 +19,13 @@ expect fun createSqliteDatabase(
     poolSize: Int = 1,
     config: KormConfig = KormConfig(),
 ): SqliteDriver
+
+/**
+ * Opens a SQLite database with a configuration block: `createSqliteDatabase("app.db") {`
+ * `config { … }; beforeStart { migrate(appMigrations) } }`. See [KormBuilder].
+ */
+fun createSqliteDatabase(
+    path: String = ":memory:",
+    poolSize: Int = 1,
+    block: KormBuilder.() -> Unit,
+): SqliteDriver = KormBuilder().apply(block).finish { createSqliteDatabase(path, poolSize, it) }

--- a/korm-sqlite/src/commonTest/kotlin/SqliteBuilderTest.kt
+++ b/korm-sqlite/src/commonTest/kotlin/SqliteBuilderTest.kt
@@ -1,0 +1,45 @@
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import io.github.kormium.BatchInsertMode
+import io.github.kormium.Migration
+import io.github.kormium.autocommit
+import io.github.kormium.createSqliteDatabase
+import io.github.kormium.database.Database
+import io.github.kormium.migrate
+import io.github.kormium.transaction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+/** The createSqliteDatabase { } builder: config { } is applied and beforeStart { } runs before
+ *  the database is returned (here, migrations create the table). JVM + native. */
+class SqliteBuilderTest {
+
+    @Test
+    fun builderAppliesConfigAndRunsBeforeStart() {
+        val migrations = listOf(Migration<SqCatalog>("builder-001") { Products.execSql(productsDdl) })
+
+        val db: Database<SqCatalog> = createSqliteDatabase {
+            config { batchInsertMode = BatchInsertMode.UnionNulls }
+            beforeStart { migrate(migrations) }   // receiver is the db; catalog comes from the list
+        }
+
+        db.use {
+            // config { } was applied to the handle.
+            assertEquals(BatchInsertMode.UnionNulls, db.config.batchInsertMode)
+
+            // beforeStart ran the migration, so the table exists and is usable.
+            val id = Uuid.random()
+            db.transaction {
+                Products.insert(Product().apply {
+                    this.id = id
+                    this.price = BigDecimal.fromInt(5)
+                    this.qty = 1
+                    this.displayName = "from-builder"
+                    this.note = null
+                    this.rank = null
+                })
+            }
+            assertEquals("from-builder", db.autocommit { Products.findById(id) }?.displayName)
+        }
+    }
+}


### PR DESCRIPTION
## What

An optional configuration block on the SQLite and Postgres factories — a familiar, Room-like entry point — without re-wrapping connection params (those stay normal args) and without owning migrations.

```kotlin
val db: Database<App> = createSqliteDatabase("app.db") {
    config { batchInsertMode = UnionNulls }   // mutable view of KormConfig
    beforeStart { migrate(appMigrations) }    // runs once before the db is returned
}
```

- **`config { }`** — a mutable mirror of `KormConfig`, initialized from a base config and built via `copy()`, so a new config field doesn't duplicate its default.
- **`beforeStart { }`** — a generic startup hook (receiver = the database) that runs once before the database is returned. The place to run migrations: Korm's `migrate`, or Flyway/Liquibase (which manage their own connection). **Migrations are intentionally not a built-in concern** — that's a separate package's job. Catalog flows through the migration list (`migrate(appMigrations)` infers `G`), so the receiver stays `Database<Nothing>`; put seed data in a migration, not here.

New `createSqliteDatabase { }` / `createDatabase { }` overloads delegate to the existing `config: KormConfig` factories. **Additive** — the `KormConfig` overloads are unchanged. The r2dbc builder is deferred (no suspend `migrate` yet; r2dbc users run migrations separately).

## Tests / docs

- `SqliteBuilderTest` (JVM + native): `config { }` is applied and `beforeStart { }` runs the migration before the db is returned.
- Docs: CHANGELOG, `api-cookbook.md` "Configure a Database with a Builder".

🤖 Generated with [Claude Code](https://claude.com/claude-code)