### PR TITLE
perf: native driver fast paths (parse cache, BigDecimal, release bench binary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to Kormium are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Performance
+- **PostgreSQL Native: repeated statements skip re-parsing.** The libpq driver now keeps a
+  per-connection LRU cache (128 entries) of the `:name` → `$n` parse/substitution result,
+  mirroring the JVM driver's parse cache. Each parameter is also converted to its text
+  form once instead of twice, and the redundant per-call length/format/type arrays are no
+  longer allocated (libpq ignores lengths for text-format parameters; null types means
+  "infer", exactly as the previous all-zero array did). Statements with positional `?`
+  parameters or Iterable/Array values keep the previous per-call path. Batch inserts gain
+  ~14% on the comparison workload.
+- **`BigDecimal` columns read and bind without bignum string arithmetic.** Plain decimal
+  text of up to 18 digits — everything PostgreSQL emits for typical `numeric` columns —
+  is parsed via a single `Long` accumulation instead of `BigDecimal.parseString`'s
+  per-digit big-integer multiplication (the hottest frames in row-materialization
+  profiles), producing a bit-identical ionspin representation. Binding renders from the
+  (significand, exponent) pair directly. Note: the bound text is now canonical — e.g.
+  `BigDecimal.fromInt(100)` binds as `100` instead of ionspin's `1.0E+2`; the database
+  value is unchanged.
+- **Benchmarks run an optimized Kotlin/Native binary.** `kormium-postgres` now links a
+  release-mode test binary (`linkBenchReleaseTest<Target>`) for the native benchmark
+  harness; the default debug test binary understated CPU-bound throughput (row
+  materialization, batch binding) by 2-3x against the JIT-optimized JVM ORMs. Linked only
+  on demand, so regular test and CI builds are unaffected.
+
 ## [0.5.0] — Review fixes and typed PostgreSQL binding
 
 ### Performance

--- a/kormium-core/src/commonMain/kotlin/TypeMapper.kt
+++ b/kormium-core/src/commonMain/kotlin/TypeMapper.kt
@@ -1,5 +1,8 @@
 package io.github.kormium
 
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import io.github.kormium.sql.bigDecimalToParamString
+
 /** Backend-specific conversion of a bound value to the driver's wire form. */
 interface TypeMapper {
     /** Converts [value] to the form bound as a parameter (e.g. UUID/BigDecimal → text). */
@@ -14,6 +17,9 @@ interface TypeMapper {
 object StandardTypeMapper : TypeMapper {
     override fun toParameter(value: Any?): Any? = when (value) {
         null, is Boolean, is Int, is Long, is Double, is String -> value
+        // BigDecimal.toString() runs bignum division per digit — hot on every numeric bind,
+        // so render from the (significand, exponent) pair instead.
+        is BigDecimal -> bigDecimalToParamString(value)
         else -> value.toString()
     }
 }

--- a/kormium-core/src/commonMain/kotlin/sql/DecimalFastPath.kt
+++ b/kormium-core/src/commonMain/kotlin/sql/DecimalFastPath.kt
@@ -1,0 +1,82 @@
+package io.github.kormium.sql
+
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+
+// 18 digits always fit in a Long (Long.MAX_VALUE has 19 digits).
+private const val MAX_FAST_DIGITS = 18
+
+/**
+ * Parses plain decimal text — the only form Postgres emits for `numeric` — straight into
+ * ionspin's (significand, exponent) representation. BigDecimal.parseString runs per-digit
+ * bignum arithmetic and dominates row-materialization profiles; this path is a single Long
+ * accumulation. Anything that isn't a plain decimal with at most [MAX_FAST_DIGITS] digits
+ * (scientific notation, NaN, huge values) falls back to parseString.
+ */
+internal fun parseBigDecimalFast(text: String): BigDecimal {
+    val negative = text.startsWith('-')
+    val start = if (negative) 1 else 0
+    var unscaled = 0L
+    var scale = 0
+    var digitChars = 0
+    var seenDot = false
+    var fracNonZero = false
+    for (i in start until text.length) {
+        val c = text[i]
+        when {
+            c in '0'..'9' -> {
+                if (digitChars == MAX_FAST_DIGITS) return BigDecimal.parseString(text)
+                unscaled = unscaled * 10 + (c - '0')
+                digitChars++
+                if (seenDot) {
+                    scale++
+                    if (c != '0') fracNonZero = true
+                }
+            }
+            // A '.' needs digits on both sides ("1.", ".5" take the reference path).
+            c == '.' && !seenDot && digitChars > 0 -> seenDot = true
+            else -> return BigDecimal.parseString(text)
+        }
+    }
+    if (digitChars == 0 || (seenDot && scale == 0)) return BigDecimal.parseString(text)
+    if (unscaled == 0L) return BigDecimal.ZERO
+    // Mirror parseString's representation quirk: fractional trailing zeros are dropped
+    // ("10.50" -> significand 105) unless the whole fraction is zeros, which is kept
+    // verbatim ("1.0" -> 10). The exponent is unaffected either way (each dropped zero
+    // lowers the digit count and the scale together).
+    if (fracNonZero) {
+        while (unscaled % 10L == 0L && scale > 0) {
+            unscaled /= 10L
+            scale--
+        }
+    }
+    if (negative) unscaled = -unscaled
+    // value = unscaled * 10^-scale; ionspin stores the scientific exponent (d.ddd * 10^e).
+    val exponent = (digitsOf(unscaled) - 1 - scale).toLong()
+    return BigDecimal.fromLongWithExponent(unscaled, exponent)
+}
+
+/**
+ * Renders a BigDecimal as a parameter string without ionspin's toString (repeated bignum
+ * division by ten). Produces `<significand>E<exponent>` in standard scientific notation —
+ * accepted by every backend that takes decimal text — or a plain integer string when the
+ * exponent works out to zero. Significands beyond Long fall back to toString().
+ */
+internal fun bigDecimalToParamString(value: BigDecimal): String {
+    if (value.isZero()) return "0"
+    val significand = value.significand
+    if (significand.bitLength() > 62) return value.toString()
+    val sigLong = significand.longValue(exactRequired = false)
+    // ionspin's exponent is scientific (d.ddd * 10^e); standard E-notation is mantissa * 10^e.
+    val standardExponent = value.exponent - (digitsOf(sigLong) - 1)
+    return if (standardExponent == 0L) sigLong.toString() else "${sigLong}E$standardExponent"
+}
+
+private fun digitsOf(value: Long): Int {
+    var v = if (value < 0) -value else value
+    var digits = 1
+    while (v >= 10) {
+        v /= 10
+        digits++
+    }
+    return digits
+}

--- a/kormium-core/src/commonMain/kotlin/sql/Extensions.kt
+++ b/kormium-core/src/commonMain/kotlin/sql/Extensions.kt
@@ -11,7 +11,7 @@ fun ResultSet.getUUID(columnIndex: Int): Uuid? {
 }
 
 fun ResultSet.getBigDecimal(columnIndex: Int): BigDecimal? {
-    return getString(columnIndex)?.let { BigDecimal.parseString(it) }
+    return getString(columnIndex)?.let { parseBigDecimalFast(it) }
 }
 
 // Note: ResultSet already provides getInstant() as a member (with the required

--- a/kormium-core/src/commonTest/kotlin/DecimalFastPathTest.kt
+++ b/kormium-core/src/commonTest/kotlin/DecimalFastPathTest.kt
@@ -1,0 +1,72 @@
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import io.github.kormium.sql.bigDecimalToParamString
+import io.github.kormium.sql.parseBigDecimalFast
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DecimalFastPathTest {
+
+    private val plainDecimals = listOf(
+        "0", "0.0", "0.00",
+        "1", "-1", "5", "-5",
+        "10", "100", "1000000",
+        "0.5", "0.50", "-0.5", "0.0050", "-0.0050",
+        "123.45", "-123.45", "1.0", "-1.0",
+        "999999999999999999",            // 18 digits — the fast-path limit
+        "99999999999999999.9",
+        "0.000000000000000001",
+        "42", "1234.5678", "-1234.5678",
+        "007", "00.50", "0.000", "10.50", "1.50",
+    )
+
+    private val fallbackOnly = listOf(
+        "1000000000000000000",           // 19 digits — beyond the fast path
+        "-1000000000000000000",
+        "123456789012345678901234567890.5",
+        "1E5", "1.5e-3", "-2.5E+10",     // scientific input never comes from PG but must still parse
+    )
+
+    /** The fast path must be indistinguishable from parseString: same value, same representation. */
+    @Test
+    fun fastParseMatchesParseStringExactly() {
+        for (s in plainDecimals + fallbackOnly) {
+            val reference = BigDecimal.parseString(s)
+            val fast = parseBigDecimalFast(s)
+            assertEquals(0, reference.compareTo(fast), "value mismatch for '$s': $reference vs $fast")
+            assertEquals(reference.significand, fast.significand, "significand mismatch for '$s'")
+            assertEquals(reference.exponent, fast.exponent, "exponent mismatch for '$s'")
+            assertEquals(reference.toString(), fast.toString(), "toString mismatch for '$s'")
+        }
+    }
+
+    /** Serialized form must parse back (via ionspin's own parser) to the same value. */
+    @Test
+    fun paramStringRoundTrips() {
+        for (s in plainDecimals + fallbackOnly) {
+            val value = BigDecimal.parseString(s)
+            val rendered = bigDecimalToParamString(value)
+            assertEquals(
+                0,
+                value.compareTo(BigDecimal.parseString(rendered)),
+                "round-trip mismatch for '$s': rendered as '$rendered'",
+            )
+        }
+    }
+
+    /** Whole numbers in Long range render as plain integers (no E suffix to surprise logs/tests). */
+    @Test
+    fun wholeNumbersRenderPlain() {
+        assertEquals("42", bigDecimalToParamString(BigDecimal.fromInt(42)))
+        assertEquals("-42", bigDecimalToParamString(BigDecimal.fromInt(-42)))
+        assertEquals("0", bigDecimalToParamString(BigDecimal.ZERO))
+    }
+
+    /** Values whose significand exceeds Long must take the toString fallback unchanged. */
+    @Test
+    fun hugeSignificandFallsBackToToString() {
+        val huge = BigDecimal.parseString("123456789012345678901234567890.5")
+        assertEquals(huge.toString(), bigDecimalToParamString(huge))
+        assertTrue(huge.significand.bitLength() > 62)
+    }
+}

--- a/kormium-core/src/commonTest/kotlin/TableTest.kt
+++ b/kormium-core/src/commonTest/kotlin/TableTest.kt
@@ -151,7 +151,7 @@ class TableTest {
         assertTrue(blockSql.contains("""ORDERBY"position"DESC"""), blockSql)
         assertTrue(blockSql.contains("LIMIT50"), blockSql)
         assertTrue(blockSql.contains("OFFSET10"), blockSql)
-        assertEquals(mapOf("p0" to price.toString(), "p1" to 1), blockParams)
+        assertEquals(mapOf("p0" to "100", "p1" to 1), blockParams)
     }
 
     @Test
@@ -367,7 +367,7 @@ class TableTest {
         assertEquals(
             mapOf(
                 "p0" to uuid.toString(),
-                "p1" to price.toString(),
+                "p1" to "100",
                 "p2" to position,
                 "p3" to text,
                 "p4" to null,
@@ -421,7 +421,7 @@ class TableTest {
         assertEquals(
             mapOf(
                 "p0" to uuid.toString(),
-                "p1" to price.toString(),
+                "p1" to "100",
                 "p2" to position,
                 "p3" to text,
                 "p4" to null,
@@ -469,7 +469,7 @@ class TableTest {
             )
         }
         assertEquals(remoteNewLinesAndSpaces(expectedResult), remoteNewLinesAndSpaces(databaseMockObj.internalSql))
-        assertEquals(mapOf("p0" to price.toString()), databaseMockObj.internalParams)
+        assertEquals(mapOf("p0" to "100"), databaseMockObj.internalParams)
     }
 
     @Test
@@ -669,7 +669,7 @@ class TableTest {
         assertTrue(sql.contains("""SELECT"products"."position",COUNT(*),SUM("products"."price")"""), sql)
         assertTrue(sql.contains("""GROUPBY"products"."position""""), sql)
         assertTrue(sql.contains("""HAVINGSUM("products"."price")>:p0"""), sql)
-        assertEquals(mapOf("p0" to BigDecimal.fromInt(100).toString()), databaseMockObj.internalParams)
+        assertEquals(mapOf("p0" to "100"), databaseMockObj.internalParams)
     }
 
     @Test

--- a/kormium-postgres/build.gradle.kts
+++ b/kormium-postgres/build.gradle.kts
@@ -27,6 +27,10 @@ kotlin {
                 defFile(project.file("src/nativeInterop/cinterop/libpq.def"))
             }
         }
+        // Optimized test binary (linkBenchReleaseTest<Target>) for benchmarks/run.sh: the default
+        // debug test kexe is unoptimized K/N code and misrepresents CPU-bound throughput by
+        // 2-3x. Linked only when explicitly requested, so regular test/CI builds don't pay for it.
+        target.binaries.test("bench", listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.RELEASE))
     }
     // mingwX64() // deferred — see the publishing plan
 

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/moreirasantos/pgkn/PostgresDriver.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/moreirasantos/pgkn/PostgresDriver.kt
@@ -1,6 +1,7 @@
 package io.github.moreirasantos.pgkn
 
 import io.github.moreirasantos.pgkn.exception.ConnectionClosedException
+import io.github.moreirasantos.pgkn.exception.InvalidDataAccessApiUsageException
 import io.github.moreirasantos.pgkn.exception.QueryExecutionException
 import io.github.moreirasantos.pgkn.paramsource.MapSqlParameterSource
 import io.github.moreirasantos.pgkn.sql.buildValueArray
@@ -30,8 +31,6 @@ import io.github.kormium.resultset.ResultSet
 import io.github.kormium.runConnection
 import io.github.kormium.runPinned
 import io.github.kormium.sqlException
-
-private val logger = KLogger("io.github.moreirasantos.pgkn.PostgresDriverKt")
 
 @OptIn(ExperimentalForeignApi::class)
 fun FPostgresDriver(
@@ -80,6 +79,12 @@ private class PostgresDriverImpl(
     private val connections: List<CPointer<PGconn>> = List(poolSize) {
         openConnection(host, port, database, user, password)
     }
+
+    // Parsed-statement cache, one per connection: the pool hands a connection to exactly
+    // one caller at a time, so its cache is only ever touched by the holder — no locking.
+    // (The Channel's send/receive provides the happens-before edge between holders.)
+    private val statementCaches: Map<CPointer<PGconn>, StatementCache> =
+        connections.associateWith { StatementCache() }
 
     private val pool = Channel<CPointer<PGconn>>(poolSize).also { channel ->
         connections.forEach { channel.trySend(it) }
@@ -203,30 +208,81 @@ private class PostgresDriverImpl(
         sql: String,
         paramSource: SqlParameterSource,
     ): CPointer<PGresult> {
+        val prepared = prepareStatement(statementCaches.getValue(connection), sql, paramSource)
+            ?: return doExecuteUncached(connection, sql, paramSource)
+        val values = Array(prepared.parameterNames.size) { i ->
+            val name = prepared.parameterNames[i]
+            try {
+                paramSource.getValue(name)?.toString()
+            } catch (ex: IllegalArgumentException) {
+                throw InvalidDataAccessApiUsageException("No value supplied for the SQL parameter '$name'", ex)
+            }
+        }
+        return execParams(connection, prepared.sql, values)
+    }
+
+    // Parse + substitution is identical across repeated calls of the same statement — cache it
+    // per connection. Returns null when the statement must take the per-call path instead:
+    // '?'-style positional parameters (not bound by name), or Iterable/Array values, whose
+    // placeholder expansion depends on the value's size.
+    private fun prepareStatement(
+        cache: StatementCache,
+        sql: String,
+        paramSource: SqlParameterSource,
+    ): PreparedSql? {
+        cache.get(sql)?.let { hit ->
+            return if (hit.parameterNames.any { isExpandable(paramSource, it) }) null else hit
+        }
+        val parsedSql = parseSql(sql)
+        if (parsedSql.unnamedParameterCount > 0) return null
+        if (parsedSql.parameterNames.any { isExpandable(paramSource, it) }) return null
+        val prepared = PreparedSql(substituteNamedParameters(parsedSql, null), parsedSql.parameterNames.toList())
+        cache.put(sql, prepared)
+        return prepared
+    }
+
+    private fun isExpandable(paramSource: SqlParameterSource, name: String): Boolean {
+        if (!paramSource.hasValue(name)) return false
+        val value = paramSource.getValue(name)
+        return value is Iterable<*> || value is Array<*>
+    }
+
+    // The pre-cache execution path, kept for statements prepareStatement can't handle:
+    // expansion and substitution are recomputed against the actual values on every call.
+    private fun doExecuteUncached(
+        connection: CPointer<PGconn>,
+        sql: String,
+        paramSource: SqlParameterSource,
+    ): CPointer<PGresult> {
         val parsedSql = parseSql(sql)
         val sqlToUse: String = substituteNamedParameters(parsedSql, paramSource)
         val params: Array<Any?> = buildValueArray(parsedSql, paramSource)
-
-        return memScoped {
-            PQexecParams(
-                connection,
-                command = sqlToUse,
-                nParams = params.size,
-                paramValues = createValues(params.size) {
-                    logger.trace { "param[$it]: ${params[it]}" }
-                    value = params[it]?.toString()?.cstr?.getPointer(this@memScoped)
-                },
-                paramLengths = params.map { it?.toString()?.length ?: 0 }.toIntArray().refTo(0),
-                paramFormats = IntArray(params.size) { TEXT_RESULT_FORMAT }.refTo(0),
-                // Bind every parameter as unspecified type (oid 0) so the server infers
-                // each type from its column context. Values are sent as text, so declaring
-                // text(25) for a numeric/timestamp column fails; 0u lets Postgres cast.
-                // Mirrors the JVM driver's stringtype=unspecified.
-                paramTypes = UIntArray(params.size) { 0u }.refTo(0),
-                resultFormat = TEXT_RESULT_FORMAT
-            )
-        }.check(connection)
+        return execParams(connection, sqlToUse, Array(params.size) { params[it]?.toString() })
     }
+
+    private fun execParams(
+        connection: CPointer<PGconn>,
+        sql: String,
+        values: Array<String?>,
+    ): CPointer<PGresult> = memScoped {
+        PQexecParams(
+            connection,
+            command = sql,
+            nParams = values.size,
+            paramValues = createValues(values.size) {
+                value = values[it]?.cstr?.getPointer(this@memScoped)
+            },
+            // Text-format parameters are null-terminated, so lengths are ignored; null
+            // formats means "all text". Null types binds every parameter as unspecified
+            // (oid 0) so the server infers each type from its column context — declaring
+            // text(25) for a numeric/timestamp column would fail, oid 0 lets Postgres
+            // cast. Mirrors the JVM driver's stringtype=unspecified.
+            paramLengths = null,
+            paramFormats = null,
+            paramTypes = null,
+            resultFormat = TEXT_RESULT_FORMAT
+        )
+    }.check(connection)
 
     private fun doExecute(connection: CPointer<PGconn>, sql: String) = memScoped {
         PQexecParams(
@@ -283,6 +339,31 @@ private fun openConnection(
         throw QueryExecutionException(message.ifEmpty { "Failed to connect to Postgres" })
     }
     return connection
+}
+
+// A statement ready for PQexecParams: the `$n`-substituted SQL and the named-parameter
+// occurrence order used to build the positional value array.
+private class PreparedSql(val sql: String, val parameterNames: List<String>)
+
+/**
+ * A small LRU of [PreparedSql] keyed by the original SQL text. LinkedHashMap keeps
+ * insertion order, so a hit re-inserts the entry to move it to the tail and eviction
+ * drops the head — the least recently used statement. Bounded so one-off SQL (large
+ * IN-lists, ad-hoc queries) cannot grow it without limit.
+ */
+private class StatementCache(private val maxEntries: Int = 128) {
+    private val map = LinkedHashMap<String, PreparedSql>()
+
+    fun get(sql: String): PreparedSql? {
+        val hit = map.remove(sql) ?: return null
+        map[sql] = hit
+        return hit
+    }
+
+    fun put(sql: String, prepared: PreparedSql) {
+        if (map.size >= maxEntries) map.remove(map.keys.first())
+        map[sql] = prepared
+    }
 }
 
 private const val TEXT_RESULT_FORMAT = 0

--- a/kormium-postgres/src/nativeTest/kotlin/NativeTableIntegrationTest.kt
+++ b/kormium-postgres/src/nativeTest/kotlin/NativeTableIntegrationTest.kt
@@ -185,6 +185,27 @@ class NativeTableIntegrationTest {
         }
     }
 
+    /**
+     * Repeated executions of one statement hit the per-connection parse cache; each call
+     * must still bind its own values. poolSize=1 pins every call to the same connection,
+     * so from the second iteration on the statement comes from the cache.
+     */
+    @Test
+    fun testRepeatedStatementsBindFreshValues() {
+        if (env("KORMIUM_DB_HOST") == null) {
+            println("KORMIUM_DB_HOST not set — skipping native integration test")
+            return
+        }
+        nativeDriver(poolSize = 1).use { driver ->
+            repeat(10) { i ->
+                val got = driver.autocommit {
+                    execute("SELECT :a::int + :b::int", mapOf("a" to i, "b" to 100)) { rs -> rs.getInt(0) }
+                }.single()
+                assertEquals(i + 100, got)
+            }
+        }
+    }
+
     /** Many worker threads hammering a small pool must not corrupt or crash anything. */
     @Test
     fun testConcurrentQueriesArePoolSafe() {


### PR DESCRIPTION
## Why

The native (libpq) column lagged JDBC badly on `selectMany` (5.1k vs 18.5k ops/s) and `batchInsert` (2.0k vs 5.3k). Profiling (`sample` on the running kexe) showed libpq/network at ~0.5% of samples — the gap was entirely client CPU:

1. **The benchmark ran the debug test binary** — unoptimized K/N code vs JIT-optimized JVM ORMs. Same-machine A/B: selectMany 3,256 → 9,760 ops/s (×3.0), batchInsert 1,502 → 3,354 (×2.2) just from release mode.
2. **ionspin bignum string machinery**: `BigDecimal.parseString` per row on reads, `BigDecimal.toString` per parameter on binds.
3. **The driver re-parsed SQL on every execute** (`parseSql` + `substituteNamedParameters`, no cache unlike the JVM driver), plus a second wasted `toString` per parameter feeding `paramLengths`, which libpq ignores for text-format parameters.

## What

- **`perf(core)`**: `DecimalFastPath.kt` — plain decimal text ≤18 digits parses via a single `Long` accumulation, bit-identical to `parseString`'s representation (including its trailing-zero quirk: `"0.50"` → significand 5 but `"1.0"` → 10, mirrored from the ionspin source and locked in by `DecimalFastPathTest` against the reference). `StandardTypeMapper` renders binds from (significand, exponent); bound text becomes canonical (`100`, not `1.0E+2`) — `TableTest` goldens updated, stored values unchanged.
- **`perf(postgres-native)`**: per-connection LRU (128 entries) of the `:name` → `$n` parse/substitution result; no locking needed since the pool pins a connection to one caller (the Channel provides the happens-before edge). One text conversion per parameter; null `paramLengths`/`paramFormats`/`paramTypes` (null types = "server infers", same as the previous all-zero array). Positional `?` and Iterable/Array values keep the old per-call path. New integration test pins poolSize=1 and asserts repeated statements bind fresh values through the cache.
- **`build(postgres)`**: release-mode test binary `linkBenchReleaseTest<Target>` for the benchmark harness; linked only on demand, so CI/test builds are unaffected. (The `run.sh` hookup lands with the benchmark-matrix branch, which it depends on.)

## Numbers (same machine/session, tuned PG 16 container)

| op | debug (old harness) | release | release + this PR |
|---|---:|---:|---:|
| selectMany | 3,256 | 9,760 | 10,010 |
| batchInsert | 1,502 | 3,354 | **3,818** |
| findById | 13,395 | 14,414 | 15,366 |

selectMany's win comes almost entirely from the release binary (now transport-bound); batchInsert gains a further ~14% from the cache + binding work. Official `summary.md` numbers should be re-measured with a full `run.sh` on a quiet machine.

## Testing

- `:kormium-core` jvm+native (incl. new `DecimalFastPathTest`, ~30-case reference corpus), `:kormium-sqlite` jvm+native, `:kormium-postgres` jvmTest (Testcontainers), `:kormium-migrate`, `:kormium-r2dbc` — all green.
- Native postgres integration suite against real PG 16: 12/12, including the new parse-cache test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)