### PR TITLE
ci: run JVM and mingwX64 native tests on a Windows runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,70 @@ jobs:
           path: "**/build/reports/tests/**"
           if-no-files-found: ignore
 
+  # Real test execution on Windows for the experimental mingwX64 target: JVM tests plus
+  # native (mingwX64) tests. The PostgreSQL server preinstalled on the runner image backs
+  # the libpq tests (Linux service containers don't work on Windows runners), and MSYS2
+  # (also preinstalled) provides the mingw libpq the test executables link against — the
+  # same route benchmarks/run.bat documents for users.
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # The Windows K/N toolchain + deps are a multi-hundred-MB download; cache them.
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-windows-kotlin-2.4.0
+
+      - name: Install mingw libpq (MSYS2)
+        run: C:\msys64\usr\bin\pacman.exe -Sy --noconfirm mingw-w64-x86_64-postgresql
+
+      - name: Start the preinstalled PostgreSQL service
+        shell: pwsh
+        run: |
+          $svc = Get-Service postgresql*
+          Set-Service -InputObject $svc -StartupType Manual
+          Start-Service -InputObject $svc
+          & "$env:PGBIN\pg_isready.exe" -h localhost -t 30
+          if ($LASTEXITCODE -ne 0) { throw "PostgreSQL is not accepting connections" }
+
+      - name: JVM tests
+        run: .\gradlew.bat :kormium-core:jvmTest :kormium-sqlite:jvmTest :kormium-migrate:jvmTest --console=plain
+
+      # The runner image's PostgreSQL uses postgres/root credentials (PGUSER/PGPASSWORD).
+      # libpq.dll and its mingw runtime live in C:\msys64\mingw64\bin, so the test
+      # executables need it on PATH.
+      - name: Native (mingwX64) tests
+        shell: pwsh
+        env:
+          KORMIUM_DB_HOST: localhost
+          KORMIUM_DB_PORT: "5432"
+          KORMIUM_DB_NAME: postgres
+          KORMIUM_DB_USER: postgres
+          KORMIUM_DB_PASSWORD: root
+        run: |
+          $env:PATH = "C:\msys64\mingw64\bin;$env:PATH"
+          .\gradlew.bat :kormium-core:mingwX64Test :kormium-postgres:mingwX64Test :kormium-sqlite:mingwX64Test :kormium-migrate:mingwX64Test --console=plain
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-windows
+          path: "**/build/reports/tests/**"
+          if-no-files-found: ignore
+
   # Compose Multiplatform targets (androidTarget + iosX64/iosArm64/iosSimulatorArm64).
   # iOS klibs only compile on a macOS host; the macos-latest runner also ships the Android
   # SDK, so it covers both. The unqualified task names run in every module that declares

--- a/kormium-sqlite/build.gradle.kts
+++ b/kormium-sqlite/build.gradle.kts
@@ -39,12 +39,17 @@ kotlin {
     val konanDataDir = System.getenv("KONAN_DATA_DIR")?.let(::File)
         ?: File(System.getProperty("user.home"), ".konan")
     val konanVersion = "2.4.0"
-    fun runKonan(): String =
-        (konanDataDir.listFiles { f ->
+    // On Windows the distribution ships run_konan.bat, which has to go through cmd /c.
+    fun runKonan(): List<String> {
+        val dist = (konanDataDir.listFiles { f ->
             f.isDirectory && f.name.startsWith("kotlin-native-prebuilt-") && f.name.endsWith(konanVersion)
-        } ?: emptyArray<File>())
-            .firstOrNull()?.resolve("bin/run_konan")?.absolutePath
+        } ?: emptyArray<File>()).firstOrNull()
             ?: error("Kotlin/Native $konanVersion toolchain not found under $konanDataDir")
+        return if (System.getProperty("os.name").startsWith("Windows"))
+            listOf("cmd", "/c", dist.resolve("bin/run_konan.bat").absolutePath)
+        else
+            listOf(dist.resolve("bin/run_konan").absolutePath)
+    }
     val sqliteDefines = listOf(
         "-O2",
         "-DSQLITE_THREADSAFE=1",
@@ -74,7 +79,7 @@ kotlin {
             doFirst {
                 objFile.get().asFile.parentFile.mkdirs()
                 commandLine(
-                    listOf(runKonan(), "clang", "clang", konanName, "-c")
+                    runKonan() + listOf("clang", "clang", konanName, "-c")
                         + sqliteDefines
                         + listOf(sqliteAmalgamation.absolutePath, "-o", objFile.get().asFile.absolutePath),
                 )
@@ -87,8 +92,10 @@ kotlin {
             outputs.file(staticLib)
             doFirst {
                 commandLine(
-                    runKonan(), "llvm", "llvm-ar", "rcs",
-                    staticLib.get().asFile.absolutePath, objFile.get().asFile.absolutePath,
+                    runKonan() + listOf(
+                        "llvm", "llvm-ar", "rcs",
+                        staticLib.get().asFile.absolutePath, objFile.get().asFile.absolutePath,
+                    ),
                 )
             }
         }

--- a/kormium-sqlite/build.gradle.kts
+++ b/kormium-sqlite/build.gradle.kts
@@ -78,11 +78,17 @@ kotlin {
             outputs.file(objFile)
             doFirst {
                 objFile.get().asFile.parentFile.mkdirs()
-                commandLine(
-                    runKonan() + listOf("clang", "clang", konanName, "-c")
-                        + sqliteDefines
-                        + listOf(sqliteAmalgamation.absolutePath, "-o", objFile.get().asFile.absolutePath),
+                // The compiler arguments go through a clang response file: on Windows the
+                // run_konan.bat hop strips `=` from arguments (cmd argument splitting), which
+                // silently destroyed the -DSQLITE_*=1 defines. Forward slashes keep the paths
+                // out of response-file escaping trouble.
+                fun q(f: File) = "\"" + f.absolutePath.replace('\\', '/') + "\""
+                val rsp = objFile.get().asFile.resolveSibling("clang-args.rsp")
+                rsp.writeText(
+                    (sqliteDefines + listOf("-c", q(sqliteAmalgamation), "-o", q(objFile.get().asFile)))
+                        .joinToString("\n"),
                 )
+                commandLine(runKonan() + listOf("clang", "clang", konanName, "@" + rsp.absolutePath))
             }
         }
         val archiveSqlite = tasks.register<Exec>("archiveSqlite3$capName") {


### PR DESCRIPTION
## Summary

Adds a `windows-latest` CI job — the first **real execution** of the experimental mingwX64 target (until now it was only cross-compiled):

- **JVM tests** on Windows: `kormium-core`, `kormium-sqlite`, `kormium-migrate`
- **Native (mingwX64) tests**: `kormium-core`, `kormium-postgres` (libpq), `kormium-sqlite`, `kormium-migrate`
- PostgreSQL server: the one **preinstalled on the runner image** (`postgres`/`root`), since Linux service containers don't work on Windows runners
- mingw libpq for linking/runtime: `pacman -S mingw-w64-x86_64-postgresql` from the preinstalled MSYS2 — the same route `benchmarks/run.bat` documents for users
- Kotlin/Native Windows toolchain cached between runs

If this goes green, the Windows target graduates from "compiles" to "tested in CI" and the docs wording can be upgraded in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)