### PR TITLE
Code review fixes: AND/OR precedence, lossless WriteListeners, nullable leftJoin pairs, bounded parse cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Kormium are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Mixed `and` / `or` predicates now render with correct precedence.** Kotlin infix calls
+  are all same-precedence and left-associative, so `a or b and c` builds `(a OR b) AND c` —
+  but it previously rendered as `a OR b AND c`, which SQL parses as `a OR (b AND c)`,
+  silently changing the query. Nested compound operands with a different operator are now
+  parenthesized.
+- **`WriteListeners` registration is now lossless under concurrency.** `add` / `remove`
+  swap the copy-on-write listener list with a CAS loop instead of a plain volatile write,
+  so concurrent Flow collections through `kormium-observe` can no longer drop each other's
+  listeners (a dropped listener meant a Flow that silently stopped updating).
+- **The JDBC `:name` parse cache is now bounded.** It is an LRU capped at 1024 entries, and
+  SQL longer than 4096 chars (batch INSERTs, large IN-lists — a distinct string per call)
+  bypasses it, so long-lived servers no longer accumulate parse entries without limit.
+
+### Changed
+- **`leftJoin` entity pairs are now properly nullable** (breaking). `Table.leftJoin` returns
+  a dedicated `LeftJoinPair` whose `find()` is `List<Pair<A, B?>>`: the right side is `null`
+  for left rows with no match (detected by a `NULL` right-side primary key). Previously
+  `find()` claimed `Pair<A, B>` and the unmatched right entity threw on first property
+  access. The `select(...)` forms, `where`, `groupBy`, `distinct` and three-table chaining
+  are unchanged; `innerJoin` is unaffected.
+
 ## [0.4.0] — Rebrand to kormium
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ All notable changes to Kormium are documented here. The format is based on
 - **The JDBC `:name` parse cache is now bounded.** It is an LRU capped at 1024 entries, and
   SQL longer than 4096 chars (batch INSERTs, large IN-lists — a distinct string per call)
   bypasses it, so long-lived servers no longer accumulate parse entries without limit.
+- **`ResultSet` / `ColumnType` docs now state the real 0-based column indexing.** The KDoc
+  (inherited from JDBC) claimed indexes are 1-based, which would mislead custom
+  `ColumnType` implementations; the convention is and was 0-based.
+- **JDBC `rollback()` now translates `SQLException`** into typed Kormium exceptions, like
+  `commit()` already did.
+- **SQLite (Native/Android): a connection released after `close()` is closed, not leaked.**
 
 ### Changed
 - **`leftJoin` entity pairs are now properly nullable** (breaking). `Table.leftJoin` returns
@@ -27,6 +33,14 @@ All notable changes to Kormium are documented here. The format is based on
   `find()` claimed `Pair<A, B>` and the unmatched right entity threw on first property
   access. The `select(...)` forms, `where`, `groupBy`, `distinct` and three-table chaining
   are unchanged; `innerJoin` is unaffected.
+- **Table metadata is read-only** (breaking): `Column.name` and `Column.nullable` are now
+  `val` (were public mutable `var`), and `getFieldDisplayNames()` returns a read-only
+  `Map` (was the internal `MutableMap`), so table metadata can no longer be corrupted at
+  runtime.
+- **`savepoint { }` outside a transaction fails fast** (breaking): calling it inside
+  `autocommit { }` / `suspendAutocommit { }` now throws `IllegalStateException` with a
+  clear message on every backend. Previously it surfaced as a confusing server error on
+  PostgreSQL while silently opening an implicit transaction on SQLite.
 
 ## [0.4.0] — Rebrand to kormium
 

--- a/docs/api-cookbook.md
+++ b/docs/api-cookbook.md
@@ -152,6 +152,14 @@ rows.forEach { row ->
 
 Use `getOrNull` when a selected field can be absent or SQL `NULL`.
 
+For entity pairs, `find()` on a `leftJoin` returns a nullable right side:
+
+```kotlin
+val pairs: List<Pair<User, Order?>> = db.autocommit {
+    (Users leftJoin Orders on (Users.id eq Orders.userId)).find()
+}
+```
+
 ## Aggregate and Read the Result
 
 ```kotlin

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -128,7 +128,16 @@ val pairs: List<Pair<User, Order>> = db.autocommit {
 }
 ```
 
-`leftJoin` is available. Read nullable right-side fields with `getOrNull`:
+`leftJoin` keeps the right side nullable. Its `find()` returns `Pair<A, B?>` — the right
+entity is `null` for left rows with no match (detected by a `NULL` right-side primary key):
+
+```kotlin
+val pairs: List<Pair<User, Order?>> = db.autocommit {
+    (Users leftJoin Orders on (Users.id eq Orders.userId)).find()
+}
+```
+
+In the `select(...)` forms, read nullable right-side fields with `getOrNull`:
 
 ```kotlin
 val rows = db.autocommit {

--- a/kormium-core/src/commonMain/kotlin/Column.kt
+++ b/kormium-core/src/commonMain/kotlin/Column.kt
@@ -33,8 +33,8 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
     /** Key under which the value is stored in [Entity.fields]; follows the Kotlin property name. */
     val fieldKey: String,
     /** Rendered SQL column identifier. Equals [fieldKey] unless a custom name was supplied. */
-    open var name: String,
-    open var nullable: kotlin.Boolean,
+    val name: String,
+    val nullable: kotlin.Boolean,
     val columnType: ColumnType<Z>,
 ) : Expression, Selectable<Z> {
 

--- a/kormium-core/src/commonMain/kotlin/ColumnType.kt
+++ b/kormium-core/src/commonMain/kotlin/ColumnType.kt
@@ -24,7 +24,7 @@ import kotlin.uuid.Uuid
  * so a column type only describes value conversion, not the SQL column type.
  */
 interface ColumnType<T> {
-    /** Reads the value at [index] (1-based per [ResultSet]) from [rs], or null for SQL NULL. */
+    /** Reads the value at [index] (0-based per [ResultSet]) from [rs], or null for SQL NULL. */
     fun read(rs: ResultSet, index: Int): T?
 
     /**

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -51,7 +51,17 @@ sealed class CompoundBooleanOp(
     private val second: Expression,
 ) : Expression {
     override fun toSql(builder: ParamBuilder): String =
-        "${first.toSql(builder)}$operator${second.toSql(builder)}"
+        "${render(first, builder)}$operator${render(second, builder)}"
+
+    // Kotlin infix calls are all same-precedence and left-associative, so `a or b and c`
+    // builds AndOp(OrOp(a, b), c). SQL gives AND higher precedence than OR, so rendering
+    // operands bare would silently change the query's meaning. Parenthesize any nested
+    // compound op with a different operator; same-operator chains are associative and
+    // stay flat.
+    private fun render(expr: Expression, builder: ParamBuilder): String {
+        val sql = expr.toSql(builder)
+        return if (expr is CompoundBooleanOp && expr.operator != operator) "($sql)" else sql
+    }
 }
 
 class AndOp(first: Expression, second: Expression) : CompoundBooleanOp(" AND ", first, second)

--- a/kormium-core/src/commonMain/kotlin/Join.kt
+++ b/kormium-core/src/commonMain/kotlin/Join.kt
@@ -95,6 +95,30 @@ class JoinPair<G : Catalog, A : Entity, B : Entity> internal constructor(
     infix fun leftJoin(other: Table<G, *>): JoinStep<G> = asJoin().leftJoin(other)
 }
 
+/**
+ * A two-table LEFT join that keeps both entity types. Unlike [JoinPair], its `find()` (on
+ * [Scope] / [SuspendScope]) returns `Pair<A, B?>` — the right side is `null` for left rows
+ * with no match. Joining a third table — or grouping — degrades to an (erased) [Join] that
+ * supports only the `select(...)` forms.
+ */
+class LeftJoinPair<G : Catalog, A : Entity, B : Entity> internal constructor(
+    internal val left: Table<G, A>,
+    internal val right: Table<G, B>,
+    private val on: Expression,
+    internal val whereExpr: Expression?,
+) {
+    fun where(condition: Expression): LeftJoinPair<G, A, B> =
+        LeftJoinPair(left, right, on, whereExpr?.let { it and condition } ?: condition)
+
+    internal fun asJoin(): Join<G> = Join(left, listOf(JoinClause(JoinType.LEFT, right, on)), whereExpr)
+
+    fun groupBy(vararg columns: Column<*, *, *>): Join<G> = asJoin().groupBy(*columns)
+    fun distinct(): Join<G> = asJoin().distinct()
+
+    infix fun innerJoin(other: Table<G, *>): JoinStep<G> = asJoin().innerJoin(other)
+    infix fun leftJoin(other: Table<G, *>): JoinStep<G> = asJoin().leftJoin(other)
+}
+
 /** A two-table join awaiting its ON condition, keeping both entity types. */
 class JoinPairStep<G : Catalog, A : Entity, B : Entity> internal constructor(
     private val left: Table<G, A>,
@@ -104,11 +128,19 @@ class JoinPairStep<G : Catalog, A : Entity, B : Entity> internal constructor(
     infix fun on(condition: Expression): JoinPair<G, A, B> = JoinPair(left, right, type, condition, null)
 }
 
+/** A two-table LEFT join awaiting its ON condition, keeping both entity types. */
+class LeftJoinPairStep<G : Catalog, A : Entity, B : Entity> internal constructor(
+    private val left: Table<G, A>,
+    private val right: Table<G, B>,
+) {
+    infix fun on(condition: Expression): LeftJoinPair<G, A, B> = LeftJoinPair(left, right, condition, null)
+}
+
 infix fun <G : Catalog, A : Entity, B : Entity> Table<G, A>.innerJoin(other: Table<G, B>): JoinPairStep<G, A, B> =
     JoinPairStep(this, other, JoinType.INNER)
 
-infix fun <G : Catalog, A : Entity, B : Entity> Table<G, A>.leftJoin(other: Table<G, B>): JoinPairStep<G, A, B> =
-    JoinPairStep(this, other, JoinType.LEFT)
+infix fun <G : Catalog, A : Entity, B : Entity> Table<G, A>.leftJoin(other: Table<G, B>): LeftJoinPairStep<G, A, B> =
+    LeftJoinPairStep(this, other)
 
 /**
  * One row of a query result. Read fields by the [Selectable] you selected:
@@ -166,6 +198,38 @@ private fun buildSelect(
 // Reads each field positionally into a ResultRow.
 private fun mapRow(fields: List<Selectable<*>>, rs: ResultSet, typeMapper: TypeMapper): ResultRow =
     ResultRow(fields.withIndex().associate { (i, f) -> fieldKey(f) to f.read(rs, i, typeMapper) })
+
+// ---- entity-pair hydration (shared by Scope and SuspendScope) ----
+
+// The SELECT list for a two-table entity-pair read: every column of both tables.
+internal fun pairSelectFields(left: Table<*, *>, right: Table<*, *>): List<Selectable<*>> =
+    (left.getFieldDisplayNames().values + right.getFieldDisplayNames().values).toList()
+
+private fun <T : Entity> Table<*, T>.hydrateFrom(row: ResultRow): T =
+    hydrate(getFieldDisplayNames().mapValues { (_, c) -> row.getOrNull(c) }.toMutableMap())
+
+internal fun <A : Entity, B : Entity> hydrateInnerPairs(
+    left: Table<*, A>,
+    right: Table<*, B>,
+    rows: List<ResultRow>,
+): List<Pair<A, B>> = rows.map { row -> left.hydrateFrom(row) to right.hydrateFrom(row) }
+
+// A LEFT JOIN row with no right-side match reads NULL in the right table's primary key —
+// impossible for a matched row, since primary keys are non-null by construction. For a
+// table without a resolvable primary key, fall back to "every right column is NULL"
+// (only wrong for a matched row consisting entirely of NULLs, which has no identity anyway).
+internal fun <A : Entity, B : Entity> hydrateLeftPairs(
+    left: Table<*, A>,
+    right: Table<*, B>,
+    rows: List<ResultRow>,
+): List<Pair<A, B?>> {
+    val rightKey: List<Column<*, *, *>> =
+        right.primaryKey.ifEmpty { right.getFieldDisplayNames().values.toList() }
+    return rows.map { row ->
+        val missing = rightKey.all { row.getOrNull(it) == null }
+        left.hydrateFrom(row) to if (missing) null else right.hydrateFrom(row)
+    }
+}
 
 internal fun runSelect(exec: SqlExecutor, join: Join<*>, fields: List<Selectable<*>>): List<ResultRow> {
     val (sql, params) = buildSelect(join, fields, exec.dialect, exec.typeMapper)

--- a/kormium-core/src/commonMain/kotlin/Scope.kt
+++ b/kormium-core/src/commonMain/kotlin/Scope.kt
@@ -20,6 +20,8 @@ class Scope<G : Catalog> internal constructor(
      * a spurious refresh, never a missed one.
      */
     internal val dirtyTables: MutableSet<String> = mutableSetOf(),
+    /** Whether this scope runs inside a transaction (see [savepoint]). */
+    private val transactional: Boolean = true,
 ) {
     private var savepointCounter = 0
 
@@ -202,8 +204,13 @@ class Scope<G : Catalog> internal constructor(
      * Runs [block] inside a SAVEPOINT on the same connection: if it throws, only its
      * work is rolled back (ROLLBACK TO SAVEPOINT) and the exception propagates; the
      * enclosing transaction may continue if the caller catches it.
+     *
+     * Requires a [transaction] scope — calling it inside [autocommit] throws
+     * [IllegalStateException] (a savepoint without a surrounding transaction is a server
+     * error on PostgreSQL and backend-dependent elsewhere).
      */
     fun <R> savepoint(block: Scope<G>.() -> R): R {
+        check(transactional) { "savepoint { } requires a transaction; use transaction { }, not autocommit { }" }
         val name = "korm_sp_${savepointCounter++}"
         exec.executeUpdate("SAVEPOINT $name")
         return try {
@@ -224,7 +231,7 @@ class Scope<G : Catalog> internal constructor(
 fun <G : Catalog, R> Database<G>.transaction(block: Scope<G>.() -> R): R {
     // The dirty-table set outlives the block so we can fire it after the commit returns.
     val dirty = mutableSetOf<String>()
-    val result = usePinned(transactional = true) { Scope<G>(it, config, dirty).block() }
+    val result = usePinned(transactional = true) { Scope<G>(it, config, dirty, transactional = true).block() }
     writeListeners.fire(dirty)
     return result
 }
@@ -235,7 +242,7 @@ fun <G : Catalog, R> Database<G>.transaction(block: Scope<G>.() -> R): R {
  */
 fun <G : Catalog, R> Database<G>.autocommit(block: Scope<G>.() -> R): R {
     val dirty = mutableSetOf<String>()
-    val result = usePinned(transactional = false) { Scope<G>(it, config, dirty).block() }
+    val result = usePinned(transactional = false) { Scope<G>(it, config, dirty, transactional = false).block() }
     writeListeners.fire(dirty)
     return result
 }

--- a/kormium-core/src/commonMain/kotlin/Scope.kt
+++ b/kormium-core/src/commonMain/kotlin/Scope.kt
@@ -145,15 +145,23 @@ class Scope<G : Catalog> internal constructor(
         asJoin().select(*fields, map = map)
 
     /** Runs a two-table join, reconstructing both sides as a `Pair` of entities. */
-    fun <A : Entity, B : Entity> JoinPair<G, A, B>.find(): List<Pair<A, B>> {
-        val aCols = left.getFieldDisplayNames()
-        val bCols = right.getFieldDisplayNames()
-        val rows = runSelect(exec, asJoin(), (aCols.values + bCols.values).toList())
-        return rows.map { row ->
-            left.hydrate(aCols.mapValues { (_, c) -> row.getOrNull(c) }.toMutableMap()) to
-                right.hydrate(bCols.mapValues { (_, c) -> row.getOrNull(c) }.toMutableMap())
-        }
-    }
+    fun <A : Entity, B : Entity> JoinPair<G, A, B>.find(): List<Pair<A, B>> =
+        hydrateInnerPairs(left, right, runSelect(exec, asJoin(), pairSelectFields(left, right)))
+
+    /** Runs a two-table LEFT join, selecting the given fields (or all columns if none are given). */
+    fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>): List<ResultRow> =
+        asJoin().select(*fields)
+
+    /** Runs a two-table LEFT join, mapping each [ResultRow] with [map]. */
+    fun <A : Entity, B : Entity, R> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
+        asJoin().select(*fields, map = map)
+
+    /**
+     * Runs a two-table LEFT join, reconstructing both sides as entity pairs. The right side
+     * is `null` for left rows with no match (detected by a NULL right-side primary key).
+     */
+    fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.find(): List<Pair<A, B?>> =
+        hydrateLeftPairs(left, right, runSelect(exec, asJoin(), pairSelectFields(left, right)))
 
     /**
      * Runs a raw query on the pinned connection, mapping each row with [handler]. Kormium can't

--- a/kormium-core/src/commonMain/kotlin/SuspendScope.kt
+++ b/kormium-core/src/commonMain/kotlin/SuspendScope.kt
@@ -17,6 +17,8 @@ class SuspendScope<G : Catalog> internal constructor(
     internal val config: KormiumConfig = KormiumConfig(),
     /** Tables written during this scope; see [Scope.dirtyTables]. */
     internal val dirtyTables: MutableSet<String> = mutableSetOf(),
+    /** Whether this scope runs inside a transaction (see [savepoint]). */
+    private val transactional: Boolean = true,
 ) {
     private var savepointCounter = 0
 
@@ -181,8 +183,13 @@ class SuspendScope<G : Catalog> internal constructor(
      * Runs [block] inside a SAVEPOINT on the same connection: if it throws, only its
      * work is rolled back (ROLLBACK TO SAVEPOINT) and the exception propagates; the
      * enclosing transaction may continue if the caller catches it.
+     *
+     * Requires a [suspendTransaction] scope — calling it inside [suspendAutocommit] throws
+     * [IllegalStateException] (a savepoint without a surrounding transaction is a server
+     * error on PostgreSQL and backend-dependent elsewhere).
      */
     suspend fun <R> savepoint(block: suspend SuspendScope<G>.() -> R): R {
+        check(transactional) { "savepoint { } requires a transaction; use suspendTransaction { }, not suspendAutocommit { }" }
         val name = "korm_sp_${savepointCounter++}"
         exec.executeUpdate("SAVEPOINT $name")
         return try {
@@ -202,7 +209,7 @@ class SuspendScope<G : Catalog> internal constructor(
  */
 suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendTransaction(block: suspend SuspendScope<G>.() -> R): R {
     val dirty = mutableSetOf<String>()
-    val result = useConnection(transactional = true) { SuspendScope<G>(it, config, dirty).block() }
+    val result = useConnection(transactional = true) { SuspendScope<G>(it, config, dirty, transactional = true).block() }
     writeListeners.fire(dirty)
     return result
 }
@@ -213,7 +220,7 @@ suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendTransaction(block: suspen
  */
 suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendAutocommit(block: suspend SuspendScope<G>.() -> R): R {
     val dirty = mutableSetOf<String>()
-    val result = useConnection(transactional = false) { SuspendScope<G>(it, config, dirty).block() }
+    val result = useConnection(transactional = false) { SuspendScope<G>(it, config, dirty, transactional = false).block() }
     writeListeners.fire(dirty)
     return result
 }

--- a/kormium-core/src/commonMain/kotlin/SuspendScope.kt
+++ b/kormium-core/src/commonMain/kotlin/SuspendScope.kt
@@ -124,15 +124,23 @@ class SuspendScope<G : Catalog> internal constructor(
         asJoin().select(*fields, map = map)
 
     /** Runs a two-table join, reconstructing both sides as a `Pair` of entities. */
-    suspend fun <A : Entity, B : Entity> JoinPair<G, A, B>.find(): List<Pair<A, B>> {
-        val aCols = left.getFieldDisplayNames()
-        val bCols = right.getFieldDisplayNames()
-        val rows = runSelect(exec, asJoin(), (aCols.values + bCols.values).toList())
-        return rows.map { row ->
-            left.hydrate(aCols.mapValues { (_, c) -> row.getOrNull(c) }.toMutableMap()) to
-                right.hydrate(bCols.mapValues { (_, c) -> row.getOrNull(c) }.toMutableMap())
-        }
-    }
+    suspend fun <A : Entity, B : Entity> JoinPair<G, A, B>.find(): List<Pair<A, B>> =
+        hydrateInnerPairs(left, right, runSelect(exec, asJoin(), pairSelectFields(left, right)))
+
+    /** Runs a two-table LEFT join, selecting the given fields (or all columns if none are given). */
+    suspend fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>): List<ResultRow> =
+        asJoin().select(*fields)
+
+    /** Runs a two-table LEFT join, mapping each [ResultRow] with [map]. */
+    suspend fun <A : Entity, B : Entity, R> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
+        asJoin().select(*fields, map = map)
+
+    /**
+     * Runs a two-table LEFT join, reconstructing both sides as entity pairs. The right side
+     * is `null` for left rows with no match (detected by a NULL right-side primary key).
+     */
+    suspend fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.find(): List<Pair<A, B?>> =
+        hydrateLeftPairs(left, right, runSelect(exec, asJoin(), pairSelectFields(left, right)))
 
     /**
      * Runs a raw query on the pinned connection, mapping each row with [handler]. Pass any

--- a/kormium-core/src/commonMain/kotlin/Table.kt
+++ b/kormium-core/src/commonMain/kotlin/Table.kt
@@ -23,7 +23,8 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
 
     private val fieldDisplayName: MutableMap<String, Column<*, *, *>> = mutableMapOf()
 
-    fun getFieldDisplayNames() = fieldDisplayName
+    /** The table's columns keyed by entity field name (Kotlin property name), in declaration order. */
+    fun getFieldDisplayNames(): Map<String, Column<*, *, *>> = fieldDisplayName
 
     /**
      * The primary-key column(s): those declared with `primaryKey = true`, or the column

--- a/kormium-core/src/commonMain/kotlin/WriteListener.kt
+++ b/kormium-core/src/commonMain/kotlin/WriteListener.kt
@@ -1,6 +1,7 @@
 package io.github.kormium
 
-import kotlin.concurrent.Volatile
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * Notified after a [transaction] / [autocommit] block (or their suspend counterparts)
@@ -28,33 +29,45 @@ fun interface Registration {
  * the shared [Disabled] registry, which ignores everything at zero cost (so observation
  * simply never fires there).
  *
- * Registration is expected at setup time (few listeners, rarely changed); the registry is
- * copy-on-write so [fire] iterates a stable snapshot without locking on the hot path.
+ * The registry is copy-on-write so [fire] iterates a stable snapshot without locking on the
+ * hot path. [add] and [Registration.remove] swap the list with a CAS loop, so concurrent
+ * registration is lossless — `kormium-observe` registers/unregisters a listener per Flow
+ * collection, which can happen from many coroutines at once.
  */
+@OptIn(ExperimentalAtomicApi::class)
 open class WriteListeners {
-    @Volatile
-    private var listeners: List<WriteListener> = emptyList()
+    private val listeners = AtomicReference<List<WriteListener>>(emptyList())
 
     /** Registers [listener]; returns a [Registration] that removes it again. */
     open fun add(listener: WriteListener): Registration {
-        listeners = listeners + listener
+        listeners.swap { it + listener }
         return Registration {
-            listeners = listeners.filterNot { it === listener }
+            listeners.swap { list -> list.filterNot { it === listener } }
         }
     }
 
     /** Delivers [tables] to every registered listener. No-op when [tables] is empty. */
     fun fire(tables: Set<String>) {
         if (tables.isEmpty()) return
-        val snapshot = listeners
+        val snapshot = listeners.load()
         for (l in snapshot) l.onCommit(tables)
     }
 
     /** True if at least one listener is registered (lets callers skip dirty-set bookkeeping). */
-    val isActive: Boolean get() = listeners.isNotEmpty()
+    val isActive: Boolean get() = listeners.load().isNotEmpty()
 
     /** The shared no-op registry for backends that don't support write notification. */
     object Disabled : WriteListeners() {
         override fun add(listener: WriteListener): Registration = Registration {}
+    }
+}
+
+// Lock-free read-modify-write: retry until no concurrent swap intervened. (The stdlib `update`
+// extension is still experimental-in-flux across targets; this is the same three-line loop.)
+@OptIn(ExperimentalAtomicApi::class)
+private inline fun <T> AtomicReference<T>.swap(transform: (T) -> T) {
+    while (true) {
+        val current = load()
+        if (compareAndSet(current, transform(current))) return
     }
 }

--- a/kormium-core/src/commonMain/kotlin/resultset/ResultSet.kt
+++ b/kormium-core/src/commonMain/kotlin/resultset/ResultSet.kt
@@ -5,212 +5,61 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 
+/**
+ * Backend-agnostic view of a query result. A driver wraps its native result set
+ * (JDBC, libpq, sqlite3, r2dbc) in this interface; core reads values through it.
+ *
+ * **Column indexes are 0-based** — the first selected column is 0 (unlike JDBC's
+ * 1-based convention; JDBC-backed wrappers translate internally). Every getter
+ * returns `null` for SQL `NULL`.
+ *
+ * The cursor starts before the first row; call [next] to advance.
+ */
 @Suppress("TooManyFunctions")
 interface ResultSet {
 
+    /** The selected column names, in select-list order. */
     val columns: Array<String>
+
     /**
-     * Moves the cursor forward one row from its current position.
-     * A {@code ResultSet} cursor is initially positioned
-     * before the first row; the first call to the method
-     * {@code next} makes the first row the current row; the
-     * second call makes the second row the current row, and so on.
-     * <p>
-     *
-     * @return {@code true} if the new current row is valid;
-     * {@code false} if there are no more rows
+     * Moves the cursor forward one row. Returns `true` if the new current row is
+     * valid, `false` when there are no more rows.
      */
     fun next(): Boolean
 
-    /**
-     * Retrieves the value of the designated column in the current row
-     * of this `ResultSet` object as
-     * a `String` in the Kotlin programming language.
-     *
-     * @param columnIndex the first column is 1, the second is 2, ...
-     * @return the column value; if the value is SQL `NULL`, the
-     * value returned is `null`
-     * @throws SQLException if the columnIndex is not valid;
-     * if a database access error occurs or this method is
-     * called on a closed result set
-     */
-
+    /** Reads column [columnIndex] (0-based) as a [String], or `null` for SQL `NULL`. */
     fun getString(columnIndex: Int): String?
 
-    /**
-     * Retrieves the value of the designated column in the current row
-     * of this `ResultSet` object as
-     * a `Boolean` in the Kotlin programming language.
-     *
-     * // TODO: currently only checking "t"
-     *
-     * <P>If the designated column has a datatype of CHAR or VARCHAR
-     * and contains a "0" or has a datatype of BIT, TINYINT, SMALLINT, INTEGER or BIGINT
-     * and contains  a 0, a value of `false` is returned.  If the designated column has a datatype
-     * of CHAR or VARCHAR
-     * and contains a "1" or has a datatype of BIT, TINYINT, SMALLINT, INTEGER or BIGINT
-     * and contains  a 1, a value of `true` is returned.
-     *
-     * @param columnIndex the first column is 1, the second is 2, ...
-     * @return the column value; if the value is SQL `NULL`, the
-     * value returned is `false`
-     * @throws SQLException if the columnIndex is not valid;
-     * if a database access error occurs or this method is
-     * called on a closed result set
-    </P> */
-    @Suppress("ForbiddenComment")
+    /** Reads column [columnIndex] (0-based) as a [Boolean], or `null` for SQL `NULL`. */
     fun getBoolean(columnIndex: Int): Boolean?
 
-    /**
-     * Retrieves the value of the designated column in the current row
-     * of this `ResultSet` object as
-     * a `Short` in the Kotlin programming language.
-     *
-     * @param columnIndex the first column is 1, the second is 2, ...
-     * @return the column value; if the value is SQL `NULL`, the
-     * value returned is `0`
-     * @throws SQLException if the columnIndex is not valid;
-     * if a database access error occurs or this method is
-     * called on a closed result set
-     */
-
+    /** Reads column [columnIndex] (0-based) as a [Short], or `null` for SQL `NULL`. */
     fun getShort(columnIndex: Int): Short?
 
-    /**
-     * Retrieves the value of the designated column in the current row
-     * of this `ResultSet` object as
-     * an `Int` in the Kotlin programming language.
-     *
-     * @param columnIndex the first column is 1, the second is 2, ...
-     * @return the column value; if the value is SQL `NULL`, the
-     * value returned is `0`
-     * @throws SQLException if the columnIndex is not valid;
-     * if a database access error occurs or this method is
-     * called on a closed result set
-     */
-
+    /** Reads column [columnIndex] (0-based) as an [Int], or `null` for SQL `NULL`. */
     fun getInt(columnIndex: Int): Int?
 
-    /**
-     * Retrieves the value of the designated column in the current row
-     * of this `ResultSet` object as
-     * a `Long` in the Kotlin programming language.
-     *
-     * @param columnIndex the first column is 1, the second is 2, ...
-     * @return the column value; if the value is SQL `NULL`, the
-     * value returned is `0`
-     * @throws SQLException if the columnIndex is not valid;
-     * if a database access error occurs or this method is
-     * called on a closed result set
-     */
-
+    /** Reads column [columnIndex] (0-based) as a [Long], or `null` for SQL `NULL`. */
     fun getLong(columnIndex: Int): Long?
 
-    /**
-     * Retrieves the value of the designated column in the current row
-     * of this `ResultSet` object as
-     * a `Float` in the Kotlin programming language.
-     *
-     * @param columnIndex the first column is 1, the second is 2, ...
-     * @return the column value; if the value is SQL `NULL`, the
-     * value returned is `0`
-     * @throws SQLException if the columnIndex is not valid;
-     * if a database access error occurs or this method is
-     * called on a closed result set
-     */
-
+    /** Reads column [columnIndex] (0-based) as a [Float], or `null` for SQL `NULL`. */
     fun getFloat(columnIndex: Int): Float?
 
-    /**
-     * Retrieves the value of the designated column in the current row
-     * of this `ResultSet` object as
-     * a `Double` in the Kotlin programming language.
-     *
-     * @param columnIndex the first column is 1, the second is 2, ...
-     * @return the column value; if the value is SQL `NULL`, the
-     * value returned is `0`
-     * @throws SQLException if the columnIndex is not valid;
-     * if a database access error occurs or this method is
-     * called on a closed result set
-     */
-
+    /** Reads column [columnIndex] (0-based) as a [Double], or `null` for SQL `NULL`. */
     fun getDouble(columnIndex: Int): Double?
 
-
-    /**
-     * Retrieves the value of the designated column in the current row
-     * of this `ResultSet` object as
-     * a `Byte` array in the Kotlin programming language.
-     * The bytes represent the raw values returned by the driver.
-     *
-     * @param columnIndex the first column is 1, the second is 2, ...
-     * @return the column value; if the value is SQL `NULL`, the
-     * value returned is `null`
-     * @throws SQLException if the columnIndex is not valid;
-     * if a database access error occurs or this method is
-     * called on a closed result set
-     */
-
+    /** Reads column [columnIndex] (0-based) as the driver's raw bytes, or `null` for SQL `NULL`. */
     fun getBytes(columnIndex: Int): ByteArray?
 
-    /**
-     * Retrieves the value of the designated column in the current row
-     * of this `ResultSet` object as
-     * a `LocalDate` object in the Kotlin programming language.
-     *
-     * @param columnIndex the first column is 1, the second is 2, ...
-     * @return the column value; if the value is SQL `NULL`, the
-     * value returned is `null`
-     * @throws SQLException if the columnIndex is not valid;
-     * if a database access error occurs or this method is
-     * called on a closed result set
-     */
-
+    /** Reads column [columnIndex] (0-based) as a [LocalDate], or `null` for SQL `NULL`. */
     fun getDate(columnIndex: Int): LocalDate?
 
-    /**
-     * Retrieves the value of the designated column in the current row
-     * of this `ResultSet` object as
-     * a `LocalTime` object in the Kotlin programming language.
-     *
-     * @param columnIndex the first column is 1, the second is 2, ...
-     * @return the column value; if the value is SQL `NULL`, the
-     * value returned is `null`
-     * @throws SQLException if the columnIndex is not valid;
-     * if a database access error occurs or this method is
-     * called on a closed result set
-     */
-
+    /** Reads column [columnIndex] (0-based) as a [LocalTime], or `null` for SQL `NULL`. */
     fun getTime(columnIndex: Int): LocalTime?
 
-    /**
-     * Retrieves the value of the designated column in the current row
-     * of this `ResultSet` object as
-     * a `Instant` object in the Kotlin programming language.
-     *
-     * @param columnIndex the first column is 1, the second is 2, ...
-     * @return the column value; if the value is SQL `NULL`, the
-     * value returned is `null`
-     * @throws SQLException if the columnIndex is not valid;
-     * if a database access error occurs or this method is
-     * called on a closed result set
-     */
-
+    /** Reads column [columnIndex] (0-based) as a [LocalDateTime], or `null` for SQL `NULL`. */
     fun getLocalDateTime(columnIndex: Int): LocalDateTime?
 
-    /**
-     * Retrieves the value of the designated column in the current row
-     * of this `ResultSet` object as
-     * a `Instant` object in the Kotlin programming language.
-     *
-     * @param columnIndex the first column is 1, the second is 2, ...
-     * @return the column value; if the value is SQL `NULL`, the
-     * value returned is `null`
-     * @throws SQLException if the columnIndex is not valid;
-     * if a database access error occurs or this method is
-     * called on a closed result set
-     */
-
+    /** Reads column [columnIndex] (0-based) as an [Instant], or `null` for SQL `NULL`. */
     fun getInstant(columnIndex: Int): Instant?
-
 }

--- a/kormium-core/src/commonTest/kotlin/TableTest.kt
+++ b/kormium-core/src/commonTest/kotlin/TableTest.kt
@@ -503,6 +503,40 @@ class TableTest {
     }
 
     @Test
+    fun testMixedAndOrKeepsKotlinEvaluationOrder() {
+        // Regression: Kotlin infix `or`/`and` are same-precedence and left-associative, so
+        // `a or b and c` builds AndOp(OrOp(a, b), c). Without parentheses SQL would parse it
+        // as `a OR (b AND c)` (AND binds tighter) — a silently different result set.
+        val expectedResult = """
+            SELECT "id", "price", "position", "text", "nullableTest" FROM "products"
+            WHERE ("position" = :p0 OR "position" = :p1) AND "text" = :p2
+        """
+        db.transaction {
+            TestTable.find(
+                Query(TestTable.position eq 1 or (TestTable.position eq 2) and (TestTable.text eq "abc"))
+            )
+        }
+        assertEquals(remoteNewLinesAndSpaces(expectedResult), remoteNewLinesAndSpaces(databaseMockObj.internalSql))
+        assertEquals(mapOf("p0" to 1, "p1" to 2, "p2" to "abc"), databaseMockObj.internalParams)
+    }
+
+    @Test
+    fun testSameOperatorChainStaysFlat() {
+        // Associative chains need no parentheses: `a and b and c` renders flat.
+        val expectedResult = """
+            SELECT "id", "price", "position", "text", "nullableTest" FROM "products"
+            WHERE "position" = :p0 AND "text" = :p1 AND "position" = :p2
+        """
+        db.transaction {
+            TestTable.find(
+                Query(TestTable.position eq 1 and (TestTable.text eq "abc") and (TestTable.position eq 3))
+            )
+        }
+        assertEquals(remoteNewLinesAndSpaces(expectedResult), remoteNewLinesAndSpaces(databaseMockObj.internalSql))
+        assertEquals(mapOf("p0" to 1, "p1" to "abc", "p2" to 3), databaseMockObj.internalParams)
+    }
+
+    @Test
     fun testUpdateWithNoNonNullFieldsFails() {
         assertFailsWith<IllegalArgumentException> {
             db.transaction { TestTable.update(Query(TestTable.id eq Uuid.random()), TestEntity()) }

--- a/kormium-core/src/commonTest/kotlin/TableTest.kt
+++ b/kormium-core/src/commonTest/kotlin/TableTest.kt
@@ -537,6 +537,15 @@ class TableTest {
     }
 
     @Test
+    fun testSavepointInAutocommitFailsFast() {
+        // A savepoint without a surrounding transaction is a server error on Postgres and
+        // backend-dependent elsewhere — fail uniformly with a clear message instead.
+        assertFailsWith<IllegalStateException> {
+            db.autocommit { savepoint { } }
+        }
+    }
+
+    @Test
     fun testUpdateWithNoNonNullFieldsFails() {
         assertFailsWith<IllegalArgumentException> {
             db.transaction { TestTable.update(Query(TestTable.id eq Uuid.random()), TestEntity()) }

--- a/kormium-core/src/jvmTest/kotlin/WriteListenersConcurrencyTest.kt
+++ b/kormium-core/src/jvmTest/kotlin/WriteListenersConcurrencyTest.kt
@@ -1,0 +1,61 @@
+import io.github.kormium.WriteListeners
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * Regression for the registry's lock-free copy-on-write: concurrent add/remove must never
+ * lose a registration. The old plain-`@Volatile` version dropped listeners under a
+ * concurrent `add` race — fatal for kormium-observe, which registers/unregisters a
+ * listener per Flow collection.
+ */
+class WriteListenersConcurrencyTest {
+
+    @Test
+    fun concurrentAddsLoseNoListener() {
+        val registry = WriteListeners()
+        val threads = 8
+        val perThread = 250
+        val delivered = AtomicInteger()
+        val start = CyclicBarrier(threads)
+
+        (1..threads).map {
+            thread {
+                start.await()
+                repeat(perThread) { registry.add { delivered.incrementAndGet() } }
+            }
+        }.forEach { it.join() }
+
+        registry.fire(setOf("t"))
+        assertEquals(threads * perThread, delivered.get(), "every concurrently-added listener must fire")
+    }
+
+    @Test
+    fun concurrentRemovesDetachEveryRemovedListener() {
+        val registry = WriteListeners()
+        val threads = 8
+        val perThread = 250
+        val survivors = AtomicInteger()
+        val removedFired = AtomicInteger()
+
+        // Each thread adds one listener that must survive, plus a batch it removes again.
+        val ready = CountDownLatch(threads)
+        (1..threads).map {
+            thread {
+                registry.add { survivors.incrementAndGet() }
+                val registrations = (1..perThread).map { registry.add { removedFired.incrementAndGet() } }
+                ready.countDown()
+                ready.await()
+                registrations.forEach { it.remove() }
+            }
+        }.forEach { it.join() }
+
+        registry.fire(setOf("t"))
+        assertEquals(threads, survivors.get(), "listeners that were not removed must all fire")
+        assertFalse(removedFired.get() > 0, "a removed listener must never fire")
+    }
+}

--- a/kormium-jdbc/build.gradle.kts
+++ b/kormium-jdbc/build.gradle.kts
@@ -25,5 +25,10 @@ kotlin {
                 implementation("com.zaxxer:HikariCP:6.2.1")
             }
         }
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }

--- a/kormium-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/JdbcDatabase.kt
+++ b/kormium-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/JdbcDatabase.kt
@@ -109,7 +109,11 @@ private class JdbcPinnedConnection(
     }
 
     override fun rollback() {
-        conn.rollback()
+        try {
+            conn.rollback()
+        } catch (e: SQLException) {
+            throw translate(e)
+        }
     }
 
     override fun release() {

--- a/kormium-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/NamedParamStatement.kt
+++ b/kormium-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/NamedParamStatement.kt
@@ -19,7 +19,7 @@ class NamedParamStatement(conn: Connection, sql: String) : AutoCloseable {
     init {
         // Parsing (`:name` -> `?` plus the parameter order) depends only on the SQL text,
         // which is identical across repeated calls of the same statement — cache it.
-        val parsed = parseCache.getOrPut(sql) { parse(sql) }
+        val parsed = cachedParse(sql)
         fields = parsed.fields
         preparedStatement = conn.prepareStatement(parsed.sql)
     }
@@ -74,7 +74,32 @@ class NamedParamStatement(conn: Connection, sql: String) : AutoCloseable {
     private class Parsed(val sql: String, val fields: List<String>)
 
     companion object {
-        private val parseCache = java.util.concurrent.ConcurrentHashMap<String, Parsed>()
+        // Reparsing is one cheap pass over the SQL string; the cache only saves it for hot,
+        // repeated statements. Bound it so one-off SQL cannot grow it without limit: an
+        // access-order LRU capped at MAX_CACHE_ENTRIES, and SQL longer than
+        // MAX_CACHEABLE_SQL_LENGTH bypasses the cache entirely — batch INSERTs and large
+        // IN-lists embed a per-call number of placeholders, so each variant is a distinct
+        // key that would only churn the cache.
+        internal const val MAX_CACHE_ENTRIES = 1024
+        internal const val MAX_CACHEABLE_SQL_LENGTH = 4096
+
+        // accessOrder = true mutates the map structurally on reads, so every access —
+        // including lookups — must hold the lock.
+        private val parseCache = object : LinkedHashMap<String, Parsed>(64, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Parsed>): Boolean =
+                size > MAX_CACHE_ENTRIES
+        }
+
+        private fun cachedParse(sql: String): Parsed =
+            if (sql.length > MAX_CACHEABLE_SQL_LENGTH) parse(sql)
+            else synchronized(parseCache) { parseCache.getOrPut(sql) { parse(sql) } }
+
+        internal val parseCacheSize: Int get() = synchronized(parseCache) { parseCache.size }
+
+        // Visible for tests: exercises the cache exactly like the constructor does.
+        internal fun parseCached(sql: String) {
+            cachedParse(sql)
+        }
 
         private fun parse(sql: String): Parsed {
             val out = StringBuilder(sql.length)

--- a/kormium-jdbc/src/jvmTest/kotlin/io/github/kormium/jdbc/ParseCacheTest.kt
+++ b/kormium-jdbc/src/jvmTest/kotlin/io/github/kormium/jdbc/ParseCacheTest.kt
@@ -1,0 +1,35 @@
+package io.github.kormium.jdbc
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The `:name` parse cache must stay bounded: an LRU capped at
+ * [NamedParamStatement.MAX_CACHE_ENTRIES], with SQL longer than
+ * [NamedParamStatement.MAX_CACHEABLE_SQL_LENGTH] (batch INSERTs, large IN-lists — a
+ * distinct string per call) bypassing it entirely.
+ */
+class ParseCacheTest {
+
+    @Test
+    fun cacheNeverExceedsItsCap() {
+        repeat(NamedParamStatement.MAX_CACHE_ENTRIES * 2) { i ->
+            NamedParamStatement.parseCached("SELECT * FROM t WHERE id = :p$i")
+        }
+        assertTrue(
+            NamedParamStatement.parseCacheSize <= NamedParamStatement.MAX_CACHE_ENTRIES,
+            "parse cache grew past its cap: ${NamedParamStatement.parseCacheSize}",
+        )
+    }
+
+    @Test
+    fun oversizedSqlBypassesTheCache() {
+        val before = NamedParamStatement.parseCacheSize
+        val hugeInList = (0 until 2000).joinToString(", ") { ":p$it" }
+        NamedParamStatement.parseCached("INSERT INTO t (c) VALUES ($hugeInList)")
+        assertTrue(
+            NamedParamStatement.parseCacheSize == before,
+            "oversized SQL must not be cached",
+        )
+    }
+}

--- a/kormium-postgres/src/jvmTest/kotlin/EdgeCaseTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/EdgeCaseTest.kt
@@ -74,6 +74,20 @@ class EdgeCaseTest {
     }
 
     @Test
+    fun leftJoinFindMissingRightIsNullPair() {
+        val pid = Uuid.random()
+        ItDatabase.transaction { EdgeTable.insert(EdgeRow().apply { id = pid; num = 1 }) }
+        val pairs: List<Pair<EdgeRow, EdgeChildRow?>> = ItDatabase.autocommit {
+            (EdgeTable leftJoin EdgeChild on (EdgeTable.id eq EdgeChild.parentId))
+                .where(EdgeTable.id eq pid)
+                .find()
+        }
+        assertEquals(1, pairs.size)
+        assertEquals(pid, pairs.single().first.id)
+        assertNull(pairs.single().second, "an unmatched right side must be null")
+    }
+
+    @Test
     fun countOfEmptyIsZeroAndSumIsNull() {
         val c = count()
         val s = EdgeTable.num.sum()

--- a/kormium-sqlite/src/androidMain/kotlin/CreateSqliteDatabase.android.kt
+++ b/kormium-sqlite/src/androidMain/kotlin/CreateSqliteDatabase.android.kt
@@ -85,7 +85,12 @@ private class SqliteAndroidDriver(path: String, private val poolSize: Int, overr
         override fun begin() { rawExec(conn, "BEGIN") }
         override fun commit() { rawExec(conn, "COMMIT") }
         override fun rollback() { rawExec(conn, "ROLLBACK") }
-        override fun release() { pool.trySend(conn) }
+
+        // If the pool is already closed (a release racing close()), close the connection
+        // directly instead of silently leaking it.
+        override fun release() {
+            if (pool.trySend(conn).isFailure) conn.close()
+        }
     }
 
     override fun <R> usePinned(transactional: Boolean, block: (SqlExecutor) -> R): R =

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -12,7 +12,9 @@ import io.github.kormium.createSqliteDatabase
 import io.github.kormium.database.Database
 import io.github.kormium.eq
 import io.github.kormium.gtEq
+import io.github.kormium.inList
 import io.github.kormium.innerJoin
+import io.github.kormium.leftJoin
 import io.github.kormium.query
 import io.github.kormium.sum
 import io.github.kormium.transaction
@@ -339,6 +341,45 @@ class SqliteIntegrationTest {
         assertEquals(listOf("Ada" to "Notes"), titles)
 
         db.transaction { Books.deleteWhere(Query(Books.id eq bookId)); Authors.deleteWhere(Query(Authors.id eq authorId)) }
+    }
+
+    /** LEFT JOIN find(): a matched right side is an entity, an unmatched one is null. */
+    @Test
+    fun testLeftJoinFindUnmatchedRightIsNull() {
+        val withBook = Uuid.random()
+        val withoutBook = Uuid.random()
+        val bookId = Uuid.random()
+        db.transaction {
+            Authors.execSql(authorsDdl)
+            Books.execSql(booksDdl)
+            Authors.insert(Author().apply { id = withBook; name = "Ada" })
+            Authors.insert(Author().apply { id = withoutBook; name = "Grace" })
+            Books.insert(Book().apply { id = bookId; authorId = withBook; title = "Notes" })
+        }
+
+        val pairs: List<Pair<Author, Book?>> = db.autocommit {
+            (Authors leftJoin Books on (Authors.id eq Books.authorId))
+                .where(Authors.id inList listOf(withBook, withoutBook))
+                .find()
+        }
+        assertEquals(2, pairs.size)
+        val byAuthor = pairs.associateBy { it.first.id }
+        assertEquals("Notes", byAuthor.getValue(withBook).second?.title)
+        assertNull(byAuthor.getValue(withoutBook).second, "an unmatched right side must be null")
+
+        // The select(...) forms still work on a LEFT join.
+        val rows = db.autocommit {
+            (Authors leftJoin Books on (Authors.id eq Books.authorId))
+                .where(Authors.id eq withoutBook)
+                .select()
+        }
+        assertEquals(1, rows.size)
+        assertNull(rows.single().getOrNull(Books.title))
+
+        db.transaction {
+            Books.deleteWhere(Query(Books.id eq bookId))
+            Authors.deleteWhere(Query(Authors.id inList listOf(withBook, withoutBook)))
+        }
     }
 }
 

--- a/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
+++ b/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
@@ -91,7 +91,11 @@ private class SqliteNativeDriver(path: String, private val poolSize: Int, overri
         override fun begin() { rawExec(conn, "BEGIN") }
         override fun commit() { rawExec(conn, "COMMIT") }
         override fun rollback() { rawExec(conn, "ROLLBACK") }
-        override fun release() { pool.trySend(conn) }
+        // If the pool is already closed (a release racing close()), close the connection
+        // directly instead of silently leaking it.
+        override fun release() {
+            if (pool.trySend(conn).isFailure) sqlite3_close_v2(conn)
+        }
     }
 
     override fun <R> usePinned(transactional: Boolean, block: (SqlExecutor) -> R): R =


### PR DESCRIPTION
Fixes everything found in the full-project code review.

## Correctness
- **Mixed `and` / `or` predicates render with correct precedence.** `a or b and c` builds `(a OR b) AND c` in Kotlin (same-precedence, left-associative infix) but rendered bare as `a OR b AND c`, which SQL parses as `a OR (b AND c)` — a silently different result set. Nested compound operands with a different operator are now parenthesized; same-operator chains stay flat.
- **`WriteListeners` registration is lossless under concurrency.** `add`/`remove` swapped the copy-on-write list with a plain volatile write, so concurrent registrations could drop one — fatal for `kormium-observe`, which registers a listener per Flow collection. Now a CAS loop on `kotlin.concurrent.atomics.AtomicReference`.
- **`leftJoin` entity pairs are nullable on the right side** (breaking). `Table.leftJoin` returns a dedicated `LeftJoinPair` whose `find()` is `List<Pair<A, B?>>` — `null` for unmatched left rows (detected by a NULL right-side primary key). Previously `find()` claimed `Pair<A, B>` and the unmatched right entity threw on first property access.
- **`savepoint { }` outside a transaction fails fast** (breaking): clear `IllegalStateException` on every backend instead of a cryptic PG server error / silent implicit transaction on SQLite.

## Resource safety
- **Bounded JDBC `:name` parse cache**: access-order LRU capped at 1024 entries; SQL over 4096 chars (batch INSERTs, large IN-lists — a distinct string per call) bypasses it.
- SQLite (Native/Android): a connection released after `close()` is closed, not leaked.
- JDBC `rollback()` translates `SQLException` like `commit()` already did.

## API hygiene
- Table metadata is read-only (breaking): `Column.name`/`Column.nullable` are `val`, `getFieldDisplayNames()` returns a read-only `Map`.
- `ResultSet`/`ColumnType` KDoc now states the real **0-based** column indexing (was JDBC copy-paste claiming 1-based — misleading for custom `ColumnType` authors).

## Tests
New: WriteListeners concurrency (8 threads × 250 add/remove), parse-cache cap/bypass, left-join null pairs (SQLite common test — runs JVM **and** native — plus a Postgres edge test), savepoint-in-autocommit guard, mixed AND/OR rendering. All suites green on JVM and macosArm64; Postgres integration green against real PG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)