### PR TITLE
chore: release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Kormium are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] — Review fixes and typed PostgreSQL binding
 
 ### Performance
 - **PostgreSQL JVM reads are ~1.7-2x faster: parameters now bind as properly-typed JDBC

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-version = 0.4.0
+version = 0.5.0
 group = io.github.kormium
 
 # The `samples` modules still use a custom-named native target (e.g. macosX64("native"))


### PR DESCRIPTION
Version bump 0.4.0 → 0.5.0 and the CHANGELOG cut for the release: correctness fixes from the full code review (AND/OR precedence, lossless WriteListeners, nullable leftJoin pairs, bounded parse cache, savepoint guard, read-only table metadata) plus typed JVM PostgreSQL parameter binding (~2x faster reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)