### PR TITLE
feat: full cross-ORM benchmark matrix with native column

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,117 @@
+# Benchmarks
+
+The full comparison matrix: **Kormium JVM**, **Kormium Native** (libpq, no JVM),
+**Exposed** and **Hibernate**, all against the same PostgreSQL workload.
+
+## TL;DR
+
+```bash
+# from the repo root; the only prerequisite is a running Docker daemon
+./benchmarks/run.sh
+```
+
+The script starts one tuned PostgreSQL container, runs the Kotlin/Native harness, then the
+JVM JMH benchmarks, and prints a merged summary (~20 minutes):
+
+```
+Benchmark summary — ops/s, higher is better
+═══════════════════════════════════════════
+Operation    Kormium  Kormium Native  Exposed  Hibernate
+--------------------------------------------------------
+findById      16,253          22,988    7,688     15,535
+selectWhere   16,022          24,096    7,637     15,873
+...
+```
+
+Useful flags:
+
+| Flag | Effect |
+| --- | --- |
+| `--quick` | fast indicative run, ~3 minutes — for checking the setup, not for quoting |
+| `--skip-native` | JVM ORMs only (works on hosts without a native toolchain) |
+| `--skip-jvm` | native harness only, then re-render the merged summary |
+
+Results are written to:
+
+- `benchmarks/build/results/jmh/summary.md` — the merged table as Markdown;
+- `benchmarks/build/results/jmh/results.json` — full JMH output with per-iteration data;
+- `benchmarks/build/results/jmh/native.json` — the native harness numbers.
+
+To re-print the table from the last run without re-running anything:
+
+```bash
+./gradlew :benchmarks:benchmarkSummary
+```
+
+## JVM-only runs via Gradle
+
+`./gradlew :benchmarks:jmh` runs the JVM matrix on its own throwaway Testcontainers
+PostgreSQL. `-Pbench.quick` applies the quick profile, and `-Pbench.filter` is a regex
+over benchmark names:
+
+```bash
+./gradlew :benchmarks:jmh "-Pbench.filter=FindById"          # one operation, all ORMs
+./gradlew :benchmarks:jmh "-Pbench.filter=kormium(Insert|Update)"
+```
+
+## What is measured
+
+Six operations per ORM, all against the same table (uuid primary key, `text` + `numeric`
+columns, index on `name`), 8 benchmark threads, connection pool of 8 for every ORM:
+
+| Operation | Shape |
+| --- | --- |
+| `findById` | `SELECT` by primary key, autocommit |
+| `selectWhere` | `SELECT ... WHERE name = ?`, index lookup returning 1 row |
+| `selectMany` | same, returning 100 rows — measures row materialization |
+| `insert` | single-row `INSERT` in a transaction |
+| `batchInsert` | 50 rows per transaction, each ORM's idiomatic batch API* |
+| `updateById` | single-row `UPDATE` by primary key (random row out of 1024) |
+
+\* kormium `insertAll` (multi-row `VALUES`), Exposed `batchInsert`, Hibernate `persist`
+loop with `hibernate.jdbc.batch_size=50`. The score unit is transactions/s, so one
+`batchInsert` op writes 50 rows.
+
+Competitor versions: Exposed 1.0.0-beta-4 and Hibernate ORM 7.0.2.Final, both via
+HikariCP (see `build.gradle.kts`).
+
+The native harness (`NativeBenchmark.kt` in `kormium-postgres/src/nativeTest`) runs the
+same six operations with the same seeding on 8 workers, compiled as an optimized release
+binary (`linkBenchReleaseTest`) — the default debug test binary understates CPU-bound
+operations (row materialization, batch binding) by 2-3x. It has no JMH, so its numbers
+come from a single timed run without an error estimate — treat them as coarser.
+
+## Methodology and stability
+
+- JMH 1.37; per benchmark: 2 forks, 5×2s warmup + 5×2s measurement, fixed 2 GiB heap.
+- PostgreSQL (`postgres:16-alpine`) keeps its data directory on tmpfs and runs with
+  `fsync`, `synchronous_commit` and `full_page_writes` off. The benchmarks measure
+  ORM/driver overhead, not disk latency — disk is by far the noisiest component,
+  especially under Docker on macOS. All ORMs get the same database.
+- The table is truncated and reseeded between iterations (seed row, 100 bulk rows,
+  1024 update targets), so write benchmarks do not grow it and drag later iterations.
+
+## Using an external PostgreSQL
+
+For Gradle runs, pass coordinates as properties (environment variables do not reliably
+reach forked JMH JVMs through the Gradle daemon):
+
+```bash
+./gradlew :benchmarks:jmh -Pbench.db.host=db.example.com -Pbench.db.port=5432 \
+    -Pbench.db.name=postgres -Pbench.db.user=postgres -Pbench.db.password=secret
+```
+
+The `KORMIUM_DB_HOST/PORT/NAME/USER/PASSWORD` environment variables are also honored
+(by both the JVM and native harnesses) when set in the process that actually runs them —
+`run.sh` uses this to point everything at its own container.
+
+Note: the durability tweaks above only apply to the container started by `run.sh` /
+Testcontainers. An external server is used as-is, so its numbers are not comparable
+with container runs.
+
+## Honesty notes
+
+These are the project's own benchmarks. Treat every number as relative: compare columns
+within one run on one machine, not against tables published elsewhere. The native column
+comes from a simpler harness than JMH. Run everything on your own hardware and database
+before making architecture decisions.

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -1,6 +1,10 @@
+import groovy.json.JsonSlurper
+import java.time.LocalDate
+import java.util.Locale
+
 plugins {
     kotlin("jvm")
-    id("me.champeau.jmh") version "0.7.2"
+    id("me.champeau.jmh") version "0.7.3"
 }
 
 repositories {
@@ -13,22 +17,146 @@ kotlin {
 
 dependencies {
     jmhImplementation(project(":kormium-postgres"))
-    jmhImplementation("org.testcontainers:postgresql:1.20.4")
-    jmhImplementation("org.postgresql:postgresql:42.7.4")
+    jmhImplementation("org.testcontainers:postgresql:1.21.3")
+    jmhImplementation("org.postgresql:postgresql:42.7.7")
     jmhImplementation("com.ionspin.kotlin:bignum:0.3.10")
-    jmhImplementation("com.zaxxer:HikariCP:6.2.1")
+    jmhImplementation("com.zaxxer:HikariCP:6.3.0")
 
     // For the cross-ORM comparison benchmark.
-    jmhImplementation("org.hibernate.orm:hibernate-core:6.4.4.Final")
-    jmhImplementation("org.hibernate.orm:hibernate-hikaricp:6.4.4.Final")
-    jmhImplementation("org.jetbrains.exposed:exposed-core:0.50.1")
-    jmhImplementation("org.jetbrains.exposed:exposed-jdbc:0.50.1")
+    jmhImplementation("org.hibernate.orm:hibernate-core:7.0.2.Final")
+    jmhImplementation("org.hibernate.orm:hibernate-hikaricp:7.0.2.Final")
+    jmhImplementation("org.jetbrains.exposed:exposed-core:1.0.0-beta-4")
+    jmhImplementation("org.jetbrains.exposed:exposed-jdbc:1.0.0-beta-4")
 }
 
+val resultsJson = layout.buildDirectory.file("results/jmh/results.json")
+val nativeJson = layout.buildDirectory.file("results/jmh/native.json")
+val summaryMd = layout.buildDirectory.file("results/jmh/summary.md")
+
 jmh {
-    warmupIterations.set(3)
-    iterations.set(5)
-    fork.set(1)
-    // Run a subset with, e.g., `-Pjmh ...` or by setting includes here, e.g.
-    // includes.add("ComparisonBenchmark")
+    jmhVersion.set("1.37")
+    // Warmup/measurement/fork counts live on the benchmark classes themselves so a plain
+    // `jmh` run and a manual `java -jar benchmarks-*-jmh.jar` run measure the same thing.
+    // `-Pbench.quick` deliberately overrides them for a fast, indicative-only run.
+    includes.add((findProperty("bench.filter") as String?) ?: "ComparisonBenchmark")
+    if (hasProperty("bench.quick")) {
+        fork.set(1)
+        warmupIterations.set(1)
+        warmup.set("1s")
+        iterations.set(2)
+        timeOnIteration.set("1s")
+    }
+    // External database coordinates (used by benchmarks/run.sh to share one Postgres with
+    // the native harness). Passed as system properties because environment variables do not
+    // reliably reach the forked JMH JVMs through a long-lived Gradle daemon.
+    for (key in listOf("host", "port", "name", "user", "password")) {
+        (findProperty("bench.db.$key") as String?)?.let { jvmArgsAppend.add("-Dkormium.db.$key=$it") }
+    }
+    resultFormat.set("JSON")
+    resultsFile.set(resultsJson)
 }
+
+// Renders build/results/jmh/results.json (plus native.json from benchmarks/run.sh, when
+// present) as a per-operation comparison table: printed to the console after every `jmh`
+// run and written to summary.md for copy-pasting.
+val benchmarkSummary = tasks.register("benchmarkSummary") {
+    group = "benchmark"
+    description = "Prints a comparison table from the latest JMH (and native) results"
+    val jsonFile = resultsJson
+    val nativeFile = nativeJson
+    val mdFile = summaryMd
+    doLast {
+        val json = jsonFile.get().asFile
+        if (!json.exists()) {
+            println("No JMH results at $json — run `./gradlew :benchmarks:jmh` first.")
+            return@doLast
+        }
+
+        fun fmt(score: Double, err: Double = Double.NaN): String =
+            String.format(Locale.ROOT, "%,.0f", score) +
+                if (err.isNaN()) "" else String.format(Locale.ROOT, " ± %,.0f", err)
+
+        val orms = listOf("kormium", "exposed", "hibernate")
+        val cells = mutableMapOf<Pair<String, String>, String>() // (operation, column) -> "score ± err"
+        val extras = mutableListOf<Pair<String, String>>()       // non-comparison benchmarks
+        var units = "ops/s"
+
+        @Suppress("UNCHECKED_CAST")
+        val results = JsonSlurper().parse(json) as List<Map<String, Any?>>
+        for (r in results) {
+            val bench = r["benchmark"] as String
+            val method = bench.substringAfterLast('.')
+            val clazz = bench.substringBeforeLast('.').substringAfterLast('.')
+            val metric = r["primaryMetric"] as Map<*, *>
+            val score = (metric["score"] as Number).toDouble()
+            val err = (metric["scoreError"] as? Number)?.toDouble() ?: Double.NaN
+            units = metric["scoreUnit"] as? String ?: units
+            val orm = orms.firstOrNull { method.startsWith(it) }
+            if (clazz == "ComparisonBenchmark" && orm != null) {
+                val op = method.removePrefix(orm).replaceFirstChar { it.lowercaseChar() }
+                cells[op to orm] = fmt(score, err)
+            } else {
+                extras += "$clazz.$method" to fmt(score, err)
+            }
+        }
+
+        // Results of the native harness (single run, no error estimate).
+        val native = nativeFile.get().asFile.takeIf { it.exists() }?.let {
+            @Suppress("UNCHECKED_CAST")
+            (JsonSlurper().parse(it) as Map<String, Any?>)
+        }.orEmpty()
+        for ((op, score) in native) cells[op to "native"] = fmt((score as Number).toDouble())
+
+        val columns = buildList {
+            add("kormium" to "Kormium")
+            if (native.isNotEmpty()) add("native" to "Kormium Native")
+            add("exposed" to "Exposed")
+            add("hibernate" to "Hibernate")
+        }
+        val ops = (listOf("findById", "selectWhere", "selectMany", "insert", "batchInsert", "updateById") +
+            cells.keys.map { it.first })
+            .distinct().filter { op -> columns.any { (key, _) -> (op to key) in cells } }
+
+        val lines = mutableListOf<String>()
+        if (ops.isNotEmpty()) {
+            val opW = (ops + "Operation").maxOf { it.length }
+            val colWs = columns.map { (key, title) ->
+                (ops.map { cells[it to key] ?: "—" } + title).maxOf { it.length }
+            }
+            lines += "Operation".padEnd(opW) + columns.indices.joinToString("") { "  " + columns[it].second.padStart(colWs[it]) }
+            lines += "-".repeat(lines[0].length)
+            for (op in ops) {
+                lines += op.padEnd(opW) + columns.indices.joinToString("") { "  " + (cells[op to columns[it].first] ?: "—").padStart(colWs[it]) }
+            }
+        }
+        for ((name, cell) in extras) lines += "$name: $cell"
+
+        val title = "Benchmark summary — $units, higher is better"
+        println()
+        println(title)
+        println("═".repeat(title.length))
+        lines.forEach(::println)
+        println()
+        println("Full JMH results: $json")
+
+        mdFile.get().asFile.writeText(buildString {
+            appendLine("# Benchmark summary")
+            appendLine()
+            appendLine("JMH, $units, higher is better. Generated ${LocalDate.now()}.")
+            appendLine()
+            if (ops.isNotEmpty()) {
+                appendLine("| Operation | " + columns.joinToString(" | ") { it.second } + " |")
+                appendLine("| --- | " + columns.joinToString(" | ") { "---:" } + " |")
+                for (op in ops) {
+                    appendLine("| `$op` | " + columns.joinToString(" | ") { cells[op to it.first] ?: "—" } + " |")
+                }
+            }
+            for ((name, cell) in extras) appendLine("- `$name`: $cell")
+            appendLine()
+            appendLine("Numbers are relative — see `benchmarks/README.md` for methodology and caveats.")
+        })
+        println("Markdown summary:  ${mdFile.get().asFile}")
+    }
+}
+
+tasks.named("jmh") { finalizedBy(benchmarkSummary) }

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Full benchmark matrix: Kormium Native + Kormium JVM + Exposed + Hibernate, all against
+# one tuned PostgreSQL container. The summary table at the end merges every column.
+#
+# Usage: benchmarks/run.sh [--quick] [--skip-native] [--skip-jvm]
+#   --quick        fast indicative run (~2-3 min instead of ~20)
+#   --skip-native  JVM ORMs only (no Kotlin/Native build)
+#   --skip-jvm     native harness only; re-renders the summary with the merged column
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+QUICK="" SKIP_NATIVE="" SKIP_JVM=""
+for arg in "$@"; do
+  case "$arg" in
+    --quick) QUICK=1 ;;
+    --skip-native) SKIP_NATIVE=1 ;;
+    --skip-jvm) SKIP_JVM=1 ;;
+    *) echo "unknown option: $arg" >&2; exit 1 ;;
+  esac
+done
+
+PORT="${KORM_BENCH_PORT:-54329}"
+CONTAINER=kormium-bench-pg
+RESULTS_DIR=benchmarks/build/results/jmh
+mkdir -p "$RESULTS_DIR"
+
+echo "==> Starting PostgreSQL (tmpfs, durability off) on port $PORT"
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+docker run -d --name "$CONTAINER" \
+  -e POSTGRES_PASSWORD=password \
+  -p "$PORT:5432" \
+  --tmpfs /var/lib/postgresql/data \
+  postgres:16-alpine \
+  postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off >/dev/null
+trap 'docker rm -f "$CONTAINER" >/dev/null 2>&1 || true' EXIT
+until docker exec "$CONTAINER" pg_isready -U postgres >/dev/null 2>&1; do sleep 0.5; done
+
+export KORMIUM_DB_HOST=127.0.0.1 KORMIUM_DB_PORT="$PORT" KORMIUM_DB_NAME=postgres
+export KORMIUM_DB_USER=postgres KORMIUM_DB_PASSWORD=password
+
+if [ -z "$SKIP_NATIVE" ]; then
+  case "$(uname -sm)" in
+    "Darwin arm64")  TARGET=macosArm64 ;;
+    "Darwin x86_64") TARGET=macosX64 ;;
+    "Linux x86_64")  TARGET=linuxX64 ;;
+    *) echo "==> No native target for '$(uname -sm)' — skipping native benchmark"; TARGET="" ;;
+  esac
+  if [ -n "$TARGET" ]; then
+    echo "==> Building native test binary ($TARGET, release)"
+    # The optimized binary: the default debug test kexe understates CPU-bound ops
+    # (row materialization, batch binding) by 2-3x vs the JIT-optimized JVM ORMs.
+    TARGET_CAP="$(printf '%s' "${TARGET:0:1}" | tr '[:lower:]' '[:upper:]')${TARGET:1}"
+    ./gradlew -q ":kormium-postgres:linkBenchReleaseTest${TARGET_CAP}"
+    KEXE=$(find "kormium-postgres/build/bin/$TARGET/benchReleaseTest" -name "*.kexe" -not -path "*.dSYM/*" | head -1)
+    echo "==> Running native benchmark"
+    RESULT_LINE=$(env KORM_BENCH=1 ${QUICK:+KORM_BENCH_OPS=500} \
+      "$KEXE" --ktest_filter='NativeBenchmark.*' | tee /dev/stderr | grep KORM_NATIVE_RESULT || true)
+    if [ -n "$RESULT_LINE" ]; then
+      # "KORM_NATIVE_RESULT findById=123 ..." -> {"findById": 123, ...}
+      echo "$RESULT_LINE" | sed 's/.*KORM_NATIVE_RESULT //' | awk '{
+        printf "{";
+        for (i = 1; i <= NF; i++) { split($i, kv, "="); printf "%s\"%s\": %s", (i > 1 ? ", " : ""), kv[1], kv[2] }
+        print "}"
+      }' > "$RESULTS_DIR/native.json"
+      echo "==> Native results written to $RESULTS_DIR/native.json"
+    else
+      echo "WARNING: native benchmark produced no KORM_NATIVE_RESULT line" >&2
+    fi
+  fi
+fi
+
+if [ -z "$SKIP_JVM" ]; then
+  echo "==> Running JVM benchmarks (kormium / Exposed / Hibernate)"
+  ./gradlew :benchmarks:jmh ${QUICK:+-Pbench.quick} \
+    -Pbench.db.host=127.0.0.1 -Pbench.db.port="$PORT" -Pbench.db.name=postgres \
+    -Pbench.db.user=postgres -Pbench.db.password=password
+else
+  ./gradlew :benchmarks:benchmarkSummary
+fi

--- a/benchmarks/src/jmh/kotlin/ComparisonBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/ComparisonBenchmark.kt
@@ -17,12 +17,15 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table as JpaTable
 import org.hibernate.SessionFactory
 import org.hibernate.cfg.Configuration
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.selectAll
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.batchInsert
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
 import org.openjdk.jmh.annotations.Measurement
 import org.openjdk.jmh.annotations.Mode
 import org.openjdk.jmh.annotations.OutputTimeUnit
@@ -33,11 +36,18 @@ import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.annotations.Threads
 import org.openjdk.jmh.annotations.Warmup
 import org.testcontainers.containers.PostgreSQLContainer
+import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
 import com.ionspin.kotlin.bignum.decimal.BigDecimal as KormiumBigDecimal
-import org.jetbrains.exposed.sql.Database as ExposedDatabase
-import org.jetbrains.exposed.sql.Table as ExposedSqlTable
+import org.jetbrains.exposed.v1.jdbc.Database as ExposedDatabase
+import org.jetbrains.exposed.v1.core.Table as ExposedSqlTable
 import kotlin.uuid.Uuid as KormiumUuid
+
+// Shared workload shape — keep in sync with the native harness (NativeBenchmark.kt in
+// kormium-postgres) so the "Kormium Native" column measures the same thing.
+const val BULK_ROWS = 100
+const val BATCH_SIZE = 50
+const val UPDATE_ROWS = 1024
 
 // --- kormium mapping ---
 object Cmp : Catalog
@@ -77,9 +87,9 @@ open class HibBench {
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Warmup(iterations = 3, time = 2)
+@Warmup(iterations = 5, time = 2)
 @Measurement(iterations = 5, time = 2)
-@Fork(1)
+@Fork(value = 2, jvmArgsAppend = ["-Xms2g", "-Xmx2g"])
 @Threads(8)
 open class ComparisonBenchmark {
 
@@ -90,13 +100,22 @@ open class ComparisonBenchmark {
     private lateinit var sessionFactory: SessionFactory
 
     private val seededJavaId: java.util.UUID = java.util.UUID.randomUUID()
-    private val seededKormiumId: KormiumUuid = KormiumUuid.fromLongs(seededJavaId.mostSignificantBits, seededJavaId.leastSignificantBits)
+    private val seededKormiumId: KormiumUuid = seededJavaId.toKormium()
+
+    // Fixed pool of rows the updateById benchmarks target; reseeded every iteration.
+    private val updateJavaIds: List<java.util.UUID> = List(UPDATE_ROWS) { java.util.UUID.randomUUID() }
+    private val updateKormiumIds: List<KormiumUuid> = updateJavaIds.map { it.toKormium() }
 
     @Setup
     fun setup() {
-        // Use an external Postgres (shared with the native benchmark) when KORMIUM_DB_HOST is
-        // set; otherwise spin up an ephemeral Testcontainers one.
-        val envHost = System.getenv("KORMIUM_DB_HOST")
+        // The jmh fat jar ends up with duplicate META-INF/services/java.sql.Driver entries
+        // and the JVM can pick the testcontainers driver over the PostgreSQL one; register
+        // the real driver explicitly so DriverManager always finds it.
+        Class.forName("org.postgresql.Driver")
+        // Use an external Postgres (shared with the native benchmark) when -Dkormium.db.host
+        // (forwarded by `-Pbench.db.host`, see build.gradle.kts) or KORMIUM_DB_HOST is set;
+        // otherwise spin up an ephemeral Testcontainers one.
+        val envHost = dbConfig("host")
         val host: String
         val port: Int
         val database: String
@@ -104,12 +123,19 @@ open class ComparisonBenchmark {
         val password: String
         if (envHost != null) {
             host = envHost
-            port = System.getenv("KORMIUM_DB_PORT")?.toInt() ?: 5432
-            database = System.getenv("KORMIUM_DB_NAME") ?: "postgres"
-            user = System.getenv("KORMIUM_DB_USER") ?: "postgres"
-            password = System.getenv("KORMIUM_DB_PASSWORD") ?: "password"
+            port = dbConfig("port")?.toInt() ?: 5432
+            database = dbConfig("name") ?: "postgres"
+            user = dbConfig("user") ?: "postgres"
+            password = dbConfig("password") ?: "password"
         } else {
-            container = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+            // tmpfs data dir + durability off: these benchmarks measure ORM/driver overhead,
+            // not disk fsync latency, and disk is by far the noisiest component (especially
+            // Docker on macOS). All three ORMs get the same treatment.
+            container = PostgreSQLContainer("postgres:16-alpine").apply {
+                withTmpFs(mapOf("/var/lib/postgresql/data" to "rw"))
+                withCommand("postgres", "-c", "fsync=off", "-c", "synchronous_commit=off", "-c", "full_page_writes=off")
+                start()
+            }
             host = container.host
             port = container.firstMappedPort
             database = container.databaseName
@@ -119,13 +145,13 @@ open class ComparisonBenchmark {
         val jdbcUrl = "jdbc:postgresql://$host:$port/$database"
 
         kormiumDb = createDatabase(host, port, database, user, password, poolSize = 8)
-        // Start from a clean table (the insert benchmarks bloat it across runs) and index
-        // `name` so selectWhere is an index lookup, not a size-dependent sequential scan.
+        // Start from a clean table and index `name` so selectWhere/selectMany are index
+        // lookups, not size-dependent sequential scans. Seeding happens in resetTable()
+        // before every iteration.
         kormiumDb.transaction {
             CmpTable.execSql("DROP TABLE IF EXISTS \"cmp_bench\"")
             CmpTable.execSql(cmpBenchDdl)
             executeUpdate("""CREATE INDEX IF NOT EXISTS cmp_bench_name_idx ON "public"."cmp_bench" ("name")""")
-            CmpTable.insert(CmpRow().apply { id = seededKormiumId; name = "seed"; amount = KormiumBigDecimal.fromInt(1) })
         }
 
         exposedDs = HikariDataSource(HikariConfig().apply {
@@ -144,7 +170,24 @@ open class ComparisonBenchmark {
             .setProperty("hibernate.connection.provider_class", "org.hibernate.hikaricp.internal.HikariCPConnectionProvider")
             .setProperty("hibernate.hikari.maximumPoolSize", "8")
             .setProperty("hibernate.hbm2ddl.auto", "none")
+            // Lets the persist loop in hibernateBatchInsert actually batch statements,
+            // matching kormium insertAll / Exposed batchInsert.
+            .setProperty("hibernate.jdbc.batch_size", BATCH_SIZE.toString())
             .buildSessionFactory()
+    }
+
+    // The insert benchmarks grow the table and its indexes, which slowly drags every later
+    // iteration; truncating between iterations keeps each iteration measuring the same state.
+    @Setup(Level.Iteration)
+    fun resetTable() {
+        kormiumDb.transaction {
+            executeUpdate("""TRUNCATE "public"."cmp_bench"""")
+            CmpTable.insert(CmpRow().apply { id = seededKormiumId; name = "seed"; amount = KormiumBigDecimal.fromInt(1) })
+            CmpTable.insertAll(List(BULK_ROWS) { newKormiumRow("bulk") })
+            CmpTable.insertAll(updateKormiumIds.map { rowId ->
+                CmpRow().apply { id = rowId; name = "upd"; amount = KormiumBigDecimal.fromInt(1) }
+            })
+        }
     }
 
     @TearDown
@@ -160,17 +203,41 @@ open class ComparisonBenchmark {
     fun kormiumFindById(): Any? = kormiumDb.autocommit { CmpTable.findById(seededKormiumId) }
 
     @Benchmark
-    fun kormiumInsert(): Any? = kormiumDb.transaction {
-        CmpTable.insert(CmpRow().apply { id = KormiumUuid.random(); name = "x"; amount = KormiumBigDecimal.fromInt(1) })
+    fun kormiumSelectWhere(): Any? = kormiumDb.autocommit { CmpTable.find(Query(CmpTable.name eq "seed")) }
+
+    @Benchmark
+    fun kormiumSelectMany(): Any? = kormiumDb.autocommit { CmpTable.find(Query(CmpTable.name eq "bulk")) }
+
+    @Benchmark
+    fun kormiumInsert(): Any? = kormiumDb.transaction { CmpTable.insert(newKormiumRow("x")) }
+
+    @Benchmark
+    fun kormiumBatchInsert(): Any? = kormiumDb.transaction {
+        CmpTable.insertAll(List(BATCH_SIZE) { newKormiumRow("x") })
     }
 
     @Benchmark
-    fun kormiumSelectWhere(): Any? = kormiumDb.autocommit { CmpTable.find(Query(CmpTable.name eq "seed")) }
+    fun kormiumUpdateById(): Any? = kormiumDb.transaction {
+        CmpTable.update(
+            Query(CmpTable.id eq updateKormiumIds[randomUpdateIndex()]),
+            CmpRow().apply { amount = KormiumBigDecimal.fromInt(2) },
+        )
+    }
 
     // --- Exposed ---
     @Benchmark
     fun exposedFindById(): Any? = transaction(exposedDb) {
         ExposedBench.selectAll().where { ExposedBench.id eq seededJavaId }.firstOrNull()
+    }
+
+    @Benchmark
+    fun exposedSelectWhere(): Any? = transaction(exposedDb) {
+        ExposedBench.selectAll().where { ExposedBench.name eq "seed" }.toList()
+    }
+
+    @Benchmark
+    fun exposedSelectMany(): Any? = transaction(exposedDb) {
+        ExposedBench.selectAll().where { ExposedBench.name eq "bulk" }.toList()
     }
 
     @Benchmark
@@ -183,13 +250,33 @@ open class ComparisonBenchmark {
     }
 
     @Benchmark
-    fun exposedSelectWhere(): Any? = transaction(exposedDb) {
-        ExposedBench.selectAll().where { ExposedBench.name eq "seed" }.toList()
+    fun exposedBatchInsert(): Any? = transaction(exposedDb) {
+        ExposedBench.batchInsert(List(BATCH_SIZE) { java.util.UUID.randomUUID() }, shouldReturnGeneratedValues = false) { rowId ->
+            this[ExposedBench.id] = rowId
+            this[ExposedBench.name] = "x"
+            this[ExposedBench.amount] = java.math.BigDecimal.ONE
+        }
+    }
+
+    @Benchmark
+    fun exposedUpdateById(): Any? = transaction(exposedDb) {
+        val rowId = updateJavaIds[randomUpdateIndex()]
+        ExposedBench.update({ ExposedBench.id eq rowId }) { it[amount] = java.math.BigDecimal.TWO }
     }
 
     // --- Hibernate ---
     @Benchmark
     fun hibernateFindById(): Any? = sessionFactory.openSession().use { it.find(HibBench::class.java, seededJavaId) }
+
+    @Benchmark
+    fun hibernateSelectWhere(): Any? = sessionFactory.openSession().use {
+        it.createQuery("from HibBench where name = :n", HibBench::class.java).setParameter("n", "seed").list()
+    }
+
+    @Benchmark
+    fun hibernateSelectMany(): Any? = sessionFactory.openSession().use {
+        it.createQuery("from HibBench where name = :n", HibBench::class.java).setParameter("n", "bulk").list()
+    }
 
     @Benchmark
     fun hibernateInsert(): Any? = sessionFactory.openSession().use { s ->
@@ -199,9 +286,34 @@ open class ComparisonBenchmark {
     }
 
     @Benchmark
-    fun hibernateSelectWhere(): Any? = sessionFactory.openSession().use {
-        it.createQuery("from HibBench where name = :n", HibBench::class.java).setParameter("n", "seed").list()
+    fun hibernateBatchInsert(): Any? = sessionFactory.openSession().use { s ->
+        val tx = s.beginTransaction()
+        repeat(BATCH_SIZE) {
+            s.persist(HibBench().apply { id = java.util.UUID.randomUUID(); name = "x"; amount = java.math.BigDecimal.ONE })
+        }
+        tx.commit()
     }
+
+    @Benchmark
+    fun hibernateUpdateById(): Any? = sessionFactory.openSession().use { s ->
+        val tx = s.beginTransaction()
+        val updated = s.createMutationQuery("update HibBench set amount = :a where id = :id")
+            .setParameter("a", java.math.BigDecimal.TWO)
+            .setParameter("id", updateJavaIds[randomUpdateIndex()])
+            .executeUpdate()
+        tx.commit()
+        updated
+    }
+
+    private fun newKormiumRow(rowName: String) =
+        CmpRow().apply { id = KormiumUuid.random(); name = rowName; amount = KormiumBigDecimal.fromInt(1) }
+
+    private fun randomUpdateIndex(): Int = ThreadLocalRandom.current().nextInt(UPDATE_ROWS)
+
+    private fun dbConfig(key: String): String? =
+        System.getProperty("kormium.db.$key") ?: System.getenv("KORMIUM_DB_${key.uppercase()}")
 }
+
+private fun java.util.UUID.toKormium() = KormiumUuid.fromLongs(mostSignificantBits, leastSignificantBits)
 
 private val cmpBenchDdl = """CREATE TABLE IF NOT EXISTS "cmp_bench" ("id" uuid NOT NULL, "name" text NOT NULL, "amount" numeric NOT NULL, PRIMARY KEY ("id"))"""

--- a/benchmarks/src/jmh/kotlin/KormiumBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/KormiumBenchmark.kt
@@ -14,6 +14,7 @@ import io.github.kormium.transaction
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
 import org.openjdk.jmh.annotations.Measurement
 import org.openjdk.jmh.annotations.Mode
 import org.openjdk.jmh.annotations.OutputTimeUnit
@@ -21,6 +22,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Threads
 import org.openjdk.jmh.annotations.Warmup
 import org.testcontainers.containers.PostgreSQLContainer
 import java.util.concurrent.TimeUnit
@@ -45,9 +47,10 @@ object BenchTable : Table<Bench, BenchRow>("bench", ::BenchRow) {
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Warmup(iterations = 3, time = 2)
+@Warmup(iterations = 5, time = 2)
 @Measurement(iterations = 5, time = 2)
-@Fork(1)
+@Fork(value = 2, jvmArgsAppend = ["-Xms2g", "-Xmx2g"])
+@Threads(8)
 open class KormiumBenchmark {
 
     private lateinit var container: PostgreSQLContainer<*>
@@ -56,7 +59,16 @@ open class KormiumBenchmark {
 
     @Setup
     fun setup() {
-        container = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+        // See ComparisonBenchmark.setup: the fat jar has duplicate java.sql.Driver service
+        // entries, so register the PostgreSQL driver explicitly.
+        Class.forName("org.postgresql.Driver")
+        // Same stability setup as ComparisonBenchmark: tmpfs data dir and durability off, so
+        // we measure ORM/driver overhead rather than disk fsync latency.
+        container = PostgreSQLContainer("postgres:16-alpine").apply {
+            withTmpFs(mapOf("/var/lib/postgresql/data" to "rw"))
+            withCommand("postgres", "-c", "fsync=off", "-c", "synchronous_commit=off", "-c", "full_page_writes=off")
+            start()
+        }
         db = createDatabase(
             host = container.host,
             port = container.firstMappedPort,
@@ -67,6 +79,16 @@ open class KormiumBenchmark {
         )
         db.transaction {
             BenchTable.execSql(benchDdl)
+            executeUpdate("""CREATE INDEX IF NOT EXISTS bench_name_idx ON "public"."bench" ("name")""")
+        }
+    }
+
+    // Keep table size constant across iterations: the insert benchmark grows the table and
+    // its indexes, which would slowly drag every later iteration.
+    @Setup(Level.Iteration)
+    fun resetTable() {
+        db.transaction {
+            executeUpdate("""TRUNCATE "public"."bench"""")
             BenchTable.insert(BenchRow().apply { id = seededId; name = "seed"; amount = BigDecimal.fromInt(1) })
         }
     }

--- a/docs/project.md
+++ b/docs/project.md
@@ -44,32 +44,30 @@ not support. Prefer focused tasks unless you are validating the full host-specif
 
 ## Benchmarks
 
-The `benchmarks` module contains JMH benchmarks comparing Kormium, Exposed and Hibernate on
-JVM:
+The `benchmarks` module measures the full matrix — Kormium JVM, Kormium Native (libpq),
+Exposed and Hibernate — over six operations (`findById`, `selectWhere`, `selectMany`,
+`insert`, `batchInsert`, `updateById`) against one shared PostgreSQL:
 
 ```bash
-./gradlew :benchmarks:jmh
+./benchmarks/run.sh            # full matrix, prints a merged summary table
+./gradlew :benchmarks:jmh      # JVM ORMs only
 ```
 
-There is also a native Kormium benchmark harness. Configure PostgreSQL with environment
-variables:
+See [benchmarks/README.md](../benchmarks/README.md) for flags, output files, what each
+operation does and the methodology (durability-off PostgreSQL on tmpfs, per-iteration
+reseeding, JMH forks).
 
-```bash
-export KORMIUM_DB_HOST=localhost
-export KORMIUM_DB_PORT=5432
-export KORMIUM_DB_NAME=postgres
-export KORMIUM_DB_USER=postgres
-export KORMIUM_DB_PASSWORD=password
-```
-
-Indicative throughput from the current README-era benchmark run, in ops/s with 8
-threads/workers:
+Indicative throughput from a `run.sh` pass on a dev machine, in ops/s with 8
+threads/workers (the native column comes from a simpler non-JMH harness):
 
 | Operation | Kormium JVM | Kormium Native | Exposed | Hibernate |
 | --- | ---: | ---: | ---: | ---: |
-| `findById` | ~8.2k | ~13.2k | ~8.2k | ~16.0k |
-| `selectWhere` | ~8.2k | ~13.7k | ~7.9k | ~16.3k |
-| `insert` | ~8.0k | ~5.0k | ~7.9k | ~8.3k |
+| `findById` | ~26.1k | ~30.6k | ~11.2k | ~26.3k |
+| `selectWhere` | ~26.4k | ~29.7k | ~10.7k | ~23.9k |
+| `selectMany` | ~19.9k | ~17.3k | ~9.8k | ~13.7k |
+| `insert` | ~12.2k | ~11.3k | ~11.8k | ~12.4k |
+| `batchInsert` | ~4.7k | ~5.4k | ~4.9k | ~4.2k |
+| `updateById` | ~11.6k | ~11.3k | ~11.1k | ~10.7k |
 
 Treat benchmark numbers as relative. Run them on your own machine and database before making
 architecture decisions.

--- a/kormium-postgres/src/nativeTest/kotlin/NativeBenchmark.kt
+++ b/kormium-postgres/src/nativeTest/kotlin/NativeBenchmark.kt
@@ -13,6 +13,7 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.toKString
 import kotlin.native.concurrent.TransferMode
 import kotlin.native.concurrent.Worker
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.time.TimeSource
 import kotlin.uuid.Uuid
@@ -46,24 +47,41 @@ object BenchTable : Table<BenchCatalog, BenchRow>("cmp_bench", ::BenchRow) {
     init { id; name; amount }
 }
 
-private val benchSeedId = Uuid.random()
+// Workload shape — keep in sync with the JVM ComparisonBenchmark in `benchmarks`.
+private const val BULK_ROWS = 100
+private const val BATCH_SIZE = 50
+private const val UPDATE_ROWS = 1024
 
-private enum class Op { FIND_BY_ID, SELECT_WHERE, INSERT }
+private val benchSeedId = Uuid.random()
+private val updateIds = List(UPDATE_ROWS) { Uuid.random() }
+
+private enum class Op { FIND_BY_ID, SELECT_WHERE, SELECT_MANY, INSERT, BATCH_INSERT, UPDATE_BY_ID }
+
+private fun newRow(rowName: String) =
+    BenchRow().apply { id = Uuid.random(); name = rowName; amount = BigDecimal.fromInt(1) }
 
 private fun runOp(db: Database<BenchCatalog>, op: Op) {
     when (op) {
         Op.FIND_BY_ID -> db.autocommit { BenchTable.findById(benchSeedId) }
         Op.SELECT_WHERE -> db.autocommit { BenchTable.find(Query(BenchTable.name eq "seed")) }
-        Op.INSERT -> db.transaction {
-            BenchTable.insert(BenchRow().apply { id = Uuid.random(); name = "x"; amount = BigDecimal.fromInt(1) })
+        Op.SELECT_MANY -> db.autocommit { BenchTable.find(Query(BenchTable.name eq "bulk")) }
+        Op.INSERT -> db.transaction { BenchTable.insert(newRow("x")) }
+        Op.BATCH_INSERT -> db.transaction { BenchTable.insertAll(List(BATCH_SIZE) { newRow("x") }) }
+        Op.UPDATE_BY_ID -> db.transaction {
+            BenchTable.update(
+                Query(BenchTable.id eq updateIds[Random.nextInt(UPDATE_ROWS)]),
+                BenchRow().apply { amount = BigDecimal.fromInt(2) },
+            )
         }
     }
 }
 
 /**
- * Native counterpart to the JVM JMH ComparisonBenchmark: same three operations, 8 worker
- * threads, against the Postgres given by KORMIUM_DB_* env vars. Opt-in via KORM_BENCH so it
- * never runs in the normal test suite. Prints ops/s lines the runner script parses.
+ * Native counterpart to the JVM JMH ComparisonBenchmark: same six operations and seeding,
+ * 8 worker threads, against the Postgres given by KORMIUM_DB_* env vars. Opt-in via
+ * KORM_BENCH so it never runs in the normal test suite. KORM_BENCH_OPS overrides the
+ * per-thread op count (default 5000) for quick smoke runs. Prints one machine-readable
+ * `KORM_NATIVE_RESULT op=ops_per_sec ...` line that benchmarks/run.sh parses.
  */
 class NativeBenchmark {
 
@@ -74,28 +92,36 @@ class NativeBenchmark {
             return
         }
         val driver = benchDriver(poolSize = 8)
-        // Fresh table + an index on `name` so selectWhere is an index lookup (matches the JVM
-        // harness) rather than a sequential scan that degrades as inserts bloat the table.
         driver.transaction {
             BenchTable.execSql("DROP TABLE IF EXISTS \"cmp_bench\"")
             BenchTable.execSql(benchDdl)
             executeUpdate("""CREATE INDEX IF NOT EXISTS cmp_bench_name_idx ON "public"."cmp_bench" ("name")""")
-            BenchTable.insert(BenchRow().apply { id = benchSeedId; name = "seed"; amount = BigDecimal.fromInt(1) })
         }
 
         val threads = 8
-        val ops = 5_000
-        val findById = bench(driver, threads, ops, Op.FIND_BY_ID)
-        val selectWhere = bench(driver, threads, ops, Op.SELECT_WHERE)
-        val insert = bench(driver, threads, ops, Op.INSERT)
+        val ops = benchEnv("KORM_BENCH_OPS")?.toInt() ?: 5_000
+        val results = listOf(
+            "findById" to Op.FIND_BY_ID,
+            "selectWhere" to Op.SELECT_WHERE,
+            "selectMany" to Op.SELECT_MANY,
+            "insert" to Op.INSERT,
+            // Batches are ~50x slower per op; scale the count down to keep the run short.
+            "batchInsert" to Op.BATCH_INSERT,
+            "updateById" to Op.UPDATE_BY_ID,
+        ).map { (name, op) ->
+            val perThread = if (op == Op.BATCH_INSERT) (ops / 25).coerceAtLeast(10) else ops
+            name to bench(driver, threads, perThread, op)
+        }
 
-        println("KORM_NATIVE_RESULT findById=${findById.toInt()} selectWhere=${selectWhere.toInt()} insert=${insert.toInt()}")
+        println("KORM_NATIVE_RESULT " + results.joinToString(" ") { (name, opsSec) -> "$name=${opsSec.toInt()}" })
         driver.close()
     }
 
-    /** Runs [opsPerThread] ops of [op] on each of [threads] workers; returns ops/second. */
+    /** Resets the table, warms up, then runs [opsPerThread] ops on [threads] workers; returns ops/s. */
     private fun bench(driver: Database<BenchCatalog>, threads: Int, opsPerThread: Int, op: Op): Double {
-        repeat(2_000) { runOp(driver, op) } // warm up
+        reset(driver)
+        repeat(minOf(2_000, opsPerThread * 2)) { runOp(driver, op) } // warm up
+        reset(driver)
         val mark = TimeSource.Monotonic.markNow()
         val workers = List(threads) { Worker.start() }
         val futures = workers.map { worker ->
@@ -107,6 +133,18 @@ class NativeBenchmark {
         val elapsedMs = mark.elapsedNow().inWholeMilliseconds.coerceAtLeast(1)
         workers.forEach { it.requestTermination().result }
         return threads.toLong() * opsPerThread * 1000.0 / elapsedMs
+    }
+
+    /** Same per-iteration state as the JVM harness: seed row, bulk rows, update targets. */
+    private fun reset(driver: Database<BenchCatalog>) {
+        driver.transaction {
+            executeUpdate("""TRUNCATE "public"."cmp_bench"""")
+            BenchTable.insert(BenchRow().apply { id = benchSeedId; name = "seed"; amount = BigDecimal.fromInt(1) })
+            BenchTable.insertAll(List(BULK_ROWS) { newRow("bulk") })
+            BenchTable.insertAll(updateIds.map { rowId ->
+                BenchRow().apply { id = rowId; name = "upd"; amount = BigDecimal.fromInt(1) }
+            })
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Expands the benchmarks from 3 JVM-only operations into an objective 6-operation matrix — **Kormium JVM, Kormium Native (libpq), Exposed, Hibernate** — all against one shared, tuned PostgreSQL.

- **`benchmarks/run.sh`** — one command runs everything and prints a merged summary table; `--quick`, `--skip-native`, `--skip-jvm` flags
- **Operations**: `findById`, `selectWhere`, `selectMany` (100-row materialization), `insert`, `batchInsert` (50/tx, idiomatic batch API per ORM), `updateById`
- **Native harness** mirrors the JVM workload exactly and is built as an optimized release test binary (the debug kexe understates CPU-bound ops 2–3x); its results merge into the summary as a `Kormium Native` column
- **Stability**: 2 JMH forks + fixed heap, truncate+reseed between iterations, tmpfs/durability-off Postgres, index-backed lookups
- **Freshness**: Exposed 1.0.0-beta-4 (v1 API), Hibernate 7.0.2.Final, JMH 1.37, Testcontainers 1.21.3
- **Output**: console table after every run + `summary.md` (markdown) + full `results.json`; `benchmarks/README.md` documents methodology and honesty caveats
- `docs/project.md` numbers table refreshed from a fresh full run (one machine, one pass)

## Indicative numbers from the refresh run (ops/s, 8 threads)

| Operation | Kormium JVM | Kormium Native | Exposed | Hibernate |
| --- | ---: | ---: | ---: | ---: |
| `findById` | ~26.1k | ~30.6k | ~11.2k | ~26.3k |
| `selectWhere` | ~26.4k | ~29.7k | ~10.7k | ~23.9k |
| `selectMany` | ~19.9k | ~17.3k | ~9.8k | ~13.7k |
| `insert` | ~12.2k | ~11.3k | ~11.8k | ~12.4k |
| `batchInsert` | ~4.7k | ~5.4k | ~4.9k | ~4.2k |
| `updateById` | ~11.6k | ~11.3k | ~11.1k | ~10.7k |

## Test plan

- [x] `./gradlew :benchmarks:jmhJar` compiles (Exposed v1 API, Hibernate 7)
- [x] `./benchmarks/run.sh --quick` end-to-end: container, native harness, JVM matrix, merged table
- [x] Two full `run.sh` passes; docs table taken from the fresh one

🤖 Generated with [Claude Code](https://claude.com/claude-code)