### PR TITLE
fix: locate Windows libpq for the native benchmark build

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -52,8 +52,12 @@ benchmarks\run.bat [--quick] [--skip-native] [--skip-jvm]
 ```
 
 The native column is built for the experimental mingwX64 target and needs a Windows
-libpq — MSYS2 (`pacman -S mingw-w64-x86_64-postgresql`) or an EDB PostgreSQL install.
-If the native binary cannot be linked, the script warns and runs the JVM matrix only.
+libpq. The easiest route is MSYS2 (`winget install MSYS2.MSYS2`, then
+`C:\msys64\usr\bin\pacman -S mingw-w64-x86_64-postgresql`); an EDB PostgreSQL install
+or anything exposing `pg_config` on PATH also works — the script auto-detects all three
+and passes the paths to Gradle (`-Plibpq.include` / `-Plibpq.lib`, settable manually for
+unusual layouts). Without a libpq the script explains what to install and runs the JVM
+matrix only.
 
 ## JVM-only runs via Gradle
 

--- a/benchmarks/run.bat
+++ b/benchmarks/run.bat
@@ -2,9 +2,11 @@
 rem Windows counterpart of run.sh: the full benchmark matrix — Kormium Native (mingwX64),
 rem Kormium JVM, Exposed and Hibernate — against one tuned PostgreSQL container.
 rem
-rem Prerequisites: Docker Desktop; for the native column, a Windows libpq
-rem (MSYS2: pacman -S mingw-w64-x86_64-postgresql, or an EDB PostgreSQL install —
-rem see kormium-postgres/src/nativeInterop/cinterop/libpq.def for the searched paths).
+rem Prerequisites: Docker Desktop; for the native column, a Windows libpq.
+rem The easiest route is MSYS2:
+rem     winget install MSYS2.MSYS2
+rem     C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-x86_64-postgresql
+rem An EDB PostgreSQL install or anything exposing pg_config on PATH also works.
 rem
 rem Usage: benchmarks\run.bat [--quick] [--skip-native] [--skip-jvm]
 rem   --quick        fast indicative run — for checking the setup, not for quoting
@@ -56,10 +58,44 @@ set "KORMIUM_DB_PASSWORD=password"
 
 if defined SKIP_NATIVE goto jvm
 
+rem --- Locate a Windows libpq: headers for the cinterop, import lib for linking, dll
+rem --- for runtime. Checked in order: MSYS2, EDB installs, pg_config on PATH.
+set "LIBPQ_INCLUDE="
+set "LIBPQ_LIB="
+set "LIBPQ_BIN="
+if exist "C:\msys64\mingw64\include\libpq-fe.h" (
+  set "LIBPQ_BIN=C:\msys64\mingw64\bin"
+  goto libpq_found
+)
+for %%V in (18 17 16 15 14) do (
+  if not defined LIBPQ_INCLUDE if exist "%ProgramFiles%\PostgreSQL\%%V\include\libpq-fe.h" (
+    set "LIBPQ_INCLUDE=%ProgramFiles%\PostgreSQL\%%V\include"
+    set "LIBPQ_LIB=%ProgramFiles%\PostgreSQL\%%V\lib"
+    set "LIBPQ_BIN=%ProgramFiles%\PostgreSQL\%%V\bin"
+  )
+)
+if defined LIBPQ_INCLUDE goto libpq_found
+for /f "delims=" %%I in ('pg_config --includedir 2^>nul') do set "LIBPQ_INCLUDE=%%I"
+for /f "delims=" %%I in ('pg_config --libdir 2^>nul') do set "LIBPQ_LIB=%%I"
+for /f "delims=" %%I in ('pg_config --bindir 2^>nul') do set "LIBPQ_BIN=%%I"
+if defined LIBPQ_INCLUDE goto libpq_found
+
+echo WARNING: no Windows libpq found - skipping the native benchmark. 1>&2
+echo WARNING: install it via MSYS2: 1>&2
+echo WARNING:     winget install MSYS2.MSYS2 1>&2
+echo WARNING:     C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-x86_64-postgresql 1>&2
+echo WARNING: or install PostgreSQL (EDB) so that "%%ProgramFiles%%\PostgreSQL\NN" exists. 1>&2
+goto jvm
+
+:libpq_found
+set "LIBPQ_PROPS="
+if defined LIBPQ_INCLUDE set LIBPQ_PROPS="-Plibpq.include=%LIBPQ_INCLUDE%" "-Plibpq.lib=%LIBPQ_LIB%"
+
 echo ==^> Building native benchmark binary (mingwX64, release)
-call gradlew.bat -q :kormium-postgres:linkBenchReleaseTestMingwX64
+call gradlew.bat -q :kormium-postgres:linkBenchReleaseTestMingwX64 %LIBPQ_PROPS%
 if errorlevel 1 (
-  echo WARNING: native binary failed to link - is a Windows libpq installed? Continuing JVM-only. 1>&2
+  echo WARNING: native binary failed to build/link - see the Gradle output above. 1>&2
+  echo WARNING: Continuing with the JVM-only matrix. 1>&2
   goto jvm
 )
 set "KEXE=kormium-postgres\build\bin\mingwX64\benchReleaseTest\test.exe"
@@ -69,9 +105,8 @@ if not exist "%KEXE%" (
 )
 
 echo ==^> Running native benchmark
-rem The exe loads libpq.dll at runtime; put the usual install locations on PATH
-rem (linking found the import lib, but the loader searches PATH, not linker paths).
-set "PATH=C:\msys64\mingw64\bin;%ProgramFiles%\PostgreSQL\17\bin;%ProgramFiles%\PostgreSQL\16\bin;%ProgramFiles%\PostgreSQL\15\bin;%PATH%"
+rem The exe loads libpq.dll at runtime; the loader searches PATH, not linker paths.
+if defined LIBPQ_BIN set "PATH=%LIBPQ_BIN%;%PATH%"
 set "KORM_BENCH=1"
 if defined QUICK (set "KORM_BENCH_OPS=500") else (set "KORM_BENCH_OPS=")
 set "NATIVE_LOG=%TEMP%\kormium-native-bench.log"
@@ -82,8 +117,7 @@ set "KORM_BENCH="
 if not "%KEXE_EXIT%"=="0" (
   echo.
   echo WARNING: native benchmark exited with code %KEXE_EXIT%. 1>&2
-  echo WARNING: if the log above is empty, libpq.dll was not found - install MSYS2 libpq 1>&2
-  echo WARNING: ^(pacman -S mingw-w64-x86_64-postgresql^) or add your PostgreSQL bin dir to PATH. 1>&2
+  echo WARNING: if the log above is empty, libpq.dll was not loadable from %LIBPQ_BIN%. 1>&2
 )
 
 rem "KORM_NATIVE_RESULT findById=123 ..." -> {"findById": 123, ...}

--- a/benchmarks/run.bat
+++ b/benchmarks/run.bat
@@ -98,9 +98,11 @@ if errorlevel 1 (
   echo WARNING: Continuing with the JVM-only matrix. 1>&2
   goto jvm
 )
-set "KEXE=kormium-postgres\build\bin\mingwX64\benchReleaseTest\test.exe"
-if not exist "%KEXE%" (
-  echo WARNING: %KEXE% not found, skipping the native benchmark 1>&2
+rem The binary is named after the "bench" test binary (bench.exe); glob to be safe.
+set "KEXE="
+for %%F in ("kormium-postgres\build\bin\mingwX64\benchReleaseTest\*.exe") do set "KEXE=%%~fF"
+if not defined KEXE (
+  echo WARNING: no .exe in kormium-postgres\build\bin\mingwX64\benchReleaseTest - skipping the native benchmark 1>&2
   goto jvm
 )
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,7 +70,8 @@ sudo apt-get install libpq-dev
 Windows Native (mingwX64) is experimental: CI runs the JVM and native test suites on a
 Windows runner. Install a Windows libpq via MSYS2
 (`pacman -S mingw-w64-x86_64-postgresql`) or an EDB PostgreSQL distribution; the cinterop
-searches `C:/msys64/mingw64` and `C:\Program Files\PostgreSQL\15..17`.
+searches `C:/msys64/mingw64` and `C:\Program Files\PostgreSQL\15..17`. For other
+layouts pass `-Plibpq.include=<dir>` and `-Plibpq.lib=<dir>` to Gradle.
 
 ### SQLite Native
 

--- a/kormium-postgres/build.gradle.kts
+++ b/kormium-postgres/build.gradle.kts
@@ -18,6 +18,21 @@ kotlin {
         }
     }
 
+    val isWindowsHost = System.getProperty("os.name").startsWith("Windows")
+    // The libpq artifact Windows test binaries link against, preferring the dynamic
+    // library: import lib, then the DLL itself (lld links DLLs directly), then the MSVC
+    // import lib. -Plibpq.lib=<dir> (set by benchmarks/run.bat) takes precedence over
+    // the known MSYS2 / EDB install locations.
+    val windowsLibpqArtifact: String? by lazy {
+        val roots = listOfNotNull((findProperty("libpq.lib") as String?)?.let { file(it).parentFile }) +
+            listOf(file("C:/msys64/mingw64")) +
+            (18 downTo 14).map { file("${System.getenv("ProgramFiles") ?: "C:/Program Files"}/PostgreSQL/$it") }
+        roots.firstNotNullOfOrNull { root ->
+            listOf("lib/libpq.dll.a", "bin/libpq.dll", "lib/libpq.lib")
+                .map(root::resolve).firstOrNull { it.isFile }
+        }?.absolutePath?.replace('\\', '/')
+    }
+
     // The native Postgres driver talks to libpq via cinterop (formerly the :pgkn module,
     // now folded into this module's nativeMain). Register the same-named "libpq" cinterop
     // on every native target so it commonizes into the shared nativeMain source set.
@@ -31,9 +46,21 @@ kotlin {
                 (findProperty("libpq.include") as String?)?.let { compilerOpts("-I$it") }
             }
         }
-        // cinterop ignores linker options; the lib dir applies when test binaries link.
-        (findProperty("libpq.lib") as String?)?.let { dir ->
-            target.binaries.all { linkerOpts("-L$dir") }
+        // cinterop ignores linker options; libpq is supplied when test binaries link.
+        // On Windows the artifact is chosen explicitly (see windowsLibpqArtifact): a bare
+        // -L/-lpq can pick the static libpq.a, whose bundled pthread shim duplicates
+        // Kotlin/Native's libwinpthread symbols.
+        if (target.name == "mingwX64" && isWindowsHost) {
+            target.binaries.all {
+                windowsLibpqArtifact?.let { linkerOpts(it) } ?: logger.warn(
+                    "kormium-postgres: no Windows libpq found; install MSYS2 " +
+                        "mingw-w64-x86_64-postgresql or pass -Plibpq.lib=<dir>",
+                )
+            }
+        } else {
+            (findProperty("libpq.lib") as String?)?.let { dir ->
+                target.binaries.all { linkerOpts("-L$dir") }
+            }
         }
         // Optimized test binary (linkBenchReleaseTest<Target>) for benchmarks/run.sh: the default
         // debug test kexe is unoptimized K/N code and misrepresents CPU-bound throughput by

--- a/kormium-postgres/build.gradle.kts
+++ b/kormium-postgres/build.gradle.kts
@@ -25,7 +25,15 @@ kotlin {
         target.compilations.getByName("main").cinterops {
             register("libpq") {
                 defFile(project.file("src/nativeInterop/cinterop/libpq.def"))
+                // Non-standard libpq locations (mainly custom Windows installs): pass
+                // -Plibpq.include=<dir> and -Plibpq.lib=<dir>. benchmarks/run.bat fills
+                // these in automatically from pg_config / known install paths.
+                (findProperty("libpq.include") as String?)?.let { compilerOpts("-I$it") }
             }
+        }
+        // cinterop ignores linker options; the lib dir applies when test binaries link.
+        (findProperty("libpq.lib") as String?)?.let { dir ->
+            target.binaries.all { linkerOpts("-L$dir") }
         }
         // Optimized test binary (linkBenchReleaseTest<Target>) for benchmarks/run.sh: the default
         // debug test kexe is unoptimized K/N code and misrepresents CPU-bound throughput by

--- a/kormium-postgres/src/nativeInterop/cinterop/libpq.def
+++ b/kormium-postgres/src/nativeInterop/cinterop/libpq.def
@@ -14,9 +14,11 @@ linkerOpts.linux = -L/usr/lib/x86_64-linux-gnu -L/usr/lib/postgresql/13/lib -L/h
 # PostgreSQL install. The unix paths at the end let the klib cross-compile from
 # macOS/Linux CI hosts — libpq-fe.h is platform-neutral, and only the final link of a
 # Windows executable needs the real Windows libpq.
+#
+# Deliberately no linkerOpts.mingw: a bare -lpq can resolve to the *static* libpq.a,
+# whose bundled win32 pthread shim collides with Kotlin/Native's libwinpthread at link
+# time (duplicate pthread_* symbols). kormium-postgres/build.gradle.kts picks the
+# dynamic artifact (libpq.dll.a / libpq.dll / libpq.lib) explicitly on Windows hosts.
 compilerOpts.mingw = -IC:/msys64/mingw64/include \
-    -I"C:\Program Files\PostgreSQL\17\include" -I"C:\Program Files\PostgreSQL\16\include" -I"C:\Program Files\PostgreSQL\15\include" \
+    -I"C:\Program Files\PostgreSQL\18\include" -I"C:\Program Files\PostgreSQL\17\include" -I"C:\Program Files\PostgreSQL\16\include" -I"C:\Program Files\PostgreSQL\15\include" \
     -I/opt/homebrew/opt/libpq/include -I/usr/local/opt/libpq/include -I/usr/include/postgresql/
-linkerOpts.mingw = -LC:/msys64/mingw64/lib \
-    -L"C:\Program Files\PostgreSQL\17\lib" -L"C:\Program Files\PostgreSQL\16\lib" -L"C:\Program Files\PostgreSQL\15\lib" \
-    -lpq


### PR DESCRIPTION
"libpq-fe.h file not found" on machines without MSYS2 libpq or an EDB
install in the paths hardcoded in libpq.def. run.bat now detects libpq
before building — MSYS2, Program Files\PostgreSQL\14..18, then
pg_config on PATH — passes the dirs to Gradle and prints actionable
install instructions (winget MSYS2 + pacman) when nothing is found,
instead of dying inside cinterop with a clang error.

Gradle side: -Plibpq.include feeds the cinterop compilerOpts and
-Plibpq.lib the test binaries' linkerOpts (cinterop itself ignores
linker options), so unusual layouts work on any host.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
