### PR TITLE
feat(native): Windows true-async reactor (winsock2 WSAPoll via C bridge)

### DIFF
--- a/kormium-postgres/WINDOWS_ASYNC_NOTES.md
+++ b/kormium-postgres/WINDOWS_ASYNC_NOTES.md
@@ -1,0 +1,34 @@
+# Windows true-async reactor — notes
+
+Linux/macOS and Windows all have a true-async libpq path: a poll-based socket reactor
+(`SocketReactorBase` + `UnixSocketReactor` on Unix, `WindowsSocketReactor` on mingwX64).
+`createSocketReactor()` returns a real reactor on every native target, so the driver never
+needs the blocking offload for its suspend path.
+
+## The Windows cinterop problem (resolved)
+
+Kotlin/Native's `platform.windows` does **not** expose `WSAPoll`/`WSADATA`/`SOCKET`/etc, and a
+direct cinterop on the system `<winsock2.h>` produces an **empty binding package**: cinterop
+runs without error yet the compiler resolves none of `SOCKET`, `socket`, `WSAPoll`,
+`sockaddr_in`, ... (confirmed identical on macOS/Linux cross-compile and a native Windows host).
+`headerFilter` variants, `-D_WIN32_WINNT`, `-DWIN32_LEAN_AND_MEAN`, and explicit sysroot `-I`
+all left the package empty. `klib dump-abi`/`contents` report 0 even for the working libpq
+cinterop, so only the compiler is ground truth.
+
+## Solution: project-owned C shim
+
+`src/nativeInterop/cinterop/winsock_shim.h` `#include`s `<winsock2.h>`/`<ws2tcpip.h>` and wraps
+the calls the reactor needs behind a small `ksock_*` API of `static inline` functions. cinterop
+emits declarations from a **project-owned** header (matched by `headerFilter`), unlike a system
+header, and compiles the inline bodies into the generated stub klib — so no separate `.c` or
+extra link step beyond `-lws2_32`. The whole Winsock surface (`SOCKET` handles, `sockaddr_in`,
+`WSAPOLLFD`, the `POLL*` flags) stays in C; Kotlin sees only opaque 64-bit handles (`ksock_t`)
+and a flat `ksock_pollfd`.
+
+The wake channel is a loopback UDP socket `connect()`ed to its own bound address, so signalling
+is a plain `send()` and draining a `recv()` loop (Winsock cannot poll a pipe). `WindowsSocketReactor`
+drives that API; `winsock.def`/`build.gradle.kts` register the cinterop with the cinterop dir on
+the include path.
+
+Verified on a native Windows host: `cinteropWinsockMingwX64`, `compileKotlinMingwX64`, and
+`linkDebugTestMingwX64` all succeed (`ws2_32` + libpq link clean).

--- a/kormium-postgres/build.gradle.kts
+++ b/kormium-postgres/build.gradle.kts
@@ -45,6 +45,16 @@ kotlin {
                 // these in automatically from pg_config / known install paths.
                 (findProperty("libpq.include") as String?)?.let { compilerOpts("-I$it") }
             }
+            // winsock2 bridge for the Windows async reactor (WSAPoll). A direct cinterop on the
+            // system <winsock2.h> yields an empty binding package, so we cinterop a project-owned
+            // shim header (winsock_shim.h) that wraps the calls — see WINDOWS_ASYNC_NOTES.md.
+            // Only the mingw target registers it.
+            if (target.name == "mingwX64") {
+                register("winsock") {
+                    defFile(project.file("src/nativeInterop/cinterop/winsock.def"))
+                    includeDirs(project.file("src/nativeInterop/cinterop"))
+                }
+            }
         }
         // cinterop ignores linker options; libpq is supplied when test binaries link.
         // On Windows the artifact is chosen explicitly (see windowsLibpqArtifact): a bare

--- a/kormium-postgres/src/mingwX64Main/kotlin/io/github/kormium/postgres/async/WindowsSocketReactor.kt
+++ b/kormium-postgres/src/mingwX64Main/kotlin/io/github/kormium/postgres/async/WindowsSocketReactor.kt
@@ -1,10 +1,66 @@
 package io.github.kormium.postgres.async
 
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import winsock.KSOCK_EV_ERR
+import winsock.KSOCK_EV_READ
+import winsock.KSOCK_EV_WRITE
+import winsock.KSOCK_INVALID
+import winsock.ksock_cleanup
+import winsock.ksock_close
+import winsock.ksock_drain_wake
+import winsock.ksock_open_wake
+import winsock.ksock_poll
+import winsock.ksock_pollfd
+import winsock.ksock_signal_wake
+import winsock.ksock_startup
+import winsock.ksock_t
+import kotlin.concurrent.Volatile
+
 /**
- * Windows has no socket reactor yet (Kotlin/Native does not expose WSAPoll and a winsock2
- * cinterop produced empty bindings on every host — see the feat/native-async-windows-wip
- * branch). Returning null makes the driver use the blocking offload for useConnection on
- * Windows, exactly as it did before the async path existed. No regression; true-async on
- * Windows is a follow-up.
+ * Windows reactor: WSAPoll over the waiter sockets plus a loopback UDP socket used as the wake
+ * channel (Winsock cannot poll a pipe, so signalling is a self-addressed datagram). The Winsock
+ * surface lives behind the project-owned `winsock` cinterop shim (`ksock_*`); Kotlin/Native's
+ * platform.windows does not expose WSAPoll and a direct system-header cinterop binds nothing.
  */
-internal actual fun createSocketReactor(): SocketReactorBase? = null
+@OptIn(ExperimentalForeignApi::class)
+internal class WindowsSocketReactor : SocketReactorBase() {
+
+    @Volatile
+    private var wakeSock: ksock_t = KSOCK_INVALID
+
+    override fun openWake() {
+        check(ksock_startup() == 0) { "WSAStartup failed" }
+        wakeSock = ksock_open_wake()
+        check(wakeSock != KSOCK_INVALID) { "wake socket setup failed" }
+    }
+
+    override fun signalWake() {
+        ksock_signal_wake(wakeSock)
+    }
+
+    override fun pollWaiters(fds: IntArray, events: IntArray): BooleanArray = memScoped {
+        val count = fds.size + 1
+        val arr = allocArray<ksock_pollfd>(count)
+        arr[0].fd = wakeSock
+        arr[0].events = KSOCK_EV_READ.toShort()
+        for (i in fds.indices) {
+            arr[i + 1].fd = fds[i].convert()
+            arr[i + 1].events = (if (events[i] == EV_WRITE) KSOCK_EV_WRITE else KSOCK_EV_READ).toShort()
+        }
+        ksock_poll(arr, count.convert(), -1)
+        if (arr[0].revents.toInt() and KSOCK_EV_READ != 0) ksock_drain_wake(wakeSock)
+        val readyMask = KSOCK_EV_READ or KSOCK_EV_WRITE or KSOCK_EV_ERR
+        BooleanArray(fds.size) { (arr[it + 1].revents.toInt() and readyMask) != 0 }
+    }
+
+    override fun closeWake() {
+        if (wakeSock != KSOCK_INVALID) ksock_close(wakeSock)
+        ksock_cleanup()
+    }
+}
+
+internal actual fun createSocketReactor(): SocketReactorBase? = WindowsSocketReactor().apply { start() }

--- a/kormium-postgres/src/nativeInterop/cinterop/winsock.def
+++ b/kormium-postgres/src/nativeInterop/cinterop/winsock.def
@@ -1,0 +1,4 @@
+headers = winsock_shim.h
+package = winsock
+headerFilter = winsock_shim.h
+linkerOpts.mingw = -lws2_32

--- a/kormium-postgres/src/nativeInterop/cinterop/winsock_shim.h
+++ b/kormium-postgres/src/nativeInterop/cinterop/winsock_shim.h
@@ -1,0 +1,145 @@
+#ifndef KORMIUM_WINSOCK_SHIM_H
+#define KORMIUM_WINSOCK_SHIM_H
+
+/*
+ * Project-owned Winsock bridge for the Windows async reactor.
+ *
+ * Kotlin/Native's platform.windows does not expose WSAPoll/WSADATA/SOCKET, and a direct
+ * cinterop on the system <winsock2.h> yields an empty binding package (see
+ * WINDOWS_ASYNC_NOTES.md). cinterop *does* emit declarations from a project-owned header,
+ * so this header wraps the handful of Winsock calls the reactor needs behind a small
+ * `ksock_*` API. The wrappers are `static inline`, so cinterop compiles them into the
+ * generated stub klib — no separate .c file or link step beyond -lws2_32.
+ *
+ * The whole Winsock surface (SOCKET handles, sockaddr_in, WSAPOLLFD, the self-addressed
+ * wake datagram) stays in C; Kotlin only sees opaque 64-bit handles and a flat poll struct.
+ */
+
+/* WSAPoll requires Windows Vista+ (0x0600). Set before any Windows header is pulled in. */
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Opaque socket handle. SOCKET is UINT_PTR (64-bit on x64); carry it as a fixed-width int. */
+typedef uint64_t ksock_t;
+
+/* Sentinel for an unopened/failed socket (mirrors INVALID_SOCKET == (SOCKET)~0). */
+#define KSOCK_INVALID ((ksock_t)~(uint64_t)0)
+
+/* Interest/readiness bits, mapped to/from the WSAPoll POLL* flags inside ksock_poll. */
+#define KSOCK_EV_READ  1
+#define KSOCK_EV_WRITE 2
+#define KSOCK_EV_ERR   4
+
+/* One entry per socket for ksock_poll; parallel to WSAPOLLFD but with our own event bits. */
+typedef struct {
+    ksock_t fd;
+    int16_t events;
+    int16_t revents;
+} ksock_pollfd;
+
+/* Initialise Winsock 2.2. Returns 0 on success, the WSAStartup error code otherwise. */
+static inline int ksock_startup(void) {
+    WSADATA wsa;
+    return WSAStartup(MAKEWORD(2, 2), &wsa);
+}
+
+static inline void ksock_cleanup(void) {
+    WSACleanup();
+}
+
+static inline int ksock_is_valid(ksock_t s) {
+    return s != KSOCK_INVALID;
+}
+
+/*
+ * Create the wake channel: a loopback UDP socket bound to an OS-assigned port, then
+ * connect()ed to its own address so a plain send() targets itself. Set non-blocking so
+ * draining the wake byte(s) never stalls the reactor. Returns KSOCK_INVALID on failure.
+ */
+static inline ksock_t ksock_open_wake(void) {
+    SOCKET s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (s == INVALID_SOCKET) return KSOCK_INVALID;
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0; /* ask the OS for an ephemeral port */
+
+    if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+        closesocket(s);
+        return KSOCK_INVALID;
+    }
+
+    /* Read back the assigned port, then connect to ourselves so send()/recv() work. */
+    int len = (int)sizeof(addr);
+    if (getsockname(s, (struct sockaddr *)&addr, &len) != 0 ||
+        connect(s, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+        closesocket(s);
+        return KSOCK_INVALID;
+    }
+
+    u_long nonblocking = 1;
+    ioctlsocket(s, FIONBIO, &nonblocking);
+    return (ksock_t)s;
+}
+
+static inline void ksock_signal_wake(ksock_t s) {
+    char b = 1;
+    send((SOCKET)s, &b, 1, 0);
+}
+
+static inline void ksock_drain_wake(ksock_t s) {
+    char buf[64];
+    while (recv((SOCKET)s, buf, (int)sizeof(buf), 0) > 0) { /* drain all queued wakes */ }
+}
+
+static inline void ksock_close(ksock_t s) {
+    closesocket((SOCKET)s);
+}
+
+/*
+ * WSAPoll over count entries; timeout_ms < 0 blocks indefinitely. Translates our event
+ * bits to/from the Winsock POLL* flags. Returns the WSAPoll result (>0 ready, 0 timeout,
+ * SOCKET_ERROR on error).
+ */
+static inline int ksock_poll(ksock_pollfd *fds, unsigned int count, int timeout_ms) {
+    if (count == 0) return 0;
+    WSAPOLLFD *wfds = (WSAPOLLFD *)malloc(sizeof(WSAPOLLFD) * count);
+    if (wfds == NULL) return SOCKET_ERROR;
+
+    for (unsigned int i = 0; i < count; i++) {
+        wfds[i].fd = (SOCKET)fds[i].fd;
+        SHORT ev = 0;
+        if (fds[i].events & KSOCK_EV_READ) ev |= POLLRDNORM;
+        if (fds[i].events & KSOCK_EV_WRITE) ev |= POLLWRNORM;
+        wfds[i].events = ev;
+        wfds[i].revents = 0;
+    }
+
+    int rc = WSAPoll(wfds, count, timeout_ms);
+
+    for (unsigned int i = 0; i < count; i++) {
+        SHORT re = wfds[i].revents;
+        int16_t out = 0;
+        if (re & (POLLRDNORM | POLLIN)) out |= KSOCK_EV_READ;
+        if (re & (POLLWRNORM | POLLOUT)) out |= KSOCK_EV_WRITE;
+        if (re & (POLLERR | POLLHUP | POLLNVAL)) out |= KSOCK_EV_ERR;
+        fds[i].revents = out;
+    }
+
+    free(wfds);
+    return rc;
+}
+
+#endif /* KORMIUM_WINSOCK_SHIM_H */

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/PostgresDriver.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/PostgresDriver.kt
@@ -152,10 +152,10 @@ private class PostgresDriverImpl(
     override fun <R> usePinned(transactional: Boolean, block: (SqlExecutor) -> R): R =
         connectionPool.runPinned(transactional, block)
 
-    // useConnection: when a reactor exists (Unix), run truly async — borrow by suspending on the
-    // pool Channel, drive every statement and BEGIN/COMMIT/ROLLBACK through the reactor (the
-    // coroutine thread is freed during each network wait), cleaning up under NonCancellable.
-    // When there is no reactor (Windows), fall back to the core blocking offload.
+    // useConnection: when a reactor exists (Unix poll, Windows WSAPoll), run truly async — borrow
+    // by suspending on the pool Channel, drive every statement and BEGIN/COMMIT/ROLLBACK through
+    // the reactor (the coroutine thread is freed during each network wait), cleaning up under
+    // NonCancellable. When there is no reactor, fall back to the core blocking offload.
     override suspend fun <R> useConnection(transactional: Boolean, block: suspend (SuspendSqlExecutor) -> R): R {
         val activeReactor = reactor ?: return connectionPool.runConnection(transactional, block)
         val conn = acquireConnectionSuspending()

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/async/SocketReactorBase.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/async/SocketReactorBase.kt
@@ -108,8 +108,7 @@ internal abstract class SocketReactorBase : AutoCloseable {
 }
 
 /**
- * Builds the platform reactor, or null on platforms without one (Windows, currently — see
- * WINDOWS_ASYNC_NOTES on the feat/native-async-windows-wip branch). A null reactor makes the
- * driver fall back to the blocking offload for its suspend path.
+ * Builds the platform reactor (poll on Unix, WSAPoll on Windows), or null on platforms without
+ * one — in which case the driver falls back to the blocking offload for its suspend path.
  */
 internal expect fun createSocketReactor(): SocketReactorBase?


### PR DESCRIPTION
Gives Windows the same true-async libpq path Linux/macOS have (#70): a `WindowsSocketReactor : SocketReactorBase` using `WSAPoll` over the in-flight sockets plus a loopback-UDP wake socket. `createSocketReactor()` now returns a real reactor on mingwX64 instead of falling back to the blocking offload.

## The blocker (now resolved)
A direct cinterop on the system `<winsock2.h>` produced an **empty binding package** — cinterop ran clean but the compiler resolved none of `SOCKET`/`WSAPoll`/`sockaddr_in`/... (confirmed identical on macOS cross-compile, the Linux CI job, and a native Windows runner, so it was a cinterop-config issue, not a host difference).

## Fix: project-owned C shim
`kormium-postgres/src/nativeInterop/cinterop/winsock_shim.h` `#include`s `<winsock2.h>`/`<ws2tcpip.h>` and wraps the handful of calls the reactor needs behind a small `ksock_*` API of `static inline` functions. cinterop **does** emit declarations from a project-owned header (matched by `headerFilter`), unlike a system header, and compiles the inline bodies into the generated stub klib — so no separate `.c` and no link step beyond `-lws2_32`.

The whole Winsock surface (`SOCKET` handles, `sockaddr_in`, `WSAPOLLFD`, the `POLL*` flags) stays in C; Kotlin sees only opaque 64-bit handles (`ksock_t`) and a flat `ksock_pollfd`. The wake channel is a loopback UDP socket `connect()`ed to its own bound address, so signalling is a plain `send()` and draining a `recv()` loop (Winsock can't poll a pipe) — which also removed the fragile `sin_addr.S_un.S_addr` field-poking from the Kotlin side.

## Verification
Built on a native Windows host (JDK 17, auto-fetched K/N toolchain):
- `cinteropWinsockMingwX64` — binds every symbol (the original blocker)
- `compileKotlinMingwX64`
- `linkDebugTestMingwX64` — `ws2_32` + libpq link clean

All green, including a full `--rerun-tasks` after rebasing onto current `main`.

Rebased onto `main` (past the `io.github.moreirasantos.pgkn` → `io.github.kormium.postgres` package rename) and squashed to one commit. Stale "Windows falls back to blocking offload" comments and `WINDOWS_ASYNC_NOTES.md` updated to reflect the resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)