### PR TITLE
feat: experimental Windows Native (mingwX64) target

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Batch scripts must keep CRLF: cmd.exe misparses goto/labels in LF-only files.
+*.bat text eol=crlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Build ktor integration modules
         run: ./gradlew :kormium-ktor:assemble :kormium-ktor-di:assemble :kormium-ktor-koin:assemble --console=plain
 
+      # Cross-compile the experimental Windows (mingwX64) klibs. There is no Windows
+      # runner yet, so nothing executes — this only keeps the target compiling. The libpq
+      # cinterop resolves platform-neutral headers from libpq-dev installed above.
+      - name: Cross-compile Windows (mingwX64) klibs
+        run: ./gradlew :kormium-core:compileKotlinMingwX64 :kormium-postgres:compileTestKotlinMingwX64 :kormium-sqlite:linkDebugTestMingwX64 :kormium-observe:compileKotlinMingwX64 :kormium-migrate:compileKotlinMingwX64 :kormium-ktor:compileKotlinMingwX64 :kormium-ktor-di:compileKotlinMingwX64 :kormium-ktor-koin:compileKotlinMingwX64 --console=plain
+
       # Self-contained SQLite samples — tests run on both JVM and native (no Docker needed).
       # The samples still use a single host-named native target, so their task is `nativeTest`.
       - name: SQLite sample tests (JVM + native)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Kormium are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **Experimental Windows Native (mingwX64) target** for all multiplatform modules:
+  `kormium-core`, `kormium-postgres` (libpq), `kormium-sqlite` (vendored amalgamation),
+  `kormium-observe`, `kormium-migrate` and the Ktor integrations. Artifacts cross-compile
+  and publish from any host; CI does not run tests on Windows yet, so the target ships
+  without compatibility guarantees. `benchmarks/run.bat` runs the benchmark matrix
+  (including the native column) on Windows.
+
 ### Performance
 - **PostgreSQL Native: repeated statements skip re-parsing.** The libpq driver now keeps a
   per-connection LRU cache (128 entries) of the `:name` → `$n` parse/substitution result,

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -43,6 +43,18 @@ To re-print the table from the last run without re-running anything:
 ./gradlew :benchmarks:benchmarkSummary
 ```
 
+## Windows
+
+Use the batch counterpart (requires Docker Desktop):
+
+```bat
+benchmarks\run.bat [--quick] [--skip-native] [--skip-jvm]
+```
+
+The native column is built for the experimental mingwX64 target and needs a Windows
+libpq — MSYS2 (`pacman -S mingw-w64-x86_64-postgresql`) or an EDB PostgreSQL install.
+If the native binary cannot be linked, the script warns and runs the JVM matrix only.
+
 ## JVM-only runs via Gradle
 
 `./gradlew :benchmarks:jmh` runs the JVM matrix on its own throwaway Testcontainers

--- a/benchmarks/run.bat
+++ b/benchmarks/run.bat
@@ -1,0 +1,107 @@
+@echo off
+rem Windows counterpart of run.sh: the full benchmark matrix — Kormium Native (mingwX64),
+rem Kormium JVM, Exposed and Hibernate — against one tuned PostgreSQL container.
+rem
+rem Prerequisites: Docker Desktop; for the native column, a Windows libpq
+rem (MSYS2: pacman -S mingw-w64-x86_64-postgresql, or an EDB PostgreSQL install —
+rem see kormium-postgres/src/nativeInterop/cinterop/libpq.def for the searched paths).
+rem
+rem Usage: benchmarks\run.bat [--quick] [--skip-native] [--skip-jvm]
+rem   --quick        fast indicative run — for checking the setup, not for quoting
+rem   --skip-native  JVM ORMs only (no libpq needed)
+rem   --skip-jvm     native harness only, then re-render the merged summary
+
+setlocal
+cd /d "%~dp0.."
+
+set "QUICK="
+set "SKIP_NATIVE="
+set "SKIP_JVM="
+:parse
+if "%~1"=="" goto parsed
+if "%~1"=="--quick" (set "QUICK=1" & shift & goto parse)
+if "%~1"=="--skip-native" (set "SKIP_NATIVE=1" & shift & goto parse)
+if "%~1"=="--skip-jvm" (set "SKIP_JVM=1" & shift & goto parse)
+echo unknown option: %~1 1>&2
+exit /b 1
+:parsed
+
+set "PORT=54329"
+if defined KORM_BENCH_PORT set "PORT=%KORM_BENCH_PORT%"
+set "CONTAINER=kormium-bench-pg"
+set "RESULTS_DIR=benchmarks\build\results\jmh"
+if not exist "%RESULTS_DIR%" mkdir "%RESULTS_DIR%"
+
+echo ==^> Starting PostgreSQL (tmpfs, durability off) on port %PORT%
+docker rm -f %CONTAINER% >nul 2>&1
+docker run -d --name %CONTAINER% -e POSTGRES_PASSWORD=password -p %PORT%:5432 --tmpfs /var/lib/postgresql/data postgres:16-alpine postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off >nul
+if errorlevel 1 (
+  echo ERROR: failed to start the PostgreSQL container - is Docker Desktop running? 1>&2
+  exit /b 1
+)
+
+:waitpg
+docker exec %CONTAINER% pg_isready -U postgres >nul 2>&1
+if errorlevel 1 (
+  timeout /t 1 /nobreak >nul
+  goto waitpg
+)
+
+rem Used by the native harness; the JVM side gets the same values via -Pbench.db.*.
+set "KORMIUM_DB_HOST=127.0.0.1"
+set "KORMIUM_DB_PORT=%PORT%"
+set "KORMIUM_DB_NAME=postgres"
+set "KORMIUM_DB_USER=postgres"
+set "KORMIUM_DB_PASSWORD=password"
+
+if defined SKIP_NATIVE goto jvm
+
+echo ==^> Building native benchmark binary (mingwX64, release)
+call gradlew.bat -q :kormium-postgres:linkBenchReleaseTestMingwX64
+if errorlevel 1 (
+  echo WARNING: native binary failed to link - is a Windows libpq installed? Continuing JVM-only. 1>&2
+  goto jvm
+)
+set "KEXE=kormium-postgres\build\bin\mingwX64\benchReleaseTest\test.exe"
+if not exist "%KEXE%" (
+  echo WARNING: %KEXE% not found, skipping the native benchmark 1>&2
+  goto jvm
+)
+
+echo ==^> Running native benchmark
+set "KORM_BENCH=1"
+if defined QUICK (set "KORM_BENCH_OPS=500") else (set "KORM_BENCH_OPS=")
+set "NATIVE_LOG=%TEMP%\kormium-native-bench.log"
+"%KEXE%" --ktest_filter=NativeBenchmark.* > "%NATIVE_LOG%" 2>&1
+type "%NATIVE_LOG%"
+set "KORM_BENCH="
+
+rem "KORM_NATIVE_RESULT findById=123 ..." -> {"findById": 123, ...}
+powershell -NoProfile -Command ^
+  "$m = Select-String -Path '%NATIVE_LOG%' -Pattern 'KORM_NATIVE_RESULT' | Select-Object -Last 1;" ^
+  "if (-not $m) { exit 1 };" ^
+  "$h = [ordered]@{};" ^
+  "foreach ($p in (($m.Line -replace '.*KORM_NATIVE_RESULT\s*', '') -split '\s+')) { $kv = $p -split '='; if ($kv.Length -eq 2) { $h[$kv[0]] = [long]$kv[1] } };" ^
+  "$h | ConvertTo-Json -Compress | Set-Content -Encoding ascii '%RESULTS_DIR%\native.json'"
+if errorlevel 1 (
+  echo WARNING: native benchmark produced no KORM_NATIVE_RESULT line 1>&2
+) else (
+  echo ==^> Native results written to %RESULTS_DIR%\native.json
+)
+
+:jvm
+if defined SKIP_JVM goto summaryonly
+echo ==^> Running JVM benchmarks (kormium / Exposed / Hibernate)
+set "JMH_ARGS=:benchmarks:jmh -Pbench.db.host=127.0.0.1 -Pbench.db.port=%PORT% -Pbench.db.name=postgres -Pbench.db.user=postgres -Pbench.db.password=password"
+if defined QUICK set "JMH_ARGS=%JMH_ARGS% -Pbench.quick"
+call gradlew.bat %JMH_ARGS%
+set "EXITCODE=%ERRORLEVEL%"
+goto cleanup
+
+:summaryonly
+call gradlew.bat :benchmarks:benchmarkSummary
+set "EXITCODE=%ERRORLEVEL%"
+
+:cleanup
+docker rm -f %CONTAINER% >nul 2>&1
+exit /b %EXITCODE%

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -119,7 +119,7 @@ The public API presents Kotlin values consistently even when storage differs.
 | macOS Native | libpq | sqlite3 |
 | Android | Not shipped | AndroidX SQLite |
 | iOS | Not shipped | sqlite3 |
-| Windows Native | Planned | Planned |
+| Windows Native | libpq (experimental) | sqlite3 (experimental) |
 | Wasm | Research | Planned |
 
 See [Installation](installation.md#platform-matrix) for module-level details.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -31,7 +31,7 @@ When these baselines change, the change should be called out in the changelog.
 | macOS Native | Published for x64 and arm64; compile and smoke coverage should be kept |
 | Android | Supported for core and SQLite compilation/runtime path |
 | iOS | Supported for core/SQLite compilation; production backend story is SQLite only |
-| Windows Native | Planned, no compatibility guarantee yet |
+| Windows Native | Experimental (mingwX64): artifacts compile and publish, but CI runs no tests on Windows yet — no compatibility guarantee |
 | Wasm | Research, no compatibility guarantee yet |
 
 ## API Stability Levels

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -67,7 +67,10 @@ brew install libpq
 sudo apt-get install libpq-dev
 ```
 
-Windows Native is planned but not shipped yet.
+Windows Native (mingwX64) is experimental: artifacts are published, but CI runs no
+tests on Windows yet. Install a Windows libpq via MSYS2
+(`pacman -S mingw-w64-x86_64-postgresql`) or an EDB PostgreSQL distribution; the cinterop
+searches `C:/msys64/mingw64` and `C:\Program Files\PostgreSQL\15..17`.
 
 ### SQLite Native
 
@@ -87,7 +90,7 @@ sudo apt-get install libsqlite3-dev
 | macOS Native | Yes | libpq | sqlite3 | No | Yes |
 | Android | Yes | No | AndroidX SQLite | No | Compiles |
 | iOS | Yes | No | sqlite3 | No | Compiles |
-| Windows Native | Planned | Planned | Planned | No | Planned |
+| Windows Native | Experimental | libpq (experimental) | sqlite3 (experimental) | No | Experimental |
 | Wasm | Research | No | Planned | No | No |
 
 The CI workflow builds JVM/Linux Native tests on Ubuntu and Android/iOS compilation on

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,7 +82,7 @@ After 1.0 the project should optimize for compatibility and ecosystem fit:
 
 These are useful but should not distract from core reliability:
 
-- Windows Native targets;
+- Windows Native hardening (mingwX64 ships as experimental; needs CI coverage on a Windows runner);
 - Wasm and browser-adjacent storage stories;
 - more SQL dialects;
 - richer schema DSL;

--- a/kormium-core/build.gradle.kts
+++ b/kormium-core/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
     linuxX64()
     macosX64()
     macosArm64()
-    // mingwX64() // deferred — see the publishing plan
+    mingwX64()
 
     applyDefaultHierarchyTemplate()
 

--- a/kormium-ktor-di/build.gradle.kts
+++ b/kormium-ktor-di/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
     linuxX64()
     macosX64()
     macosArm64()
-    // mingwX64() // deferred — see the publishing plan
+    mingwX64()
 
     applyDefaultHierarchyTemplate()
 

--- a/kormium-ktor-koin/build.gradle.kts
+++ b/kormium-ktor-koin/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
     linuxX64()
     macosX64()
     macosArm64()
-    // mingwX64() // deferred — see the publishing plan
+    mingwX64()
 
     applyDefaultHierarchyTemplate()
 

--- a/kormium-ktor/build.gradle.kts
+++ b/kormium-ktor/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
     linuxX64()
     macosX64()
     macosArm64()
-    // mingwX64() // deferred — see the publishing plan
+    mingwX64()
 
     applyDefaultHierarchyTemplate()
 

--- a/kormium-migrate/build.gradle.kts
+++ b/kormium-migrate/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
     linuxX64()
     macosX64()
     macosArm64()
-    // mingwX64() // deferred — see the publishing plan
+    mingwX64()
 
     applyDefaultHierarchyTemplate()
 

--- a/kormium-observe/build.gradle.kts
+++ b/kormium-observe/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
     linuxX64()
     macosX64()
     macosArm64()
-    // mingwX64() // deferred — see the publishing plan
+    mingwX64()
 
     applyDefaultHierarchyTemplate()
 

--- a/kormium-postgres/build.gradle.kts
+++ b/kormium-postgres/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
     // The native Postgres driver talks to libpq via cinterop (formerly the :pgkn module,
     // now folded into this module's nativeMain). Register the same-named "libpq" cinterop
     // on every native target so it commonizes into the shared nativeMain source set.
-    listOf(linuxX64(), macosX64(), macosArm64()).forEach { target ->
+    listOf(linuxX64(), macosX64(), macosArm64(), mingwX64()).forEach { target ->
         target.compilations.getByName("main").cinterops {
             register("libpq") {
                 defFile(project.file("src/nativeInterop/cinterop/libpq.def"))
@@ -32,8 +32,6 @@ kotlin {
         // 2-3x. Linked only when explicitly requested, so regular test/CI builds don't pay for it.
         target.binaries.test("bench", listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.RELEASE))
     }
-    // mingwX64() // deferred — see the publishing plan
-
     applyDefaultHierarchyTemplate()
 
     sourceSets {

--- a/kormium-postgres/src/nativeInterop/cinterop/libpq.def
+++ b/kormium-postgres/src/nativeInterop/cinterop/libpq.def
@@ -10,5 +10,13 @@ linkerOpts.osx = -L/opt/homebrew/opt/libpq/lib -L/usr/local/opt/libpq/lib -lpq
 compilerOpts.linux = -I/usr/include/postgresql/ -I/home/linuxbrew/.linuxbrew/opt/libpq/include -I/opt/homebrew/opt/libpq/include -I/usr/local/opt/libpq/include -lpq
 linkerOpts.linux = -L/usr/lib/x86_64-linux-gnu -L/usr/lib/postgresql/13/lib -L/home/linuxbrew/.linuxbrew/opt/libpq/libpkg-config -L/opt/homebrew/opt/libpq/lib -L/usr/local/opt/libpq/lib -lpq
 
-compilerOpts.mingw = -I"C:\Program Files\PostgreSQL\15\include"
-linkerOpts.mingw = -L"%ProgramFiles%/PostgreSQL/15/lib"
+# Windows: MSYS2 mingw64 libpq (pacman -S mingw-w64-x86_64-postgresql) or an EDB
+# PostgreSQL install. The unix paths at the end let the klib cross-compile from
+# macOS/Linux CI hosts — libpq-fe.h is platform-neutral, and only the final link of a
+# Windows executable needs the real Windows libpq.
+compilerOpts.mingw = -IC:/msys64/mingw64/include \
+    -I"C:\Program Files\PostgreSQL\17\include" -I"C:\Program Files\PostgreSQL\16\include" -I"C:\Program Files\PostgreSQL\15\include" \
+    -I/opt/homebrew/opt/libpq/include -I/usr/local/opt/libpq/include -I/usr/include/postgresql/
+linkerOpts.mingw = -LC:/msys64/mingw64/lib \
+    -L"C:\Program Files\PostgreSQL\17\lib" -L"C:\Program Files\PostgreSQL\16\lib" -L"C:\Program Files\PostgreSQL\15\lib" \
+    -lpq

--- a/kormium-sqlite/build.gradle.kts
+++ b/kormium-sqlite/build.gradle.kts
@@ -57,7 +57,7 @@ kotlin {
     // Register the same-named "sqlite3" cinterop on every native target so it commonizes
     // into the shared nativeMain source set.
     listOf(
-        linuxX64(), macosX64(), macosArm64(),
+        linuxX64(), macosX64(), macosArm64(), mingwX64(),
         iosX64(), iosArm64(), iosSimulatorArm64(),
     ).forEach { target ->
         val konanName = target.konanTarget.name // e.g. linux_x64, macos_arm64, ios_arm64
@@ -105,8 +105,6 @@ kotlin {
         }
         tasks.named("cinteropSqlite3$capName").configure { dependsOn(archiveSqlite) }
     }
-    // mingwX64() // deferred — see the publishing plan
-
     applyDefaultHierarchyTemplate()
 
     sourceSets {

--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ module details.
 | macOS Native | libpq | sqlite3 | Published artifacts for x64 and arm64 |
 | Android | Not shipped | AndroidX SQLite | `kormium-core` and `kormium-sqlite` compile for Android |
 | iOS | Not shipped | sqlite3 | `kormium-core`, `kormium-sqlite` and Ktor integration compile for iOS |
-| Windows Native | Planned | Planned | mingw targets are deferred |
+| Windows Native | libpq (experimental) | sqlite3 (experimental) | mingwX64 artifacts compile and publish; no CI test runs on Windows yet |
 | Wasm | Research | Planned | No shipped backend yet |
 
 ## Minimal Workflow


### PR DESCRIPTION
## Summary

Enables the deferred `mingwX64` target across all multiplatform modules and makes the benchmark suite runnable on Windows.

- **Targets**: `kormium-core`, `kormium-postgres` (libpq cinterop), `kormium-sqlite` (vendored amalgamation built with the K/N mingw toolchain), `kormium-observe`, `kormium-migrate`, Ktor integrations
- **`libpq.def`**: MSYS2 + EDB PostgreSQL paths for Windows, with platform-neutral unix header fallbacks so klibs cross-compile from macOS/Linux hosts; only linking a Windows executable needs the real Windows libpq
- **`benchmarks/run.bat`**: Windows counterpart of `run.sh` — tuned Postgres container, native mingwX64 release benchmark binary with graceful JVM-only fallback, JVM matrix, merged summary table
- **CI**: new step cross-compiles every mingwX64 klib on the Linux runner so the target stays green (no Windows runner yet — nothing executes)
- **Docs**: platform tables move Windows from Planned to Experimental, installation notes, changelog entry; `.gitattributes` pins `*.bat` to CRLF

## Status / honesty

- Verified from macOS: all mingwX64 main + test sources compile, libpq cinterop commonizes, the sqlite mingw test exe links cross-host
- **Not yet executed on real Windows** — the target ships as experimental with no compatibility guarantee (docs say so explicitly)
- Follow-up candidates: a `windows-latest` CI job that links and runs the sqlite tests, and Postgres tests once a Windows service container story exists

## Test plan

- [x] `compileKotlinMingwX64` for all 8 modules from macOS
- [x] `compileTestKotlinMingwX64` for postgres (NativeBenchmark) and sqlite
- [x] `linkDebugTestMingwX64` for sqlite (static, links cross-host)
- [x] Existing macOS native targets still compile after adding the 4th target to commonization
- [ ] `benchmarks\run.bat` on a real Windows machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)