### PR TITLE
feat(mysql): add MySQL/MariaDB engine (JDBC + native libmariadb + r2dbc)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,22 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
+      # Backs the native (libmariadb) MySQL tests. MariaDB uses mysql_native_password, so the
+      # native client connects over plaintext without the caching_sha2 public-key dance.
+      mysql:
+        image: mariadb:11
+        env:
+          MARIADB_ROOT_PASSWORD: password
+          MARIADB_DATABASE: kormium_test
+          MARIADB_USER: kormium
+          MARIADB_PASSWORD: kormium
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "healthcheck.sh --connect --innodb_initialized"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
       - uses: actions/checkout@v4
@@ -31,8 +47,8 @@ jobs:
           distribution: temurin
           java-version: "21"
 
-      - name: Install libpq + libsqlite3 (for the Kotlin/Native cinterops)
-        run: sudo apt-get update && sudo apt-get install -y libpq-dev libsqlite3-dev
+      - name: Install libpq + libsqlite3 + libmariadb (for the Kotlin/Native cinterops)
+        run: sudo apt-get update && sudo apt-get install -y libpq-dev libsqlite3-dev libmariadb-dev
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -52,7 +68,13 @@ jobs:
           KORMIUM_DB_NAME: postgres
           KORMIUM_DB_USER: postgres
           KORMIUM_DB_PASSWORD: password
-        run: ./gradlew :kormium-core:linuxX64Test :kormium-postgres:linuxX64Test :kormium-sqlite:linuxX64Test :kormium-migrate:linuxX64Test --console=plain
+          # kormium-mysql's native tests read MYSQL_* and run against the MariaDB service above.
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_PORT: "3306"
+          MYSQL_DB: kormium_test
+          MYSQL_USER: kormium
+          MYSQL_PASSWORD: kormium
+        run: ./gradlew :kormium-core:linuxX64Test :kormium-postgres:linuxX64Test :kormium-sqlite:linuxX64Test :kormium-migrate:linuxX64Test :kormium-mysql:linuxX64Test --console=plain
 
       # The ktor integration libraries are libraries (no native exe link), so assemble
       # builds their JVM + native artifacts to verify they compile on every target.
@@ -79,6 +101,10 @@ jobs:
       # Testcontainers.
       - name: r2dbc tests (Testcontainers, JVM)
         run: ./gradlew :kormium-r2dbc:jvmTest --console=plain
+
+      # MySQL JVM (JDBC) end-to-end tests spin up their own MySQL via Testcontainers.
+      - name: MySQL JVM tests (Testcontainers, JVM)
+        run: ./gradlew :kormium-mysql:jvmTest --console=plain
 
       # Postgres samples — JVM end-to-end tests spin up their own Postgres via Testcontainers.
       # samples:r2dbc is the async variant of ktor-di.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,8 @@ jobs:
           distribution: temurin
           java-version: "21"
 
-      - name: Install libpq (for the Kotlin/Native libpq cinterop)
-        run: brew install libpq
+      - name: Install libpq + mariadb-connector-c (for the Kotlin/Native cinterops)
+        run: brew install libpq mariadb-connector-c
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ All notable changes to Kormium are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **New engine: MySQL / MariaDB (`kormium-mysql`).** A second full database engine, mirroring
+  `kormium-postgres`, with `MySqlDialect` (backtick identifiers, MySQL `LIMIT`/`OFFSET`), the
+  `MySqlDriver` interface and a `createDatabase(...)` factory across three backends:
+  - **JVM (JDBC)** over `mysql-connector-j` — typed parameter binding, vendor-code exception
+    mapping (1062 → `UniqueViolationException`, 1452 → `ForeignKeyViolationException`, …), and a
+    UTC-pinned session so `Instant` round-trips through `TIMESTAMP`.
+  - **Native (Linux/macOS)** over the MariaDB Connector/C (`libmariadb`, API-compatible with
+    `libmysqlclient`) using prepared statements (`mysql_stmt_*`). The suspend path offloads to the
+    IO dispatcher (libmysql has no portable non-blocking API), as PostgreSQL Native does on Windows.
+    Windows native is not built (served by the JVM driver).
+  - **R2DBC** via `createMySqlR2dbcDatabase(...)` in `kormium-r2dbc` (now multi-backend), over
+    `io.asyncer:r2dbc-mysql`.
+
+  UUIDs are stored as `CHAR(36)` text and JSON as MySQL's native `JSON`. There is no
+  transaction-scoped advisory lock (MySQL `GET_LOCK` is session-scoped), so `kormium-migrate` runs
+  without one on MySQL (as on SQLite).
+
+### Changed
+- **Core: `Dialect` gained write-path rendering hooks** so the INSERT family is no longer
+  hardcoded to Postgres/SQLite syntax: `renderLimitOffset(limit, offset)` (a bare `OFFSET` without
+  `LIMIT` is a MySQL syntax error), `supportsReturning`, `renderInsertDefaultValues`,
+  `renderUpsertSuffix` and `renderInsertOrIgnoreSuffix`. All have defaults equal to the previous
+  behaviour, so Standard / Postgres / SQLite output is unchanged. `MySqlDialect` overrides them
+  (`() VALUES ()`, `ON DUPLICATE KEY UPDATE`, and — since MySQL has no `RETURNING` —
+  `insert/upsert(returning = true)` re-selects the row by primary key).
+- **`kormium-migrate`: journal `id` column is now `varchar(255)`** (was `text`). MySQL forbids a
+  `TEXT` primary key without a prefix length; `varchar(255)` is equally valid on Postgres and SQLite.
+
 ## [0.6.0] — Native driver hardening and true-async reads
 
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,7 @@ allprojects {
 val publishableModules = setOf(
     "kormium-core",
     "kormium-postgres",
+    "kormium-mysql",
     "kormium-jdbc",
     "kormium-sqlite",
     "kormium-r2dbc",

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -41,6 +41,46 @@ PostgreSQL notes:
 - On Kotlin/Native, libpq sends parameters as text and the dialect adds the needed
   `::type` casts.
 
+## MySQL / MariaDB
+
+Artifact:
+
+```kotlin
+implementation("io.github.kormium:kormium-mysql")
+```
+
+Factory:
+
+```kotlin
+val db: Database<App> = createDatabase(
+    host = "localhost",
+    port = 3306,
+    database = "app",
+    user = "root",
+    password = "password",
+    poolSize = 10,
+)
+```
+
+Implementations:
+
+- JVM: `mysql-connector-j` plus HikariCP through `kormium-jdbc`.
+- Kotlin/Native (Linux/macOS): MariaDB Connector/C (`libmariadb`) cinterop using prepared
+  statements. Windows is served by the JVM driver.
+- Async on JVM: `createMySqlR2dbcDatabase(...)` in `kormium-r2dbc` over `io.asyncer:r2dbc-mysql`.
+
+Native builds need `libmariadb` headers/libraries on the build machine
+(`brew install mariadb-connector-c` / `apt-get install libmariadb-dev`).
+
+MySQL notes:
+
+- UUID is stored as `CHAR(36)`; JSON uses the native `JSON` type. The session is pinned to UTC so
+  `Instant`/`TIMESTAMP` round-trips unchanged.
+- Integrity violations are mapped to typed exceptions by vendor code (1062 unique, 1452 foreign
+  key, 1048 NOT NULL, 3819 check) since MySQL reports them all under SQLSTATE 23000.
+- No transaction-scoped advisory lock (MySQL `GET_LOCK` is session-scoped), so `kormium-migrate`
+  runs without one — prefer migrating from a single instance.
+
 ## SQLite
 
 Artifact:

--- a/kormium-bom/build.gradle.kts
+++ b/kormium-bom/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
         listOf(
             "kormium-core",
             "kormium-postgres",
+            "kormium-mysql",
             "kormium-jdbc",
             "kormium-sqlite",
             "kormium-migrate",

--- a/kormium-core/src/commonMain/kotlin/Dialect.kt
+++ b/kormium-core/src/commonMain/kotlin/Dialect.kt
@@ -19,12 +19,56 @@ interface Dialect {
     fun renderOffset(offset: UInt): String
 
     /**
+     * Renders the combined `LIMIT`/`OFFSET` tail. The default composes the two independent
+     * [renderLimit] + [renderOffset] clauses, which is correct for backends that accept a
+     * bare `OFFSET`. MySQL does not — `OFFSET` without `LIMIT` is a syntax error there — so its
+     * dialect overrides this to emit the two together (a sentinel `LIMIT` when only an offset
+     * is set). Standard/Postgres/SQLite keep the default and render identically to before.
+     */
+    fun renderLimitOffset(limit: UInt, offset: UInt): String =
+        renderLimit(limit) + renderOffset(offset)
+
+    /**
      * SQL that acquires a transaction-scoped advisory lock keyed by [key], or `null` when the
      * backend has no such mechanism. Used by `kormium-migrate` to serialize a migration run across
      * concurrently-starting application instances; the lock is released automatically when the
      * surrounding transaction commits. The default is `null` (no lock).
      */
     fun advisoryLockSql(key: Long): String? = null
+
+    // ---- write-path rendering (Postgres/SQLite-flavoured by default; MySQL overrides) ----
+
+    /**
+     * Whether the backend supports `INSERT ... RETURNING`. When `false` (MySQL), an
+     * `insert(returning = true)` runs the insert without a RETURNING clause and re-selects the
+     * stored row by primary key instead. Default `true` (Postgres and SQLite both support it).
+     */
+    val supportsReturning: Boolean get() = true
+
+    /**
+     * The full `INSERT` statement for a row with no assigned columns (every column takes its DB
+     * default). Standard SQL is `INSERT INTO t DEFAULT VALUES`; MySQL has no `DEFAULT VALUES` and
+     * spells it `INSERT INTO t () VALUES ()`.
+     */
+    fun renderInsertDefaultValues(qualifiedTable: String): String =
+        "INSERT INTO $qualifiedTable DEFAULT VALUES"
+
+    /**
+     * The conflict/update tail of an upsert, appended to `INSERT INTO t (...) VALUES (...) `.
+     * [conflictColumns] are already quoted and [setClause] already rendered (`"col" = :bind, ...`).
+     * Standard SQL targets the conflict columns (`ON CONFLICT (...) DO UPDATE SET ...`); MySQL keys
+     * on any declared unique/primary index and ignores the column list (`ON DUPLICATE KEY UPDATE`).
+     */
+    fun renderUpsertSuffix(conflictColumns: List<String>, setClause: String): String =
+        "ON CONFLICT (${conflictColumns.joinToString(", ")}) DO UPDATE SET $setClause"
+
+    /**
+     * The conflict tail of an insert-or-ignore, appended to `INSERT INTO t (...) VALUES (...) `.
+     * [conflictColumns] are already quoted. Standard SQL is `ON CONFLICT (...) DO NOTHING`; MySQL
+     * uses a no-op `ON DUPLICATE KEY UPDATE col = col` (ignores only a duplicate-key conflict).
+     */
+    fun renderInsertOrIgnoreSuffix(conflictColumns: List<String>): String =
+        "ON CONFLICT (${conflictColumns.joinToString(", ")}) DO NOTHING"
 }
 
 /**

--- a/kormium-core/src/commonMain/kotlin/Query.kt
+++ b/kormium-core/src/commonMain/kotlin/Query.kt
@@ -15,9 +15,8 @@ data class Query(
     fun toSql(builder: ParamBuilder): String {
         val whereStr = whereExpression?.let { "WHERE ${it.toSql(builder)} " } ?: ""
         val orderByStr = orderBy?.let { "ORDER BY ${prepareOrderBy(it, builder)} " } ?: ""
-        val limitStr = builder.dialect.renderLimit(limit)
-        val offsetStr = builder.dialect.renderOffset(offset)
-        return "$whereStr$orderByStr$limitStr$offsetStr"
+        val limitOffsetStr = builder.dialect.renderLimitOffset(limit, offset)
+        return "$whereStr$orderByStr$limitOffsetStr"
     }
 
     /**

--- a/kormium-core/src/commonMain/kotlin/Table.kt
+++ b/kormium-core/src/commonMain/kotlin/Table.kt
@@ -82,6 +82,26 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         return sql.trimIndent() to builder.params
     }
 
+    // Re-selects a just-written row by its primary key, for backends without RETURNING (MySQL):
+    // the insert/upsert runs first, then this reads the stored row back (DB defaults applied).
+    private fun selectByPkSql(entity: T, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
+        val pk = primaryKey
+        check(pk.isNotEmpty()) {
+            "returning=true on $tableName needs a primary key: this backend has no RETURNING, " +
+                "so the written row is re-selected by primary key"
+        }
+        val builder = paramBuilder(dialect, typeMapper)
+        val where = pk.joinToString(" AND ") { col ->
+            require(entity.fields.containsKey(col.fieldKey)) {
+                "returning=true on $tableName needs the primary-key column \"${col.name}\" set on the " +
+                    "entity (this backend re-selects the written row by primary key; it has no RETURNING)"
+            }
+            "${dialect.quoteIdentifier(col.name)} = ${builder.bind(col.bindParam(entity.fields[col.fieldKey]))}"
+        }
+        val sql = "SELECT ${getColumnNames(dialect).joinToString(", ")} FROM ${qualifiedTableName(dialect)} WHERE $where"
+        return sql.trimIndent() to builder.params
+    }
+
     private fun selectSql(query: Query, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
         val builder = paramBuilder(dialect, typeMapper)
         val queryStr = query.toSql(builder)
@@ -98,7 +118,7 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         // database can apply its default / generated value), an explicit null is bound as NULL.
         val presentFields = generatePresentFields(entity)
         val base = if (presentFields.isEmpty()) {
-            "INSERT INTO ${qualifiedTableName(dialect)} DEFAULT VALUES"
+            dialect.renderInsertDefaultValues(qualifiedTableName(dialect))
         } else {
             val columns = presentFields.joinToString(", ") { dialect.quoteIdentifier(it.first) }
             val values = presentFields.joinToString(", ") { builder.bind(it.second) }
@@ -156,7 +176,7 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
                 // No assigned fields: a multi-row DEFAULT VALUES isn't valid, so emit one per row.
                 for (idx in group.entityIndices) {
                     statements += BatchStatement(
-                        "INSERT INTO ${qualifiedTableName(dialect)} DEFAULT VALUES$returningSuffix",
+                        dialect.renderInsertDefaultValues(qualifiedTableName(dialect)) + returningSuffix,
                         emptyMap(),
                         listOf(idx),
                     )
@@ -192,12 +212,12 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         require(insertFields.isNotEmpty()) { "upsert() needs at least one field set on the insert entity" }
         val columns = insertFields.joinToString(", ") { dialect.quoteIdentifier(it.first) }
         val values = insertFields.joinToString(", ") { builder.bind(it.second) }
-        val conflictCols = conflict.joinToString(", ") { dialect.quoteIdentifier(it.name) }
+        val conflictCols = conflict.map { dialect.quoteIdentifier(it.name) }
         val updateFields = generatePresentFields(update)
         require(updateFields.isNotEmpty()) { "upsert() needs at least one field set on the update entity" }
         val setClause = updateFields.joinToString(", ") { "${dialect.quoteIdentifier(it.first)} = ${builder.bind(it.second)}" }
         val base = "INSERT INTO ${qualifiedTableName(dialect)} ($columns) VALUES ($values) " +
-            "ON CONFLICT ($conflictCols) DO UPDATE SET $setClause"
+            dialect.renderUpsertSuffix(conflictCols, setClause)
         val sql = if (returning) "$base RETURNING ${getColumnNames(dialect).joinToString(", ")}" else base
         return sql to builder.params
     }
@@ -214,9 +234,9 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         require(insertFields.isNotEmpty()) { "insertOrIgnore() needs at least one field set on the entity" }
         val columns = insertFields.joinToString(", ") { dialect.quoteIdentifier(it.first) }
         val values = insertFields.joinToString(", ") { builder.bind(it.second) }
-        val conflictCols = conflict.joinToString(", ") { dialect.quoteIdentifier(it.name) }
+        val conflictCols = conflict.map { dialect.quoteIdentifier(it.name) }
         return "INSERT INTO ${qualifiedTableName(dialect)} ($columns) VALUES ($values) " +
-            "ON CONFLICT ($conflictCols) DO NOTHING" to builder.params
+            dialect.renderInsertOrIgnoreSuffix(conflictCols) to builder.params
     }
 
     private fun countSql(query: Query, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
@@ -274,37 +294,55 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         exec.execute(selectAllSql(exec.dialect)) { rs -> mapToDao(rs, exec.typeMapper) }
 
     internal fun insert(entity: T, exec: SqlExecutor, returning: Boolean): T? {
-        val (sql, params) = insertSql(entity, exec.dialect, exec.typeMapper, returning)
-        if (!returning) {
-            exec.executeUpdate(sql = sql, namedParameters = params)
-            return entity
+        val dialect = exec.dialect
+        val emitReturning = returning && dialect.supportsReturning
+        val (sql, params) = insertSql(entity, dialect, exec.typeMapper, emitReturning)
+        if (returning && emitReturning) {
+            return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
         }
-        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+        exec.executeUpdate(sql = sql, namedParameters = params)
+        if (!returning) return entity
+        // No RETURNING (MySQL): re-select the stored row by primary key.
+        val (selSql, selParams) = selectByPkSql(entity, dialect, exec.typeMapper)
+        return exec.execute(selSql, selParams) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
     }
 
     internal fun insertAll(entities: List<T>, exec: SqlExecutor, returning: Boolean, mode: BatchInsertMode): List<T> {
         if (entities.isEmpty()) return emptyList()
-        val statements = buildBatchStatements(entities, mode, exec.dialect, exec.typeMapper, returning)
-        if (!returning) {
-            for (s in statements) exec.executeUpdate(sql = s.sql, namedParameters = s.params)
-            return entities
+        val dialect = exec.dialect
+        val emitReturning = returning && dialect.supportsReturning
+        val statements = buildBatchStatements(entities, mode, dialect, exec.typeMapper, emitReturning)
+        if (returning && emitReturning) {
+            val out = arrayOfNulls<Entity>(entities.size)
+            for (s in statements) {
+                val rows = exec.execute(s.sql, s.params) { rs -> mapToDao(rs, exec.typeMapper) }
+                rows.forEachIndexed { k, row -> out[s.indices[k]] = row }
+            }
+            @Suppress("UNCHECKED_CAST")
+            return out.toList() as List<T>
         }
-        val out = arrayOfNulls<Entity>(entities.size)
-        for (s in statements) {
-            val rows = exec.execute(s.sql, s.params) { rs -> mapToDao(rs, exec.typeMapper) }
-            rows.forEachIndexed { k, row -> out[s.indices[k]] = row }
+        for (s in statements) exec.executeUpdate(sql = s.sql, namedParameters = s.params)
+        if (!returning) return entities
+        // No RETURNING (MySQL): re-select every row by primary key, in input order.
+        return entities.map { entity ->
+            val (selSql, selParams) = selectByPkSql(entity, dialect, exec.typeMapper)
+            exec.execute(selSql, selParams) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+                ?: error("inserted row not found re-selecting by primary key in $tableName")
         }
-        @Suppress("UNCHECKED_CAST")
-        return out.toList() as List<T>
     }
 
     internal fun upsert(entity: T, conflict: List<Column<*, *, *>>, update: T, exec: SqlExecutor, returning: Boolean): T? {
-        val (sql, params) = upsertSql(entity, conflict, update, exec.dialect, exec.typeMapper, returning)
-        if (!returning) {
-            exec.executeUpdate(sql = sql, namedParameters = params)
-            return entity
+        val dialect = exec.dialect
+        val emitReturning = returning && dialect.supportsReturning
+        val (sql, params) = upsertSql(entity, conflict, update, dialect, exec.typeMapper, emitReturning)
+        if (returning && emitReturning) {
+            return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
         }
-        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+        exec.executeUpdate(sql = sql, namedParameters = params)
+        if (!returning) return entity
+        // No RETURNING (MySQL): re-select the upserted row by primary key.
+        val (selSql, selParams) = selectByPkSql(entity, dialect, exec.typeMapper)
+        return exec.execute(selSql, selParams) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
     }
 
     internal fun insertOrIgnore(entity: T, conflict: List<Column<*, *, *>>, exec: SqlExecutor): Long {
@@ -347,37 +385,52 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         exec.execute(selectAllSql(exec.dialect)) { rs -> mapToDao(rs, exec.typeMapper) }
 
     internal suspend fun insert(entity: T, exec: SuspendSqlExecutor, returning: Boolean): T? {
-        val (sql, params) = insertSql(entity, exec.dialect, exec.typeMapper, returning)
-        if (!returning) {
-            exec.executeUpdate(sql = sql, namedParameters = params)
-            return entity
+        val dialect = exec.dialect
+        val emitReturning = returning && dialect.supportsReturning
+        val (sql, params) = insertSql(entity, dialect, exec.typeMapper, emitReturning)
+        if (returning && emitReturning) {
+            return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
         }
-        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+        exec.executeUpdate(sql = sql, namedParameters = params)
+        if (!returning) return entity
+        val (selSql, selParams) = selectByPkSql(entity, dialect, exec.typeMapper)
+        return exec.execute(selSql, selParams) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
     }
 
     internal suspend fun insertAll(entities: List<T>, exec: SuspendSqlExecutor, returning: Boolean, mode: BatchInsertMode): List<T> {
         if (entities.isEmpty()) return emptyList()
-        val statements = buildBatchStatements(entities, mode, exec.dialect, exec.typeMapper, returning)
-        if (!returning) {
-            for (s in statements) exec.executeUpdate(sql = s.sql, namedParameters = s.params)
-            return entities
+        val dialect = exec.dialect
+        val emitReturning = returning && dialect.supportsReturning
+        val statements = buildBatchStatements(entities, mode, dialect, exec.typeMapper, emitReturning)
+        if (returning && emitReturning) {
+            val out = arrayOfNulls<Entity>(entities.size)
+            for (s in statements) {
+                val rows = exec.execute(s.sql, s.params) { rs -> mapToDao(rs, exec.typeMapper) }
+                rows.forEachIndexed { k, row -> out[s.indices[k]] = row }
+            }
+            @Suppress("UNCHECKED_CAST")
+            return out.toList() as List<T>
         }
-        val out = arrayOfNulls<Entity>(entities.size)
-        for (s in statements) {
-            val rows = exec.execute(s.sql, s.params) { rs -> mapToDao(rs, exec.typeMapper) }
-            rows.forEachIndexed { k, row -> out[s.indices[k]] = row }
+        for (s in statements) exec.executeUpdate(sql = s.sql, namedParameters = s.params)
+        if (!returning) return entities
+        return entities.map { entity ->
+            val (selSql, selParams) = selectByPkSql(entity, dialect, exec.typeMapper)
+            exec.execute(selSql, selParams) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+                ?: error("inserted row not found re-selecting by primary key in $tableName")
         }
-        @Suppress("UNCHECKED_CAST")
-        return out.toList() as List<T>
     }
 
     internal suspend fun upsert(entity: T, conflict: List<Column<*, *, *>>, update: T, exec: SuspendSqlExecutor, returning: Boolean): T? {
-        val (sql, params) = upsertSql(entity, conflict, update, exec.dialect, exec.typeMapper, returning)
-        if (!returning) {
-            exec.executeUpdate(sql = sql, namedParameters = params)
-            return entity
+        val dialect = exec.dialect
+        val emitReturning = returning && dialect.supportsReturning
+        val (sql, params) = upsertSql(entity, conflict, update, dialect, exec.typeMapper, emitReturning)
+        if (returning && emitReturning) {
+            return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
         }
-        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+        exec.executeUpdate(sql = sql, namedParameters = params)
+        if (!returning) return entity
+        val (selSql, selParams) = selectByPkSql(entity, dialect, exec.typeMapper)
+        return exec.execute(selSql, selParams) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
     }
 
     internal suspend fun insertOrIgnore(entity: T, conflict: List<Column<*, *, *>>, exec: SuspendSqlExecutor): Long {

--- a/kormium-migrate/src/commonMain/kotlin/Migration.kt
+++ b/kormium-migrate/src/commonMain/kotlin/Migration.kt
@@ -31,6 +31,16 @@ class Migration<G : Catalog> private constructor(
     internal val statements: List<String>,
     internal val checksum: String,
 ) {
+    // The journal records the id as varchar(MAX_ID_LENGTH) (see [migrate]); reject an over-long id
+    // here, at construction, rather than letting it fail later on INSERT into the journal.
+    init {
+        require(id.length <= MAX_ID_LENGTH) {
+            "Migration id must be at most $MAX_ID_LENGTH characters " +
+                "(it is stored in the kormium_migrations.id varchar($MAX_ID_LENGTH) column), " +
+                "was ${id.length}: \"$id\""
+        }
+    }
+
     /** A migration written as one SQL string; statements are separated by top-level `;`. */
     constructor(id: String, sql: String) : this(id, splitStatements(sql), crc32(normalize(sql)))
 
@@ -38,6 +48,13 @@ class Migration<G : Catalog> private constructor(
     constructor(id: String, statements: List<String>) :
         this(id, statements, crc32(statements.joinToString("\n;\n") { normalize(it) }))
 }
+
+/**
+ * Maximum length of a [Migration.id]. It must fit the journal's `id varchar(MAX_ID_LENGTH)` primary
+ * key — a value MySQL accepts as a key (a `TEXT` PK needs a prefix length) and that is equally valid
+ * on Postgres and SQLite. 255 is comfortably longer than any sensible migration id.
+ */
+private const val MAX_ID_LENGTH = 255
 
 /** Thrown when an already-applied migration's SQL no longer matches the recorded checksum. */
 class MigrationChecksumException(
@@ -89,9 +106,11 @@ fun <G : Catalog> Database<G>.migrate(migrations: List<Migration<G>>) {
     usePinned(transactional = true) { exec ->
         exec.dialect.advisoryLockSql(migrationLockKey)?.let { exec.execute(it) }
 
+        // id is varchar(255), not text: MySQL forbids a TEXT/BLOB column as a PRIMARY KEY without a
+        // prefix length (error 1170), and varchar(255) is equally valid on Postgres and SQLite.
         exec.execute(
             "CREATE TABLE IF NOT EXISTS $JOURNAL " +
-                "(id text NOT NULL PRIMARY KEY, checksum text NOT NULL, applied_at text NOT NULL, idx integer NOT NULL)",
+                "(id varchar($MAX_ID_LENGTH) NOT NULL PRIMARY KEY, checksum text NOT NULL, applied_at text NOT NULL, idx integer NOT NULL)",
         )
 
         val applied: Map<String, String> = exec

--- a/kormium-mysql/README.md
+++ b/kormium-mysql/README.md
@@ -1,0 +1,85 @@
+# kormium-mysql
+
+The MySQL / MariaDB backend for [Kormium](../readme.md). Provides `createDatabase(...)`, the
+`MySqlDialect` and the `MySqlDriver`, with two interchangeable transports:
+
+- **JVM** — JDBC via `mysql-connector-j`, pooled with HikariCP.
+- **Native** (Linux/macOS) — the MariaDB Connector/C (`libmariadb`, API-compatible with
+  `libmysqlclient`) through cinterop, no JVM required.
+
+For non-blocking MySQL on the JVM, see [`createMySqlR2dbcDatabase`](../kormium-r2dbc/README.md) in
+`kormium-r2dbc` (over `io.asyncer:r2dbc-mysql`).
+
+## Install
+
+```kotlin
+dependencies {
+    implementation(platform("io.github.kormium:kormium-bom:<version>"))
+    implementation("io.github.kormium:kormium-mysql")
+}
+```
+
+`kormium-core` is pulled in transitively.
+
+### Native system library
+
+On Kotlin/Native the driver links against the MariaDB Connector/C:
+
+```bash
+# macOS
+brew install mariadb-connector-c
+# Debian / Ubuntu
+sudo apt-get install libmariadb-dev
+```
+
+## Example
+
+```kotlin
+val db: Database<App> = createDatabase(
+    host = "localhost",
+    port = 3306,
+    database = "app",
+    user = "root",
+    password = "password",
+    poolSize = 10,
+)
+
+val adults = db.autocommit {
+    Users.find { where { Users.age gtEq 18 } }
+}
+```
+
+## MySQL specifics
+
+- **UUID** is stored as `CHAR(36)` text (MySQL has no UUID type); bind/read go through that form.
+  For binary `BINARY(16)` storage, map your own column type with `ColumnType.convert`.
+- **JSON** uses MySQL's native `JSON` type; a `JsonElement` binds as its text and reads back via text.
+- **Timestamps** round-trip in UTC: the session is pinned to UTC, so an `Instant` stored in a
+  `TIMESTAMP` reads back unchanged.
+- **Write path.** MySQL has no `RETURNING`, so `insert/insertAll/upsert(returning = true)` run the
+  write and then **re-select the row by primary key** — transparent, but it needs a primary key (and
+  the PK value set on the entity), otherwise it throws. `upsert` maps to `ON DUPLICATE KEY UPDATE`
+  (which keys on any unique/primary index, so the `onConflict` columns are advisory on MySQL), and
+  `insertOrIgnore` to a no-op `ON DUPLICATE KEY UPDATE`.
+- **No advisory lock.** MySQL `GET_LOCK` is session-scoped (not released at `COMMIT`), so
+  `kormium-migrate` runs without an advisory lock on MySQL — as it does on SQLite. Prefer migrating
+  from a single instance.
+- **Native suspend path** offloads blocking calls to the IO dispatcher (libmysql has no portable
+  non-blocking API); the blocking `usePinned` path calls the client directly.
+
+## Platforms
+
+| Platform | Transport |
+| --- | --- |
+| JVM | JDBC / HikariCP |
+| Linux Native | libmariadb |
+| macOS Native | libmariadb |
+| Windows Native | Use the JVM driver |
+
+Android and iOS do not ship a MySQL backend — use `kormium-sqlite` there.
+
+## Documentation
+
+- [Backends and platform support](../docs/backends.md)
+- [Installation](../docs/installation.md)
+- [Quick start](../docs/quick-start.md)

--- a/kormium-mysql/build.gradle.kts
+++ b/kormium-mysql/build.gradle.kts
@@ -1,0 +1,94 @@
+plugins {
+    kotlin("multiplatform")
+}
+
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    jvmToolchain(21)
+
+    jvm {
+        testRuns["test"].executionTask.configure {
+            useJUnitPlatform()
+        }
+    }
+
+    // The native MySQL driver talks to a MySQL C client (MariaDB Connector/C, libmariadb) via
+    // cinterop. Register the same-named "libmysqlclient" cinterop on every native target so it
+    // commonizes into the shared nativeMain source set. Unlike libpq there is no portable
+    // non-blocking API, so the suspend path falls back to the core blocking offload.
+    //
+    // Unix-only: the MYSQL_BIND buffers use `unsigned long` lengths, which are 64-bit on the
+    // LP64 unix targets but 32-bit on Windows LLP64 — the K/N commonizer rejects that mismatch in
+    // shared nativeMain metadata. Windows is served by the JVM (JDBC) driver. mingwX64 is therefore
+    // intentionally absent here.
+    listOf(linuxX64(), macosX64(), macosArm64()).forEach { target ->
+        target.compilations.getByName("main").cinterops {
+            register("libmysqlclient") {
+                defFile(project.file("src/nativeInterop/cinterop/libmysqlclient.def"))
+                // Non-standard client locations: pass -Pmysql.include=<dir> (and -Pmysql.lib=<dir>
+                // for the link step below).
+                (findProperty("mysql.include") as String?)?.let { compilerOpts("-I$it") }
+            }
+        }
+        (findProperty("mysql.lib") as String?)?.let { dir ->
+            target.binaries.all { linkerOpts("-L$dir") }
+        }
+    }
+    applyDefaultHierarchyTemplate()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                // Exposes createDatabase(...) plus the MySQL Dialect + MySqlDriver interface.
+                // MySqlDriver is part of the public return type, so :kormium-core is an api dependency.
+                api(project(":kormium-core"))
+                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
+                // MySqlJvmTypeMapper binds a JsonElement as its text form into a JSON column.
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation("com.ionspin.kotlin:bignum:0.3.10")
+            }
+        }
+        val jvmMain by getting {
+            dependencies {
+                // The JVM MySQL driver is the shared JDBC driver wired with the mysql-connector-j
+                // URL + MySqlResultSetWrapper (which uses kotlinx-datetime).
+                implementation(project(":kormium-jdbc"))
+                implementation("com.mysql:mysql-connector-j:8.4.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
+                // MySqlJvmTypeMapper converts ionspin BigDecimal to java.math.BigDecimal.
+                implementation("com.ionspin.kotlin:bignum:0.3.10")
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                // End-to-end tests of the JVM driver against a real MySQL in Docker.
+                implementation(project(":kormium-migrate"))
+                implementation("org.testcontainers:mysql:1.20.4")
+                implementation("com.mysql:mysql-connector-j:8.4.0")
+                // For the all-column-types round-trip test (Instant / Json columns).
+                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+            }
+        }
+        val nativeMain by getting {
+            dependencies {
+                // The native libmysqlclient driver.
+                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+            }
+        }
+        val nativeTest by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+            }
+        }
+    }
+}

--- a/kormium-mysql/src/commonMain/kotlin/MySqlDialect.kt
+++ b/kormium-mysql/src/commonMain/kotlin/MySqlDialect.kt
@@ -1,0 +1,52 @@
+package io.github.kormium
+
+/**
+ * MySQL / MariaDB dialect. Differs from [StandardDialect] in three places:
+ *
+ *  - identifiers are quoted with backticks (MySQL's default), not double quotes;
+ *  - `LIMIT`/`OFFSET` are rendered together, because MySQL rejects a bare `OFFSET` — see
+ *    [renderLimitOffset];
+ *  - there is no transaction-scoped advisory lock (MySQL `GET_LOCK` is session-scoped and is
+ *    not released at `COMMIT`), so [advisoryLockSql] stays `null` like SQLite.
+ *
+ * Bind rendering is the plain `:name` form: MySQL has no `::uuid` / `::jsonb` cast syntax. A
+ * [Uuid] is stored as text (`CHAR(36)`) and a [kotlinx.serialization.json.JsonElement] binds as a
+ * string literal into a `JSON` column — both handled by `MySqlJvmTypeMapper`, not the dialect.
+ */
+object MySqlDialect : Dialect by StandardDialect {
+    override fun quoteIdentifier(name: String): String =
+        "`${name.replace("`", "``")}`"
+
+    /**
+     * MySQL needs a `LIMIT` whenever an `OFFSET` is present — `SELECT ... OFFSET 5` is a syntax
+     * error. So when only an offset is set we emit a sentinel `LIMIT` of the maximum unsigned
+     * BIGINT (MySQL's documented "all rows from here" idiom). When a real limit is set, the
+     * standard `LIMIT n OFFSET m` is valid as-is.
+     */
+    override fun renderLimitOffset(limit: UInt, offset: UInt): String {
+        val limited = limit != UInt.MAX_VALUE
+        val offsetted = offset != 0u
+        return when {
+            !limited && !offsetted -> ""
+            !offsetted -> "LIMIT $limit "
+            limited -> "LIMIT $limit OFFSET $offset "
+            // Offset without a real limit: MySQL requires a LIMIT, so use the max-BIGINT sentinel.
+            else -> "LIMIT 18446744073709551615 OFFSET $offset "
+        }
+    }
+
+    // MySQL has no RETURNING — the core re-selects the inserted row by primary key instead.
+    override val supportsReturning: Boolean get() = false
+
+    // MySQL spells "all defaults" as `() VALUES ()`, not `DEFAULT VALUES`.
+    override fun renderInsertDefaultValues(qualifiedTable: String): String =
+        "INSERT INTO $qualifiedTable () VALUES ()"
+
+    // MySQL upsert keys on any unique/primary index, so the conflict column list is not used.
+    override fun renderUpsertSuffix(conflictColumns: List<String>, setClause: String): String =
+        "ON DUPLICATE KEY UPDATE $setClause"
+
+    // No `ON CONFLICT DO NOTHING`; a no-op self-assignment on a conflict column ignores a dup key.
+    override fun renderInsertOrIgnoreSuffix(conflictColumns: List<String>): String =
+        "ON DUPLICATE KEY UPDATE ${conflictColumns.first()} = ${conflictColumns.first()}"
+}

--- a/kormium-mysql/src/commonMain/kotlin/MySqlDriver.kt
+++ b/kormium-mysql/src/commonMain/kotlin/MySqlDriver.kt
@@ -1,0 +1,20 @@
+package io.github.kormium
+
+import io.github.kormium.database.Database
+import io.github.kormium.database.SuspendDatabase
+
+/**
+ * A MySQL/MariaDB-backed [Database] (and [SuspendDatabase]). This is the type returned by the
+ * driver factories; it adds [AutoCloseable] so the underlying connection pool can be released
+ * (or used via a `use { }` block). Blocking query methods come from [Database]; the suspend path
+ * (suspendTransaction/suspendAutocommit) comes from [SuspendDatabase]. Mirrors [PostgresDriver].
+ */
+interface MySqlDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoCloseable {
+    // Resolves the config default inherited from both Database and SuspendDatabase; concrete
+    // drivers supply it (from the createDatabase config argument).
+    override val config: KormiumConfig
+
+    // Resolves the writeListeners default inherited from both interfaces; concrete drivers
+    // supply a real registry so change observation (kormium-observe) works.
+    override val writeListeners: WriteListeners
+}

--- a/kormium-mysql/src/commonMain/kotlin/MySqlErrors.kt
+++ b/kormium-mysql/src/commonMain/kotlin/MySqlErrors.kt
@@ -1,0 +1,26 @@
+package io.github.kormium
+
+/**
+ * Maps a MySQL/MariaDB **vendor error code** to the most specific core [QueryException] subtype.
+ *
+ * MySQL reports every integrity violation under SQLSTATE `23000`, so the standard SQLSTATE mapping
+ * ([sqlException]) can't tell them apart — the vendor code is the authoritative discriminator. This
+ * single table is shared by all three MySQL backends: the JVM JDBC translator (`getErrorCode`), the
+ * native driver (`mysql_stmt_errno`) and the r2dbc translator (`R2dbcException.errorCode`).
+ *
+ * Codes (common to MySQL 8 and MariaDB): 1062/1586 duplicate entry, 1451/1452 foreign key,
+ * 1048/1364 NOT NULL (column cannot be null / has no default), 3819 CHECK (MySQL 8.0.16+ /
+ * MariaDB 10.2+). Unknown codes fall back to the standard SQLSTATE mapping.
+ */
+fun mysqlVendorException(
+    message: String,
+    vendorCode: Int,
+    sqlState: String? = null,
+    cause: Throwable? = null,
+): QueryException = when (vendorCode) {
+    1062, 1586 -> UniqueViolationException(message, sqlState, cause)
+    1451, 1452 -> ForeignKeyViolationException(message, sqlState, cause)
+    1048, 1364 -> NotNullViolationException(message, sqlState, cause)
+    3819 -> CheckViolationException(message, sqlState, cause)
+    else -> sqlException(message, sqlState, cause)
+}

--- a/kormium-mysql/src/commonMain/kotlin/database/CreateDatabase.kt
+++ b/kormium-mysql/src/commonMain/kotlin/database/CreateDatabase.kt
@@ -1,0 +1,31 @@
+package io.github.kormium.database
+
+import io.github.kormium.KormiumBuilder
+import io.github.kormium.KormiumConfig
+import io.github.kormium.MySqlDriver
+
+expect fun createDatabase(
+    host: String,
+    port: Int = 3306,
+    database: String,
+    user: String,
+    password: String,
+    poolSize: Int = 10,
+    config: KormiumConfig = KormiumConfig(),
+): MySqlDriver
+
+/**
+ * Opens a MySQL/MariaDB database with a configuration block: `createDatabase(host = …, …) {`
+ * `config { … }; beforeStart { migrate(appMigrations) } }`. See [KormiumBuilder].
+ */
+fun createDatabase(
+    host: String,
+    port: Int = 3306,
+    database: String,
+    user: String,
+    password: String,
+    poolSize: Int = 10,
+    block: KormiumBuilder.() -> Unit,
+): MySqlDriver = KormiumBuilder().apply(block).finish {
+    createDatabase(host, port, database, user, password, poolSize, it)
+}

--- a/kormium-mysql/src/commonTest/kotlin/MySqlDialectTest.kt
+++ b/kormium-mysql/src/commonTest/kotlin/MySqlDialectTest.kt
@@ -1,0 +1,58 @@
+import io.github.kormium.MySqlDialect
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * Pure-function tests of [MySqlDialect]'s rendering — no database needed. These pin the
+ * MySQL-specific SQL the write path depends on (backtick quoting, LIMIT/OFFSET, the INSERT family),
+ * so a regression shows up here rather than only in the Testcontainers/native integration suites.
+ */
+class MySqlDialectTest {
+
+    @Test
+    fun quotesWithBackticks() {
+        assertEquals("`name`", MySqlDialect.quoteIdentifier("name"))
+        assertEquals("`a``b`", MySqlDialect.quoteIdentifier("a`b"))
+    }
+
+    @Test
+    fun limitOffsetMysqlSemantics() {
+        assertEquals("", MySqlDialect.renderLimitOffset(UInt.MAX_VALUE, 0u))
+        assertEquals("LIMIT 10 ", MySqlDialect.renderLimitOffset(10u, 0u))
+        assertEquals("LIMIT 10 OFFSET 5 ", MySqlDialect.renderLimitOffset(10u, 5u))
+        // Offset without a real limit needs a sentinel LIMIT (a bare OFFSET is a syntax error).
+        assertEquals("LIMIT 18446744073709551615 OFFSET 5 ", MySqlDialect.renderLimitOffset(UInt.MAX_VALUE, 5u))
+    }
+
+    @Test
+    fun hasNoReturning() {
+        assertFalse(MySqlDialect.supportsReturning)
+    }
+
+    @Test
+    fun insertDefaultValuesMysqlForm() {
+        assertEquals("INSERT INTO `t` () VALUES ()", MySqlDialect.renderInsertDefaultValues("`t`"))
+    }
+
+    @Test
+    fun upsertUsesOnDuplicateKeyUpdate() {
+        assertEquals(
+            "ON DUPLICATE KEY UPDATE `qty` = :q",
+            MySqlDialect.renderUpsertSuffix(listOf("`id`"), "`qty` = :q"),
+        )
+    }
+
+    @Test
+    fun insertOrIgnoreIsNoOpUpsert() {
+        assertEquals(
+            "ON DUPLICATE KEY UPDATE `id` = `id`",
+            MySqlDialect.renderInsertOrIgnoreSuffix(listOf("`id`")),
+        )
+    }
+
+    @Test
+    fun noAdvisoryLock() {
+        assertEquals(null, MySqlDialect.advisoryLockSql(42L))
+    }
+}

--- a/kormium-mysql/src/jvmMain/kotlin/MySqlExceptionTranslator.kt
+++ b/kormium-mysql/src/jvmMain/kotlin/MySqlExceptionTranslator.kt
@@ -1,0 +1,13 @@
+package io.github.kormium
+
+import io.github.kormium.jdbc.SqlExceptionTranslator
+
+/**
+ * MySQL/MariaDB collapse every integrity violation onto SQLSTATE `23000`, so the standard
+ * SQLSTATE-based translation can't tell a unique violation from a foreign-key one. We therefore
+ * branch on the vendor error code (`SQLException.getErrorCode`) via the shared [mysqlVendorException]
+ * table.
+ */
+val MySqlExceptionTranslator: SqlExceptionTranslator = { e ->
+    mysqlVendorException(e.message ?: "SQL error", e.errorCode, e.sqlState, e)
+}

--- a/kormium-mysql/src/jvmMain/kotlin/MySqlJvmTypeMapper.kt
+++ b/kormium-mysql/src/jvmMain/kotlin/MySqlJvmTypeMapper.kt
@@ -1,0 +1,38 @@
+package io.github.kormium
+
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.toJavaInstant
+import kotlinx.datetime.toJavaLocalDate
+import kotlinx.datetime.toJavaLocalDateTime
+import kotlinx.datetime.toJavaLocalTime
+import kotlinx.serialization.json.JsonElement
+import java.time.ZoneOffset
+import kotlin.uuid.Uuid
+
+/**
+ * JVM MySQL/MariaDB parameter mapping: binds values as properly-typed JDBC objects (mirrors
+ * [PostgresJvmTypeMapper]) so server-prepared statements declare real parameter types.
+ *
+ * MySQL has no native UUID or cast syntax, so a [Uuid] binds as its `CHAR(36)` text form, and a
+ * [JsonElement] binds as a string literal — MySQL parses it into a `JSON` column. An [Instant]
+ * binds as an `OffsetDateTime` at UTC (a `TIMESTAMP` is stored/compared in UTC); the connection
+ * URL pins the session zone to UTC so the value round-trips unchanged.
+ */
+object MySqlJvmTypeMapper : TypeMapper {
+    override fun toParameter(value: Any?): Any? = when (value) {
+        // StandardTypeMapper would toString() these; pass them through so they bind as real types.
+        is Float, is Short -> value
+        is Uuid -> value.toString()
+        is BigDecimal -> java.math.BigDecimal(value.toString())
+        is Instant -> value.toJavaInstant().atOffset(ZoneOffset.UTC)
+        is LocalDate -> value.toJavaLocalDate()
+        is LocalTime -> value.toJavaLocalTime()
+        is LocalDateTime -> value.toJavaLocalDateTime()
+        is JsonElement -> value.toString()
+        else -> StandardTypeMapper.toParameter(value)
+    }
+}

--- a/kormium-mysql/src/jvmMain/kotlin/MySqlResultSetWrapper.kt
+++ b/kormium-mysql/src/jvmMain/kotlin/MySqlResultSetWrapper.kt
@@ -1,0 +1,66 @@
+package io.github.kormium
+
+import io.github.kormium.resultset.ResultSet
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.toKotlinInstant
+import kotlinx.datetime.toKotlinLocalDate
+import kotlinx.datetime.toKotlinLocalDateTime
+import kotlinx.datetime.toKotlinLocalTime
+import java.sql.ResultSetMetaData
+import java.time.OffsetDateTime
+
+/**
+ * Adapts a MySQL/MariaDB JDBC [java.sql.ResultSet] to core's backend-agnostic [ResultSet].
+ *
+ * Date/time columns are read through mysql-connector-j's `java.time` `getObject` conversions
+ * (rather than text) so there is no string-parsing or timezone guesswork: `TIMESTAMP` comes back
+ * as an [OffsetDateTime] (the session is pinned to UTC by the connection URL) and yields the
+ * correct [Instant]. UUID (`CHAR(36)`) and `JSON` columns are plain text via [getString], which
+ * lines up with korm's text-based column reading.
+ */
+class MySqlResultSetWrapper(private val rs: java.sql.ResultSet) : ResultSet {
+    // Lazy: the hot read path maps columns positionally and never touches this.
+    override val columns: Array<String> by lazy { internalGetColumns() }
+
+    private fun internalGetColumns(): Array<String> {
+        val md: ResultSetMetaData = rs.metaData
+        return (0..<md.columnCount).map { md.getColumnLabel(it + 1) }.toTypedArray()
+    }
+
+    override fun next(): Boolean = rs.next()
+
+    override fun getString(columnIndex: Int): String? = rs.getString(columnIndex + 1)
+
+    // JDBC's primitive getters return 0/false for SQL NULL, so wasNull() must be consulted to
+    // distinguish a real value from NULL on nullable columns.
+    override fun getBoolean(columnIndex: Int): Boolean? = rs.getBoolean(columnIndex + 1).orNull()
+
+    override fun getShort(columnIndex: Int): Short? = rs.getShort(columnIndex + 1).orNull()
+
+    override fun getInt(columnIndex: Int): Int? = rs.getInt(columnIndex + 1).orNull()
+
+    override fun getLong(columnIndex: Int): Long? = rs.getLong(columnIndex + 1).orNull()
+
+    override fun getFloat(columnIndex: Int): Float? = rs.getFloat(columnIndex + 1).orNull()
+
+    override fun getDouble(columnIndex: Int): Double? = rs.getDouble(columnIndex + 1).orNull()
+
+    private fun <T> T.orNull(): T? = if (rs.wasNull()) null else this
+
+    override fun getBytes(columnIndex: Int): ByteArray? = rs.getBytes(columnIndex + 1)
+
+    override fun getDate(columnIndex: Int): LocalDate? =
+        rs.getObject(columnIndex + 1, java.time.LocalDate::class.java)?.toKotlinLocalDate()
+
+    override fun getTime(columnIndex: Int): LocalTime? =
+        rs.getObject(columnIndex + 1, java.time.LocalTime::class.java)?.toKotlinLocalTime()
+
+    override fun getLocalDateTime(columnIndex: Int): LocalDateTime? =
+        rs.getObject(columnIndex + 1, java.time.LocalDateTime::class.java)?.toKotlinLocalDateTime()
+
+    override fun getInstant(columnIndex: Int): Instant? =
+        rs.getObject(columnIndex + 1, OffsetDateTime::class.java)?.toInstant()?.toKotlinInstant()
+}

--- a/kormium-mysql/src/jvmMain/kotlin/database/Database.jvm.kt
+++ b/kormium-mysql/src/jvmMain/kotlin/database/Database.jvm.kt
@@ -1,0 +1,55 @@
+package io.github.kormium.database
+
+import io.github.kormium.KormiumConfig
+import io.github.kormium.MySqlDialect
+import io.github.kormium.MySqlDriver
+import io.github.kormium.MySqlExceptionTranslator
+import io.github.kormium.MySqlJvmTypeMapper
+import io.github.kormium.MySqlResultSetWrapper
+import io.github.kormium.jdbc.JdbcDatabase
+
+/**
+ * A MySQL/MariaDB [MySqlDriver] backed by the shared [JdbcDatabase] (HikariCP pool over
+ * mysql-connector-j). Mirrors the Postgres JDBC driver.
+ *
+ * URL parameters:
+ *  - `cachePrepStmts` + `useServerPrepStmts` make repeated statements server-prepared and cached,
+ *    so each execution is one round-trip (the MySQL analogue of pgjdbc's prepareThreshold=1).
+ *  - `connectionTimeZone=UTC` + `forceConnectionTimeZoneToSession=true` pin the session to UTC so
+ *    an [kotlinx.datetime.Instant] bound as a UTC `OffsetDateTime` round-trips through a
+ *    `TIMESTAMP` unchanged, and is read back correctly by [MySqlResultSetWrapper.getInstant].
+ *
+ * Integrity violations are mapped by vendor code through [MySqlExceptionTranslator] (MySQL reports
+ * them all under SQLSTATE 23000, which the standard SQLSTATE translator can't disambiguate).
+ */
+private class MySqlJdbcDriver(
+    host: String,
+    port: Int,
+    database: String,
+    user: String,
+    password: String,
+    poolSize: Int,
+    config: KormiumConfig,
+) : JdbcDatabase(
+    jdbcUrl = "jdbc:mysql://$host:$port/$database" +
+        "?cachePrepStmts=true&useServerPrepStmts=true" +
+        "&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true",
+    username = user,
+    password = password,
+    poolSize = poolSize,
+    dialect = MySqlDialect,
+    typeMapper = MySqlJvmTypeMapper,
+    wrap = ::MySqlResultSetWrapper,
+    translate = MySqlExceptionTranslator,
+    config = config,
+), MySqlDriver
+
+actual fun createDatabase(
+    host: String,
+    port: Int,
+    database: String,
+    user: String,
+    password: String,
+    poolSize: Int,
+    config: KormiumConfig,
+): MySqlDriver = MySqlJdbcDriver(host, port, database, user, password, poolSize, config)

--- a/kormium-mysql/src/jvmTest/kotlin/TableIntegrationTest.kt
+++ b/kormium-mysql/src/jvmTest/kotlin/TableIntegrationTest.kt
@@ -1,0 +1,485 @@
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import io.github.kormium.Catalog
+import io.github.kormium.Column
+import io.github.kormium.Entity
+import io.github.kormium.ForeignKeyViolationException
+import io.github.kormium.Query
+import io.github.kormium.Table
+import io.github.kormium.UniqueViolationException
+import io.github.kormium.autocommit
+import io.github.kormium.database.Database
+import io.github.kormium.database.createDatabase
+import io.github.kormium.eq
+import io.github.kormium.migrate.Migration
+import io.github.kormium.migrate.migrate
+import io.github.kormium.transaction
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.MySQLContainer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+
+/**
+ * End-to-end tests for the JVM MySQL driver against a real MySQL (Testcontainers). Mirrors the
+ * Postgres [TableIntegrationTest], adapted to MySQL DDL (backtick quoting, CHAR(36) UUIDs, JSON
+ * type) and exercising the MySQL-specific LIMIT/OFFSET rendering and vendor-code exception mapping.
+ */
+class TableIntegrationTest {
+
+    @Test
+    fun testInsertFindUpdateDeleteRoundTrip() {
+        assumeDockerAvailable()
+        val id = Uuid.random()
+        ItDatabase.transaction {
+            ItProducts.insert(ItProduct().apply {
+                this.id = id
+                this.price = BigDecimal.fromInt(100)
+                this.qty = 5
+                this.displayName = "widget"
+                this.note = null
+                this.rank = null
+            })
+
+            val found = ItProducts.findById(id)
+            assertEquals(id, found?.id)
+            assertEquals(5, found?.qty)
+            assertEquals("widget", found?.displayName)
+            assertNull(found?.note)
+            // Regression: a nullable numeric column that is NULL must read back as null, not 0.
+            assertNull(found?.rank)
+            assertEquals(0, BigDecimal.fromInt(100).compareTo(found?.price!!))
+
+            ItProducts.update(Query(ItProducts.id eq id), ItProduct().apply { this.qty = 9 })
+            assertEquals(9, ItProducts.findById(id)?.qty)
+
+            ItProducts.deleteWhere(Query(ItProducts.id eq id))
+            assertNull(ItProducts.findById(id))
+        }
+    }
+
+    /** A value containing a quote round-trips intact, proving end-to-end parameterization. */
+    @Test
+    fun testValueWithQuoteRoundTrips() {
+        assumeDockerAvailable()
+        val id = Uuid.random()
+        val tricky = "O'Brien'; DROP TABLE it_products; --"
+        ItDatabase.transaction {
+            ItProducts.insert(ItProduct().apply {
+                this.id = id
+                this.price = BigDecimal.fromInt(1)
+                this.qty = 1
+                this.displayName = tricky
+                this.note = null
+            })
+            assertEquals(tricky, ItProducts.findById(id)?.displayName)
+        }
+    }
+
+    /** MySQL LIMIT/OFFSET: both a real limit+offset and an offset-without-limit must render valid SQL. */
+    @Test
+    fun testLimitOffsetRendersValidMySql() {
+        assumeDockerAvailable()
+        val ids = List(5) { Uuid.random() }
+        ItDatabase.transaction {
+            ItProducts.insertAll(ids.mapIndexed { i, id ->
+                ItProduct().apply {
+                    this.id = id; this.price = BigDecimal.fromInt(i); this.qty = i
+                    this.displayName = "page"; this.note = null; this.rank = null
+                }
+            })
+        }
+        // LIMIT 2 OFFSET 1 ordered by qty -> rows 1,2.
+        val page = ItDatabase.autocommit {
+            ItProducts.find {
+                where { ItProducts.displayName eq "page" }
+                orderBy ASC ItProducts.qty
+                limit = 2
+                offset = 1
+            }
+        }
+        assertEquals(listOf(1, 2), page.map { it.qty })
+
+        // OFFSET without a real LIMIT: MySQL needs a sentinel LIMIT, supplied by MySqlDialect.
+        val tail = ItDatabase.autocommit {
+            ItProducts.find {
+                where { ItProducts.displayName eq "page" }
+                orderBy ASC ItProducts.qty
+                offset = 2
+            }
+        }
+        assertEquals(listOf(2, 3, 4), tail.map { it.qty })
+
+        ItDatabase.transaction { ids.forEach { ItProducts.deleteWhere(Query(ItProducts.id eq it)) } }
+    }
+
+    /** insert(returning=true): MySQL has no RETURNING, so the row is re-selected by PK. */
+    @Test
+    fun testReturningInsertReSelectsRow() {
+        assumeDockerAvailable()
+        val id = Uuid.random()
+        val returned = ItDatabase.transaction {
+            ItProducts.insert(
+                ItProduct().apply {
+                    this.id = id; this.price = BigDecimal.fromInt(7); this.qty = 7
+                    this.displayName = "ret"; this.note = null; this.rank = null
+                },
+                returning = true,
+            )
+        }
+        assertEquals(id, returned?.id)
+        assertEquals("ret", returned?.displayName)
+        ItDatabase.transaction { ItProducts.deleteWhere(Query(ItProducts.id eq id)) }
+    }
+
+    /** upsert on a PK conflict updates the existing row (MySQL ON DUPLICATE KEY UPDATE). */
+    @Test
+    fun testUpsertOnConflictUpdates() {
+        assumeDockerAvailable()
+        val id = Uuid.random()
+        ItDatabase.transaction {
+            ItProducts.insert(ItProduct().apply {
+                this.id = id; this.price = BigDecimal.fromInt(1); this.qty = 1
+                this.displayName = "orig"; this.note = null; this.rank = null
+            })
+        }
+        ItDatabase.transaction {
+            ItProducts.upsert(
+                ItProduct().apply {
+                    this.id = id; this.price = BigDecimal.fromInt(1); this.qty = 1
+                    this.displayName = "x"; this.note = null; this.rank = null
+                },
+                onConflict = ItProducts.id,
+                update = ItProduct().apply { this.qty = 99 },
+            )
+        }
+        val row = ItDatabase.autocommit { ItProducts.findById(id) }
+        assertEquals(99, row?.qty)
+        assertEquals("orig", row?.displayName) // update only touched qty
+        ItDatabase.transaction { ItProducts.deleteWhere(Query(ItProducts.id eq id)) }
+    }
+
+    /** insertOrIgnore leaves the existing row untouched on a PK conflict (MySQL no-op upsert). */
+    @Test
+    fun testInsertOrIgnoreKeepsExisting() {
+        assumeDockerAvailable()
+        val id = Uuid.random()
+        ItDatabase.transaction {
+            ItProducts.insert(ItProduct().apply {
+                this.id = id; this.price = BigDecimal.fromInt(1); this.qty = 1
+                this.displayName = "keep"; this.note = null; this.rank = null
+            })
+        }
+        ItDatabase.transaction {
+            ItProducts.insertOrIgnore(
+                ItProduct().apply {
+                    this.id = id; this.price = BigDecimal.fromInt(2); this.qty = 2
+                    this.displayName = "dup"; this.note = null; this.rank = null
+                },
+                onConflict = ItProducts.id,
+            )
+        }
+        assertEquals("keep", ItDatabase.autocommit { ItProducts.findById(id) }?.displayName)
+        ItDatabase.transaction { ItProducts.deleteWhere(Query(ItProducts.id eq id)) }
+    }
+
+    /** A failing statement must not break the driver; the next query still runs. */
+    @Test
+    fun testConnectionSurvivesQueryError() {
+        assumeDockerAvailable()
+        ItDatabase.newDriver(poolSize = 1).use { driver ->
+            assertFailsWith<Exception> {
+                driver.autocommit { execute("SELECT * FROM table_that_does_not_exist") { rs -> rs.getInt(0) } }
+            }
+            assertEquals(1, driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single())
+        }
+    }
+
+    /** Using the driver after close() must fail. */
+    @Test
+    fun testUseAfterCloseThrows() {
+        assumeDockerAvailable()
+        val driver = ItDatabase.newDriver(poolSize = 1)
+        driver.close()
+        assertFailsWith<Exception> {
+            driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }
+        }
+    }
+
+    /** An exception out of a transaction block must ROLLBACK every statement in it. */
+    @Test
+    fun testTransactionRollsBackOnException() {
+        assumeDockerAvailable()
+        val id = Uuid.random()
+        assertFailsWith<RuntimeException> {
+            ItDatabase.transaction {
+                ItProducts.insert(ItProduct().apply {
+                    this.id = id; this.price = BigDecimal.fromInt(1); this.qty = 1
+                    this.displayName = "rollback"; this.note = null; this.rank = null
+                })
+                throw RuntimeException("boom")
+            }
+        }
+        assertNull(ItDatabase.autocommit { ItProducts.findById(id) })
+    }
+
+    /** Migrations apply in order, exactly once, and re-running the list is a no-op. */
+    @Test
+    fun testMigrationsRunOnceAndAreIdempotent() {
+        assumeDockerAvailable()
+        val suffix = Uuid.random().toString().replace("-", "")
+        val table = "mig_probe_$suffix"
+        val migrations = listOf(
+            Migration<ItCatalog>("001-$suffix", "CREATE TABLE `$table` (id int)"),
+            Migration<ItCatalog>("002-$suffix", "INSERT INTO `$table` (id) VALUES (1)"),
+        )
+        ItDatabase.migrate(migrations)
+        ItDatabase.migrate(migrations) // already applied -> no-op
+
+        val rows = ItDatabase.autocommit { execute("SELECT id FROM `$table`") { it.getInt(0) } }
+        assertEquals(listOf(1), rows)
+
+        ItDatabase.autocommit { executeUpdate("DROP TABLE `$table`") }
+        ItDatabase.autocommit {
+            executeUpdate(
+                "DELETE FROM kormium_migrations WHERE id IN (:a, :b)",
+                mapOf("a" to "001-$suffix", "b" to "002-$suffix"),
+            )
+        }
+    }
+
+    /** Every supported column type round-trips through a generated table. */
+    @Test
+    fun testAllColumnTypesRoundTrip() {
+        assumeDockerAvailable()
+        val id = Uuid.random()
+        val instant = kotlinx.datetime.Instant.parse("2024-01-02T03:04:05Z")
+        val json = kotlinx.serialization.json.JsonPrimitive("hi")
+        val date = kotlinx.datetime.LocalDate.parse("2024-01-02")
+        val time = kotlinx.datetime.LocalTime.parse("03:04:05")
+        val dateTime = kotlinx.datetime.LocalDateTime.parse("2024-01-02T03:04:05")
+        ItDatabase.transaction {
+            AllTypes.execSql(allTypesDdl)
+            AllTypes.insert(AllTypesEntity().apply {
+                this.id = id
+                this.anInt = 42
+                this.aDouble = 2.5
+                this.aBool = true
+                this.aText = "txt"
+                this.aDecimal = BigDecimal.fromInt(123)
+                this.anInstant = instant
+                this.aJson = json
+                this.aLong = 9_000_000_000L
+                this.aFloat = 1.5f
+                this.aShort = 7.toShort()
+                this.aDate = date
+                this.aTime = time
+                this.aDateTime = dateTime
+            })
+        }
+        val row = ItDatabase.autocommit { AllTypes.findById(id) }!!
+        assertEquals(42, row.anInt)
+        assertEquals(2.5, row.aDouble)
+        assertEquals(true, row.aBool)
+        assertEquals("txt", row.aText)
+        assertEquals(0, BigDecimal.fromInt(123).compareTo(row.aDecimal))
+        assertEquals(instant, row.anInstant)
+        assertEquals(json, row.aJson)
+        assertEquals(9_000_000_000L, row.aLong)
+        assertEquals(1.5f, row.aFloat)
+        assertEquals(7.toShort(), row.aShort)
+        assertEquals(date, row.aDate)
+        assertEquals(time, row.aTime)
+        assertEquals(dateTime, row.aDateTime)
+        ItDatabase.transaction { AllTypes.deleteWhere(Query(AllTypes.id eq id)) }
+    }
+
+    /** A duplicate primary key surfaces as a typed UniqueViolationException (vendor 1062). */
+    @Test
+    fun testUniqueViolationIsTyped() {
+        assumeDockerAvailable()
+        val id = Uuid.random()
+        ItDatabase.transaction {
+            ItProducts.insert(ItProduct().apply {
+                this.id = id; this.price = BigDecimal.fromInt(1); this.qty = 1
+                this.displayName = "dup"; this.note = null; this.rank = null
+            })
+        }
+        assertFailsWith<UniqueViolationException> {
+            ItDatabase.transaction {
+                ItProducts.insert(ItProduct().apply {
+                    this.id = id; this.price = BigDecimal.fromInt(2); this.qty = 2
+                    this.displayName = "dup2"; this.note = null; this.rank = null
+                })
+            }
+        }
+        ItDatabase.transaction { ItProducts.deleteWhere(Query(ItProducts.id eq id)) }
+    }
+
+    /** A foreign-key violation surfaces as a typed ForeignKeyViolationException (vendor 1452). */
+    @Test
+    fun testForeignKeyViolationIsTyped() {
+        assumeDockerAvailable()
+        ItDatabase.transaction { Authors.execSql(authorsDdl); Books.execSql(booksDdl) }
+        assertFailsWith<ForeignKeyViolationException> {
+            ItDatabase.transaction {
+                Books.insert(Book().apply {
+                    id = Uuid.random(); authorId = Uuid.random(); title = "orphan"
+                })
+            }
+        }
+        ItDatabase.transaction {
+            Books.execSql("DROP TABLE IF EXISTS `books`")
+            Authors.execSql("DROP TABLE IF EXISTS `authors`")
+        }
+    }
+
+    private fun assumeDockerAvailable() =
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable, "Docker is not available")
+}
+
+class Author : Entity() {
+    var id by Authors.id
+    var name by Authors.name
+}
+
+object Authors : Table<ItCatalog, Author>("authors", ::Author) {
+    val id by Column.UUID()
+    val name by Column.Text()
+
+    init { id; name }
+}
+
+class Book : Entity() {
+    var id by Books.id
+    var authorId by Books.authorId
+    var title by Books.title
+}
+
+object Books : Table<ItCatalog, Book>("books", ::Book) {
+    val id by Column.UUID()
+    val authorId by Column.UUID()
+    val title by Column.Text()
+
+    init { id; authorId; title }
+}
+
+class ItProduct : Entity() {
+    var id by ItProducts.id
+    var price by ItProducts.price
+    var qty by ItProducts.qty
+    var displayName by ItProducts.displayName
+    var note by ItProducts.note
+    var rank by ItProducts.rank
+}
+
+object ItCatalog : Catalog
+
+class AllTypesEntity : Entity() {
+    var id by AllTypes.id
+    var anInt by AllTypes.anInt
+    var aDouble by AllTypes.aDouble
+    var aBool by AllTypes.aBool
+    var aText by AllTypes.aText
+    var aDecimal by AllTypes.aDecimal
+    var anInstant by AllTypes.anInstant
+    var aJson by AllTypes.aJson
+    var aLong by AllTypes.aLong
+    var aFloat by AllTypes.aFloat
+    var aShort by AllTypes.aShort
+    var aDate by AllTypes.aDate
+    var aTime by AllTypes.aTime
+    var aDateTime by AllTypes.aDateTime
+}
+
+object AllTypes : Table<ItCatalog, AllTypesEntity>("all_types", ::AllTypesEntity) {
+    val id by Column.UUID()
+    val anInt by Column.Int()
+    val aDouble by Column.Double()
+    val aBool by Column.Boolean()
+    val aText by Column.Text()
+    val aDecimal by Column.BigDecimal()
+    val anInstant by Column.Instant()
+    val aJson by Column.Json()
+    val aLong by Column.Long()
+    val aFloat by Column.Float()
+    val aShort by Column.Short()
+    val aDate by Column.LocalDate()
+    val aTime by Column.LocalTime()
+    val aDateTime by Column.LocalDateTime()
+
+    init {
+        id; anInt; aDouble; aBool; aText; aDecimal; anInstant; aJson
+        aLong; aFloat; aShort; aDate; aTime; aDateTime
+    }
+}
+
+object ItProducts : Table<ItCatalog, ItProduct>("it_products", ::ItProduct) {
+    val id by Column.UUID()
+    val price by Column.BigDecimal()
+    val qty by Column.Int()
+    val displayName by Column.Text()
+    val note by Column.Text().nullable()
+    val rank by Column.Int().nullable()
+
+    init {
+        id; price; qty; displayName; note; rank
+    }
+}
+
+/**
+ * Exposes the JDBC MySQL [createDatabase] driver as a [Database], backed by a MySQL container
+ * started once for the test run. The container is launched with mysql_native_password so the
+ * first plaintext handshake does not need the caching_sha2_password public-key retrieval dance.
+ */
+object ItDatabase : Database<ItCatalog> {
+    private val container = MySQLContainer("mysql:8.0")
+        .withCommand("--default-authentication-plugin=mysql_native_password")
+        .apply { start() }
+
+    private val driver = createDatabase(
+        host = container.host,
+        port = container.firstMappedPort,
+        database = container.databaseName,
+        user = container.username,
+        password = container.password,
+    )
+
+    fun newDriver(poolSize: Int) = createDatabase(
+        host = container.host,
+        port = container.firstMappedPort,
+        database = container.databaseName,
+        user = container.username,
+        password = container.password,
+        poolSize = poolSize,
+    )
+
+    init {
+        driver.autocommit {
+            executeUpdate(
+                """
+                CREATE TABLE IF NOT EXISTS `it_products` (
+                    `id` CHAR(36) PRIMARY KEY,
+                    `price` DECIMAL(20,4) NOT NULL,
+                    `qty` INT NOT NULL,
+                    `displayName` VARCHAR(255) NOT NULL,
+                    `note` TEXT,
+                    `rank` INT
+                )
+                """.trimIndent(),
+            )
+        }
+    }
+
+    override fun <R> usePinned(transactional: Boolean, block: (io.github.kormium.SqlExecutor) -> R): R =
+        driver.usePinned(transactional, block)
+
+    override fun close() = driver.close()
+}
+
+// Raw schema DDL for tests (MySQL types). UUID -> CHAR(36); jsonb -> JSON; timestamptz -> TIMESTAMP.
+private val allTypesDdl = """CREATE TABLE IF NOT EXISTS `all_types` (`id` CHAR(36) NOT NULL, `anInt` INT NOT NULL, `aDouble` DOUBLE NOT NULL, `aBool` BOOLEAN NOT NULL, `aText` TEXT NOT NULL, `aDecimal` DECIMAL(20,4) NOT NULL, `anInstant` TIMESTAMP NOT NULL, `aJson` JSON NOT NULL, `aLong` BIGINT NOT NULL, `aFloat` FLOAT NOT NULL, `aShort` SMALLINT NOT NULL, `aDate` DATE NOT NULL, `aTime` TIME NOT NULL, `aDateTime` DATETIME NOT NULL, PRIMARY KEY (`id`))"""
+private val authorsDdl = """CREATE TABLE IF NOT EXISTS `authors` (`id` CHAR(36) NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY (`id`))"""
+private val booksDdl = """CREATE TABLE IF NOT EXISTS `books` (`id` CHAR(36) NOT NULL, `authorId` CHAR(36) NOT NULL, `title` TEXT NOT NULL, PRIMARY KEY (`id`), CONSTRAINT `fk_books_author` FOREIGN KEY (`authorId`) REFERENCES `authors` (`id`))"""

--- a/kormium-mysql/src/nativeInterop/cinterop/libmysqlclient.def
+++ b/kormium-mysql/src/nativeInterop/cinterop/libmysqlclient.def
@@ -1,0 +1,31 @@
+headers = mysql.h
+# Broad filter (like libpq.def): mysql.h pulls in mariadb_stmt.h / mariadb_com.h etc., and the
+# prepared-statement functions (mysql_stmt_errno/error/...) live in those, not mysql.h itself.
+headerFilter = *
+package = mysql
+
+# The native MySQL driver links against a MySQL C client library. We target the MariaDB
+# Connector/C (libmariadb), which is API-compatible with libmysqlclient and ships the same
+# mysql.h, and is far easier to install in CI (brew mariadb-connector-c / apt libmariadb-dev)
+# than Oracle's libmysqlclient. The Oracle client also works if its headers/lib are on the paths.
+#
+# Non-standard locations: pass -Pmysql.include=<dir> and -Pmysql.lib=<dir> (see build.gradle.kts).
+
+compilerOpts.osx = -I/opt/homebrew/opt/mariadb-connector-c/include/mariadb \
+    -I/usr/local/opt/mariadb-connector-c/include/mariadb \
+    -I/opt/homebrew/opt/mysql-client/include/mysql \
+    -I/usr/local/opt/mysql-client/include/mysql
+linkerOpts.osx = -L/opt/homebrew/opt/mariadb-connector-c/lib -L/usr/local/opt/mariadb-connector-c/lib \
+    -L/opt/homebrew/opt/mysql-client/lib -L/usr/local/opt/mysql-client/lib -lmariadb
+
+# The trailing macOS brew paths let the linuxX64 klib cross-compile from a macOS publish host
+# (mysql.h is platform-neutral; only the final link of a Linux executable needs the real lib).
+compilerOpts.linux = -I/usr/include/mariadb -I/usr/include/mysql \
+    -I/opt/homebrew/opt/mariadb-connector-c/include/mariadb -I/usr/local/opt/mariadb-connector-c/include/mariadb
+linkerOpts.linux = -L/usr/lib/x86_64-linux-gnu -lmariadb
+
+# Windows: MariaDB Connector/C install. The unix include paths at the end let the klib
+# cross-compile from macOS/Linux CI hosts — mysql.h is platform-neutral, and only the final
+# link of a Windows executable needs the real Windows import library.
+compilerOpts.mingw = -IC:/msys64/mingw64/include/mariadb -IC:/msys64/mingw64/include/mysql \
+    -I/opt/homebrew/opt/mariadb-connector-c/include/mariadb -I/usr/include/mariadb

--- a/kormium-mysql/src/nativeMain/kotlin/database/Database.native.kt
+++ b/kormium-mysql/src/nativeMain/kotlin/database/Database.native.kt
@@ -1,0 +1,21 @@
+package io.github.kormium.database
+
+import io.github.kormium.KormiumConfig
+import io.github.kormium.MySqlDriver
+import io.github.kormium.mysql.MySqlNativeDriver
+
+/**
+ * A native MySQL/MariaDB [MySqlDriver] backed by a MySQL C client (MariaDB Connector/C) over a
+ * fixed connection pool. The blocking path (usePinned) calls the client directly; the suspend path
+ * (useConnection) offloads each blocking call to the IO dispatcher — there is no portable
+ * non-blocking MySQL client API, so this is the same strategy the Postgres driver uses on Windows.
+ */
+actual fun createDatabase(
+    host: String,
+    port: Int,
+    database: String,
+    user: String,
+    password: String,
+    poolSize: Int,
+    config: KormiumConfig,
+): MySqlDriver = MySqlNativeDriver(host, port, database, user, password, poolSize, config)

--- a/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/MySqlNativeDriver.kt
+++ b/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/MySqlNativeDriver.kt
@@ -1,0 +1,344 @@
+package io.github.kormium.mysql
+
+import io.github.kormium.ConnectionPool
+import io.github.kormium.KormiumConfig
+import io.github.kormium.MySqlDialect
+import io.github.kormium.MySqlDriver
+import io.github.kormium.PinnedConnection
+import io.github.kormium.SqlExecutor
+import io.github.kormium.SqlParameterSource
+import io.github.kormium.SuspendSqlExecutor
+import io.github.kormium.WriteListeners
+import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.mysql.exception.ConnectionClosedException
+import io.github.kormium.mysql.exception.QueryExecutionException
+import io.github.kormium.mysql.exception.mysqlException
+import io.github.kormium.resultset.ResultSet
+import io.github.kormium.runConnection
+import io.github.kormium.runPinned
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ULongVar
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.plus
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.readBytes
+import kotlinx.cinterop.set
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.value
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import mysql.MYSQL
+import mysql.MYSQL_BIND
+import mysql.MYSQL_RES
+import mysql.MYSQL_STMT
+import mysql.MYSQL_TYPE_NULL
+import mysql.MYSQL_TYPE_STRING
+import mysql.mysql_close
+import mysql.mysql_error
+import mysql.mysql_fetch_fields
+import mysql.mysql_init
+import mysql.mysql_num_fields
+import mysql.mysql_ping
+import mysql.mysql_query
+import mysql.mysql_real_connect
+import mysql.mysql_set_character_set
+import mysql.mysql_stmt_affected_rows
+import mysql.mysql_stmt_bind_param
+import mysql.mysql_stmt_bind_result
+import mysql.mysql_stmt_close
+import mysql.mysql_stmt_errno
+import mysql.mysql_stmt_error
+import mysql.mysql_stmt_execute
+import mysql.mysql_stmt_fetch
+import mysql.mysql_stmt_fetch_column
+import mysql.mysql_stmt_init
+import mysql.mysql_stmt_num_rows
+import mysql.mysql_stmt_prepare
+import mysql.mysql_stmt_result_metadata
+import mysql.mysql_stmt_sqlstate
+import mysql.mysql_stmt_store_result
+
+// libmysql return codes for mysql_stmt_fetch (not always surfaced as cinterop constants).
+private const val MYSQL_NO_DATA = 100
+private const val MYSQL_DATA_TRUNCATED = 101
+
+// Per-column result buffer size: large enough that numerics, dates, UUIDs and short text never
+// truncate (so their length is reported on the first fetch); longer values refetch into an exact buffer.
+private const val INLINE_BUFFER = 256
+
+/** Either an update count (no result set) or fully-materialized rows. */
+private sealed interface StatementResult {
+    class Update(val count: Long) : StatementResult
+    class Rows(val columns: Array<String>, val rows: List<Array<ByteArray?>>) : StatementResult
+}
+
+@OptIn(ExperimentalForeignApi::class)
+internal class MySqlNativeDriver(
+    private val host: String,
+    private val port: Int,
+    private val database: String,
+    private val user: String,
+    private val password: String,
+    private val poolSize: Int,
+    override val config: KormiumConfig,
+) : MySqlDriver, SuspendDatabase<Nothing> {
+
+    init {
+        require(poolSize >= 1) { "poolSize must be >= 1, was $poolSize" }
+    }
+
+    override val writeListeners: WriteListeners = WriteListeners()
+
+    // A MySQL connection handle is single-threaded: one command at a time. We keep a fixed pool and
+    // hand each connection to exactly one caller at a time through a Channel that doubles as the
+    // "free connection" queue (the same model as the native Postgres driver).
+    private val connections: List<MysqlPtr> = List(poolSize) { openConnection() }
+    private val pool = Channel<MysqlPtr>(poolSize).also { ch -> connections.forEach { ch.trySend(it) } }
+    private val closeLock = Mutex()
+
+    private fun openConnection(): MysqlPtr {
+        val conn = mysql_init(null) ?: throw QueryExecutionException("mysql_init failed (out of memory)")
+        val ok = mysql_real_connect(conn, host, user, password, database, port.convert(), null, 0.convert())
+        if (ok == null) {
+            val message = mysql_error(conn)?.toKString().orEmpty()
+            mysql_close(conn)
+            throw QueryExecutionException(message.ifEmpty { "Failed to connect to MySQL" })
+        }
+        // utf8mb4 so non-ASCII text (and emoji) round-trips; updates the client charset and issues
+        // SET NAMES under the hood. mysql-connector-j already defaults to utf8mb4 on the JVM path.
+        mysql_set_character_set(conn, "utf8mb4")
+        // Pin the session to UTC so a TIMESTAMP round-trips with the UTC datetime text we bind/read.
+        mysql_query(conn, "SET time_zone = '+00:00'")
+        return conn
+    }
+
+    // mysql_ping reconnects a dropped connection when the MYSQL_OPT_RECONNECT default applies; if it
+    // still fails the connection is dead, so reopen it from the stored credentials before reuse.
+    private fun ensureAlive(conn: MysqlPtr): MysqlPtr {
+        if (mysql_ping(conn) == 0) return conn
+        mysql_close(conn)
+        return openConnection()
+    }
+
+    private val connectionPool = object : ConnectionPool {
+        override fun acquire(): PinnedConnection {
+            val conn = pool.tryReceive().getOrNull() ?: try {
+                runBlocking { pool.receive() }
+            } catch (_: ClosedReceiveChannelException) {
+                throw ConnectionClosedException()
+            }
+            return MysqlPinnedConnection(ensureAlive(conn))
+        }
+
+        override suspend fun acquireSuspending(): PinnedConnection {
+            val conn = pool.tryReceive().getOrNull() ?: try {
+                pool.receive()
+            } catch (_: ClosedReceiveChannelException) {
+                throw ConnectionClosedException()
+            }
+            return MysqlPinnedConnection(ensureAlive(conn))
+        }
+    }
+
+    private inner class MysqlPinnedConnection(private val conn: MysqlPtr) : PinnedConnection {
+        override val executor: SqlExecutor = MysqlExecutor(conn)
+        override fun begin() { simpleQuery(conn, "BEGIN") }
+        override fun commit() { simpleQuery(conn, "COMMIT") }
+        override fun rollback() { simpleQuery(conn, "ROLLBACK") }
+        override fun release() { pool.trySend(conn) }
+    }
+
+    override fun <R> usePinned(transactional: Boolean, block: (SqlExecutor) -> R): R =
+        connectionPool.runPinned(transactional, block)
+
+    override suspend fun <R> useConnection(transactional: Boolean, block: suspend (SuspendSqlExecutor) -> R): R =
+        connectionPool.runConnection(transactional, block)
+
+    override fun close() {
+        // tryLock() succeeds only for the first caller; the lock is never released, making close()
+        // idempotent. Draining the pool first waits for any in-flight statement to return its
+        // connection, so we never mysql_close one another thread still uses.
+        if (!closeLock.tryLock()) return
+        runBlocking { repeat(poolSize) { mysql_close(pool.receive()) } }
+        pool.close()
+    }
+
+    private inner class MysqlExecutor(private val conn: MysqlPtr) : SqlExecutor {
+        override val dialect = MySqlDialect
+        override val typeMapper = MySqlNativeTypeMapper
+
+        override fun <T> execute(sql: String, namedParameters: Map<String, Any?>, handler: (ResultSet) -> T) =
+            run(sql, namedParameters).read(handler)
+
+        override fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T) =
+            run(sql, paramSource.toMap()).read(handler)
+
+        override fun execute(sql: String, namedParameters: Map<String, Any?>) = run(sql, namedParameters).count()
+
+        override fun execute(sql: String, paramSource: SqlParameterSource) = run(sql, paramSource.toMap()).count()
+
+        override fun executeUpdate(sql: String, namedParameters: Map<String, Any?>) = run(sql, namedParameters).count()
+
+        private fun run(sql: String, namedParameters: Map<String, Any?>): StatementResult {
+            val parsed = parseNamed(sql)
+            val values = parsed.names.map { name ->
+                if (!namedParameters.containsKey(name)) {
+                    throw QueryExecutionException("No value supplied for the SQL parameter ':$name'")
+                }
+                MySqlNativeTypeMapper.toParameter(namedParameters[name])?.toString()
+            }
+            return runStatement(conn, parsed.sql, values)
+        }
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private typealias MysqlPtr = kotlinx.cinterop.CPointer<MYSQL>
+
+@OptIn(ExperimentalForeignApi::class)
+private fun SqlParameterSource.toMap(): Map<String, Any?> =
+    (parameterNames ?: emptyArray()).associateWith { getValue(it) }
+
+@OptIn(ExperimentalForeignApi::class)
+private fun StatementResult.count(): Long = when (this) {
+    is StatementResult.Update -> count
+    is StatementResult.Rows -> rows.size.toLong()
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun <T> StatementResult.read(handler: (ResultSet) -> T): List<T> = when (this) {
+    is StatementResult.Update -> emptyList()
+    is StatementResult.Rows -> {
+        val rs = MySqlResultSet(columns, rows)
+        ArrayList<T>(rows.size).apply { while (rs.next()) add(handler(rs)) }
+    }
+}
+
+/** Runs a parameter-less statement (BEGIN/COMMIT/ROLLBACK/SET) via the text protocol. */
+@OptIn(ExperimentalForeignApi::class)
+private fun simpleQuery(conn: MysqlPtr, sql: String) {
+    if (mysql_query(conn, sql) != 0) {
+        throw mysqlException(mysql_error(conn)?.toKString().orEmpty().ifEmpty { "MySQL query failed" }, 0u)
+    }
+}
+
+/**
+ * Prepares [sql] (with `?` placeholders), binds [values] as text parameters, executes, and either
+ * returns the affected-row count (no result set) or fully materializes the rows. All output columns
+ * are bound as `MYSQL_TYPE_STRING`, so reading collapses to text.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private fun runStatement(conn: MysqlPtr, sql: String, values: List<String?>): StatementResult = memScoped {
+    val stmt = mysql_stmt_init(conn) ?: throw QueryExecutionException("mysql_stmt_init failed")
+    try {
+        val sqlBytes = sql.encodeToByteArray()
+        if (mysql_stmt_prepare(stmt, sql, sqlBytes.size.convert()) != 0) throwStmtError(stmt)
+
+        if (values.isNotEmpty()) {
+            val binds = allocArray<MYSQL_BIND>(values.size)
+            values.forEachIndexed { k, v ->
+                if (v == null) {
+                    binds[k].buffer_type = MYSQL_TYPE_NULL
+                } else {
+                    val bytes = v.encodeToByteArray()
+                    val buf = allocArray<ByteVar>(bytes.size + 1)
+                    bytes.forEachIndexed { idx, byte -> buf[idx] = byte }
+                    val lenVar = alloc<ULongVar>()
+                    lenVar.value = bytes.size.convert()
+                    binds[k].buffer_type = MYSQL_TYPE_STRING
+                    binds[k].buffer = buf
+                    binds[k].buffer_length = bytes.size.convert()
+                    binds[k].length = lenVar.ptr
+                }
+            }
+            if (mysql_stmt_bind_param(stmt, binds).toInt() != 0) throwStmtError(stmt)
+        }
+
+        if (mysql_stmt_execute(stmt) != 0) throwStmtError(stmt)
+
+        val meta = mysql_stmt_result_metadata(stmt)
+        if (meta == null) {
+            StatementResult.Update(mysql_stmt_affected_rows(stmt).toLong())
+        } else {
+            try {
+                fetchAll(stmt, meta)
+            } finally {
+                mysql.mysql_free_result(meta)
+            }
+        }
+    } finally {
+        mysql_stmt_close(stmt)
+    }
+}
+
+/** Binds every column as a string, stores the result client-side, and materializes all rows. */
+@OptIn(ExperimentalForeignApi::class)
+private fun fetchAll(stmt: kotlinx.cinterop.CPointer<MYSQL_STMT>, meta: kotlinx.cinterop.CPointer<MYSQL_RES>): StatementResult.Rows =
+    memScoped {
+        val nFields = mysql_num_fields(meta).toInt()
+        val fields = mysql_fetch_fields(meta)!!
+        val names = Array(nFields) { fields[it].name!!.toKString() }
+
+        val binds = allocArray<MYSQL_BIND>(nFields)
+        val lengths = allocArray<ULongVar>(nFields)
+        val isNulls = allocArray<ByteVar>(nFields)
+        val errors = allocArray<ByteVar>(nFields)
+        // Each column gets a real fixed buffer up front, not a zero-length one. A zero-length result
+        // bind does not reliably report the converted length for binary-typed columns (a DOUBLE read
+        // as MYSQL_TYPE_STRING comes back empty), so we bind a buffer big enough for numerics, dates,
+        // UUIDs and short text, and only fall back to a per-column refetch when a value is truncated.
+        val buffers = Array(nFields) { allocArray<ByteVar>(INLINE_BUFFER) }
+        for (c in 0 until nFields) {
+            binds[c].buffer_type = MYSQL_TYPE_STRING
+            binds[c].buffer = buffers[c]
+            binds[c].buffer_length = INLINE_BUFFER.convert()
+            binds[c].length = lengths + c
+            binds[c].is_null = isNulls + c
+            binds[c].error = errors + c
+        }
+        if (mysql_stmt_bind_result(stmt, binds).toInt() != 0) throwStmtError(stmt)
+        if (mysql_stmt_store_result(stmt) != 0) throwStmtError(stmt)
+
+        val rows = ArrayList<Array<ByteArray?>>(mysql_stmt_num_rows(stmt).toInt())
+        while (true) {
+            val rc = mysql_stmt_fetch(stmt)
+            if (rc == MYSQL_NO_DATA) break
+            if (rc != 0 && rc != MYSQL_DATA_TRUNCATED) throwStmtError(stmt)
+            val row = arrayOfNulls<ByteArray>(nFields)
+            for (c in 0 until nFields) {
+                if (isNulls[c].toInt() != 0) continue
+                val len = lengths[c].toInt()
+                row[c] = if (len <= INLINE_BUFFER) {
+                    buffers[c].readBytes(len)
+                } else {
+                    // Value longer than the inline buffer (large TEXT/BLOB): refetch this column
+                    // alone into an exactly-sized buffer, then restore the inline buffer.
+                    val big = allocArray<ByteVar>(len)
+                    binds[c].buffer = big
+                    binds[c].buffer_length = len.convert()
+                    mysql_stmt_fetch_column(stmt, binds[c].ptr, c.convert(), 0.convert())
+                    val bytes = big.readBytes(len)
+                    binds[c].buffer = buffers[c]
+                    binds[c].buffer_length = INLINE_BUFFER.convert()
+                    bytes
+                }
+            }
+            rows.add(row)
+        }
+        StatementResult.Rows(names, rows)
+    }
+
+@OptIn(ExperimentalForeignApi::class)
+private fun throwStmtError(stmt: kotlinx.cinterop.CPointer<MYSQL_STMT>): Nothing {
+    val errno = mysql_stmt_errno(stmt)
+    val message = mysql_stmt_error(stmt)?.toKString().orEmpty().ifEmpty { "MySQL statement failed" }
+    val sqlState = mysql_stmt_sqlstate(stmt)?.toKString()?.takeIf { it.isNotBlank() && it != "00000" }
+    throw mysqlException(message, errno, sqlState)
+}

--- a/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/MySqlNativeTypeMapper.kt
+++ b/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/MySqlNativeTypeMapper.kt
@@ -1,0 +1,33 @@
+package io.github.kormium.mysql
+
+import io.github.kormium.StandardTypeMapper
+import io.github.kormium.TypeMapper
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Native MySQL parameter mapping. The native driver binds every value as text (MySQL coerces the
+ * string to the column type), so this only needs to fix the cases where the default text form is
+ * not a valid MySQL literal:
+ *
+ *  - an [Instant] / [LocalDateTime] render with a `T` separator (and `Z`), which MySQL rejects —
+ *    they become `"yyyy-MM-dd HH:mm:ss"` (the Instant first projected to UTC, matching the
+ *    `SET time_zone = '+00:00'` the driver issues on connect).
+ *
+ * Everything else (UUID, JsonElement, BigDecimal, primitives, LocalDate/LocalTime) is handled by
+ * [StandardTypeMapper] — their `toString()` is already a valid MySQL literal.
+ */
+object MySqlNativeTypeMapper : TypeMapper {
+    override fun toParameter(value: Any?): Any? = when (value) {
+        is Instant -> value.toLocalDateTime(TimeZone.UTC).toMysqlText()
+        is LocalDateTime -> value.toMysqlText()
+        // MySQL's BOOLEAN is TINYINT: a text-bound parameter must be "1"/"0", not "true"/"false"
+        // (which strict mode rejects with "Incorrect integer value").
+        is Boolean -> if (value) "1" else "0"
+        else -> StandardTypeMapper.toParameter(value)
+    }
+
+    private fun LocalDateTime.toMysqlText(): String = toString().replace('T', ' ')
+}

--- a/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/MySqlResultSet.kt
+++ b/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/MySqlResultSet.kt
@@ -1,0 +1,60 @@
+package io.github.kormium.mysql
+
+import io.github.kormium.resultset.ResultSet
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+
+/**
+ * A core [ResultSet] over a fully-materialized MySQL result. Each cell is the column's raw bytes
+ * (or `null` for SQL NULL): the native driver binds every output column as `MYSQL_TYPE_STRING`, so
+ * the bytes are the value's text form — exactly what korm's text-based column reading expects (the
+ * same model as libpq's text result format). Binary columns are read verbatim via [getBytes].
+ *
+ * Date/times come back as MySQL's space-separated `"yyyy-MM-dd HH:mm:ss"`; the session is pinned to
+ * UTC on connect, so a `TIMESTAMP` text reads back as the correct [Instant].
+ */
+internal class MySqlResultSet(
+    override val columns: Array<String>,
+    private val rows: List<Array<ByteArray?>>,
+) : ResultSet {
+
+    private var index = -1
+
+    override fun next(): Boolean {
+        index++
+        return index < rows.size
+    }
+
+    private fun text(columnIndex: Int): String? = rows[index][columnIndex]?.decodeToString()
+
+    override fun getString(columnIndex: Int): String? = text(columnIndex)
+
+    // MySQL renders BOOLEAN/TINYINT(1) as "0"/"1".
+    override fun getBoolean(columnIndex: Int): Boolean? = text(columnIndex)?.let { it != "0" }
+
+    override fun getShort(columnIndex: Int): Short? = text(columnIndex)?.toShort()
+
+    override fun getInt(columnIndex: Int): Int? = text(columnIndex)?.toInt()
+
+    override fun getLong(columnIndex: Int): Long? = text(columnIndex)?.toLong()
+
+    override fun getFloat(columnIndex: Int): Float? = text(columnIndex)?.toFloat()
+
+    override fun getDouble(columnIndex: Int): Double? = text(columnIndex)?.toDouble()
+
+    override fun getBytes(columnIndex: Int): ByteArray? = rows[index][columnIndex]
+
+    override fun getDate(columnIndex: Int): LocalDate? = text(columnIndex)?.let { LocalDate.parse(it) }
+
+    override fun getTime(columnIndex: Int): LocalTime? = text(columnIndex)?.let { LocalTime.parse(it) }
+
+    override fun getLocalDateTime(columnIndex: Int): LocalDateTime? =
+        text(columnIndex)?.let { LocalDateTime.parse(it.replace(' ', 'T')) }
+
+    override fun getInstant(columnIndex: Int): Instant? =
+        text(columnIndex)?.let { LocalDateTime.parse(it.replace(' ', 'T')).toInstant(TimeZone.UTC) }
+}

--- a/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/NamedSql.kt
+++ b/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/NamedSql.kt
@@ -1,0 +1,58 @@
+package io.github.kormium.mysql
+
+/** A SQL string with its `:name` placeholders rewritten to MySQL `?`, plus the names in order. */
+internal class NamedSql(val sql: String, val names: List<String>)
+
+/**
+ * Rewrites korm's `:name` placeholders to MySQL positional `?` and records the names in occurrence
+ * order so values bind by index. Quoted strings/identifiers (`'…'`, `"…"`, `` `…` ``) and `--` /
+ * `/* */` comments are copied verbatim so a `:` inside them is not treated as a parameter. MySQL has
+ * no `::` cast operator, so (unlike the Postgres parser) there is no special-casing for it.
+ */
+internal fun parseNamed(sql: String): NamedSql {
+    val out = StringBuilder(sql.length)
+    val names = ArrayList<String>()
+    var i = 0
+    while (i < sql.length) {
+        val c = sql[i]
+        when {
+            c == '\'' || c == '"' || c == '`' -> {
+                out.append(c)
+                i++
+                while (i < sql.length) {
+                    val ch = sql[i]
+                    out.append(ch)
+                    i++
+                    if (ch == c) {
+                        // A doubled quote is an escape inside the literal, not its end.
+                        if (i < sql.length && sql[i] == c) {
+                            out.append(sql[i]); i++; continue
+                        }
+                        break
+                    }
+                }
+            }
+            c == '-' && i + 1 < sql.length && sql[i + 1] == '-' -> {
+                while (i < sql.length && sql[i] != '\n') { out.append(sql[i]); i++ }
+            }
+            c == '/' && i + 1 < sql.length && sql[i + 1] == '*' -> {
+                out.append("/*"); i += 2
+                while (i < sql.length) {
+                    if (sql[i] == '*' && i + 1 < sql.length && sql[i + 1] == '/') {
+                        out.append("*/"); i += 2; break
+                    }
+                    out.append(sql[i]); i++
+                }
+            }
+            c == ':' && i + 1 < sql.length && (sql[i + 1].isLetter() || sql[i + 1] == '_') -> {
+                var j = i + 1
+                while (j < sql.length && (sql[j].isLetterOrDigit() || sql[j] == '_')) j++
+                names.add(sql.substring(i + 1, j))
+                out.append('?')
+                i = j
+            }
+            else -> { out.append(c); i++ }
+        }
+    }
+    return NamedSql(out.toString(), names)
+}

--- a/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/exception/Exceptions.kt
+++ b/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/exception/Exceptions.kt
@@ -1,0 +1,19 @@
+package io.github.kormium.mysql.exception
+
+import io.github.kormium.KormiumException
+import io.github.kormium.QueryException
+import io.github.kormium.mysqlVendorException
+
+/** Raised when a statement (or the initial connection) fails on the server. */
+class QueryExecutionException(message: String, cause: Throwable? = null) : KormiumException(message, cause)
+
+/** Raised when the native driver is used after it was closed. */
+class ConnectionClosedException : KormiumException("MySqlDriver is closed")
+
+/**
+ * Maps a MySQL/MariaDB vendor error number (`mysql_stmt_errno`) to the most specific core
+ * [QueryException] subtype via the shared [mysqlVendorException] table. [sqlState] is the server's
+ * 5-character SQLSTATE (`mysql_stmt_sqlstate`) when known.
+ */
+fun mysqlException(message: String, errno: UInt, sqlState: String? = null): QueryException =
+    mysqlVendorException(message, errno.toInt(), sqlState)

--- a/kormium-mysql/src/nativeTest/kotlin/NativeMySqlTest.kt
+++ b/kormium-mysql/src/nativeTest/kotlin/NativeMySqlTest.kt
@@ -1,0 +1,291 @@
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import io.github.kormium.Catalog
+import io.github.kormium.Column
+import io.github.kormium.Entity
+import io.github.kormium.MySqlDriver
+import io.github.kormium.Query
+import io.github.kormium.Table
+import io.github.kormium.UniqueViolationException
+import io.github.kormium.autocommit
+import io.github.kormium.database.Database
+import io.github.kormium.database.createDatabase
+import io.github.kormium.eq
+import io.github.kormium.transaction
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.serialization.json.JsonPrimitive
+import platform.posix.getenv
+import kotlinx.cinterop.toKString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.uuid.Uuid
+
+/**
+ * End-to-end tests for the native (libmysqlclient/MariaDB Connector/C) driver. They need a running
+ * MySQL/MariaDB reachable at MYSQL_HOST/MYSQL_PORT/MYSQL_USER/MYSQL_PASSWORD/MYSQL_DB (defaults:
+ * 127.0.0.1:3306, root, empty, kormium_test). When no server is reachable the suite skips itself
+ * (the native test target has no Docker/Testcontainers, so this mirrors assumeDockerAvailable).
+ */
+@OptIn(ExperimentalForeignApi::class)
+class NativeMySqlTest {
+
+    private fun env(name: String, default: String): String = getenv(name)?.toKString() ?: default
+
+    private fun connectOrNull(poolSize: Int = 4): MySqlDriver? = try {
+        createDatabase(
+            host = env("MYSQL_HOST", "127.0.0.1"),
+            port = env("MYSQL_PORT", "3306").toInt(),
+            database = env("MYSQL_DB", "kormium_test"),
+            user = env("MYSQL_USER", "root"),
+            password = env("MYSQL_PASSWORD", ""),
+            poolSize = poolSize,
+        )
+    } catch (e: Throwable) {
+        println("Skipping native MySQL test: ${e.message}")
+        null
+    }
+
+    @Test
+    fun allColumnTypesRoundTrip() {
+        val driver = connectOrNull() ?: return
+        val db: Database<NativeCatalog> = driver
+        driver.use {
+            val id = Uuid.random()
+            val instant = Instant.parse("2024-01-02T03:04:05Z")
+            val json = JsonPrimitive("hi")
+            val date = LocalDate.parse("2024-01-02")
+            val time = LocalTime.parse("03:04:05")
+            val dateTime = LocalDateTime.parse("2024-01-02T03:04:05")
+            db.transaction {
+                NativeAllTypes.execSql(allTypesDdl)
+                NativeAllTypes.deleteWhere(Query(NativeAllTypes.id eq id))
+                NativeAllTypes.insert(NativeAllTypesEntity().apply {
+                    this.id = id
+                    this.anInt = 42
+                    this.aDouble = 2.5
+                    this.aBool = true
+                    this.aText = "txt"
+                    this.aDecimal = BigDecimal.fromInt(123)
+                    this.anInstant = instant
+                    this.aJson = json
+                    this.aLong = 9_000_000_000L
+                    this.aFloat = 1.5f
+                    this.aShort = 7.toShort()
+                    this.aDate = date
+                    this.aTime = time
+                    this.aDateTime = dateTime
+                })
+            }
+            val row = db.autocommit { NativeAllTypes.findById(id) }!!
+            assertEquals(42, row.anInt)
+            assertEquals(2.5, row.aDouble)
+            assertEquals(true, row.aBool)
+            assertEquals("txt", row.aText)
+            assertEquals(0, BigDecimal.fromInt(123).compareTo(row.aDecimal))
+            assertEquals(instant, row.anInstant)
+            assertEquals(json, row.aJson)
+            assertEquals(9_000_000_000L, row.aLong)
+            assertEquals(1.5f, row.aFloat)
+            assertEquals(7.toShort(), row.aShort)
+            assertEquals(date, row.aDate)
+            assertEquals(time, row.aTime)
+            assertEquals(dateTime, row.aDateTime)
+            db.transaction { NativeAllTypes.deleteWhere(Query(NativeAllTypes.id eq id)) }
+        }
+    }
+
+    @Test
+    fun crudAndQuoteRoundTrip() {
+        val driver = connectOrNull() ?: return
+        val db: Database<NativeCatalog> = driver
+        driver.use {
+            db.transaction { NativeProducts.execSql(productsDdl) }
+            val id = Uuid.random()
+            val tricky = "O'Brien'; DROP TABLE x; --"
+            db.transaction {
+                NativeProducts.deleteWhere(Query(NativeProducts.id eq id))
+                NativeProducts.insert(NativeProduct().apply {
+                    this.id = id; this.qty = 5; this.name = tricky
+                })
+            }
+            val found = db.autocommit { NativeProducts.findById(id) }
+            assertEquals(5, found?.qty)
+            assertEquals(tricky, found?.name)
+            db.transaction {
+                NativeProducts.update(Query(NativeProducts.id eq id), NativeProduct().apply { qty = 9 })
+            }
+            assertEquals(9, db.autocommit { NativeProducts.findById(id) }?.qty)
+            db.transaction { NativeProducts.deleteWhere(Query(NativeProducts.id eq id)) }
+        }
+    }
+
+    @Test
+    fun returningInsertReSelectsByPk() {
+        val driver = connectOrNull() ?: return
+        val db: Database<NativeCatalog> = driver
+        driver.use {
+            db.transaction { NativeProducts.execSql(productsDdl) }
+            val id = Uuid.random()
+            db.transaction { NativeProducts.deleteWhere(Query(NativeProducts.id eq id)) }
+            val returned = db.transaction {
+                NativeProducts.insert(
+                    NativeProduct().apply { this.id = id; this.qty = 7; this.name = "ret" },
+                    returning = true,
+                )
+            }
+            assertEquals(id, returned?.id)
+            assertEquals("ret", returned?.name)
+            db.transaction { NativeProducts.deleteWhere(Query(NativeProducts.id eq id)) }
+        }
+    }
+
+    @Test
+    fun upsertAndInsertOrIgnore() {
+        val driver = connectOrNull() ?: return
+        val db: Database<NativeCatalog> = driver
+        driver.use {
+            db.transaction { NativeProducts.execSql(productsDdl) }
+            val id = Uuid.random()
+            db.transaction {
+                NativeProducts.deleteWhere(Query(NativeProducts.id eq id))
+                NativeProducts.insert(NativeProduct().apply { this.id = id; this.qty = 1; this.name = "orig" })
+            }
+            db.transaction {
+                NativeProducts.upsert(
+                    NativeProduct().apply { this.id = id; this.qty = 1; this.name = "x" },
+                    onConflict = NativeProducts.id,
+                    update = NativeProduct().apply { this.qty = 99 },
+                )
+            }
+            assertEquals(99, db.autocommit { NativeProducts.findById(id) }?.qty)
+
+            db.transaction {
+                NativeProducts.insertOrIgnore(
+                    NativeProduct().apply { this.id = id; this.qty = 2; this.name = "dup" },
+                    onConflict = NativeProducts.id,
+                )
+            }
+            assertEquals("orig", db.autocommit { NativeProducts.findById(id) }?.name) // unchanged
+            db.transaction { NativeProducts.deleteWhere(Query(NativeProducts.id eq id)) }
+        }
+    }
+
+    @Test
+    fun cyrillicRoundTrip() {
+        val driver = connectOrNull() ?: return
+        val db: Database<NativeCatalog> = driver
+        driver.use {
+            db.transaction { NativeProducts.execSql(productsDdl) }
+            val id = Uuid.random()
+            val text = "Привет, мир 🌍"
+            db.transaction {
+                NativeProducts.deleteWhere(Query(NativeProducts.id eq id))
+                NativeProducts.insert(NativeProduct().apply { this.id = id; this.qty = 1; this.name = text })
+            }
+            assertEquals(text, db.autocommit { NativeProducts.findById(id) }?.name)
+            db.transaction { NativeProducts.deleteWhere(Query(NativeProducts.id eq id)) }
+        }
+    }
+
+    @Test
+    fun typedUniqueViolation() {
+        val driver = connectOrNull() ?: return
+        val db: Database<NativeCatalog> = driver
+        driver.use {
+            db.transaction { NativeProducts.execSql(productsDdl) }
+            val id = Uuid.random()
+            db.transaction {
+                NativeProducts.deleteWhere(Query(NativeProducts.id eq id))
+                NativeProducts.insert(NativeProduct().apply { this.id = id; this.qty = 1; this.name = "dup" })
+            }
+            assertFailsWith<UniqueViolationException> {
+                db.transaction {
+                    NativeProducts.insert(NativeProduct().apply { this.id = id; this.qty = 2; this.name = "dup2" })
+                }
+            }
+            db.transaction { NativeProducts.deleteWhere(Query(NativeProducts.id eq id)) }
+        }
+    }
+
+    @Test
+    fun transactionRollsBack() {
+        val driver = connectOrNull() ?: return
+        val db: Database<NativeCatalog> = driver
+        driver.use {
+            db.transaction { NativeProducts.execSql(productsDdl) }
+            val id = Uuid.random()
+            assertFailsWith<RuntimeException> {
+                db.transaction {
+                    NativeProducts.insert(NativeProduct().apply { this.id = id; this.qty = 1; this.name = "boom" })
+                    throw RuntimeException("boom")
+                }
+            }
+            assertEquals(null, db.autocommit { NativeProducts.findById(id) })
+        }
+    }
+}
+
+object NativeCatalog : Catalog
+
+class NativeProduct : Entity() {
+    var id by NativeProducts.id
+    var qty by NativeProducts.qty
+    var name by NativeProducts.name
+}
+
+object NativeProducts : Table<NativeCatalog, NativeProduct>("native_products", ::NativeProduct) {
+    val id by Column.UUID()
+    val qty by Column.Int()
+    val name by Column.Text()
+
+    init { id; qty; name }
+}
+
+class NativeAllTypesEntity : Entity() {
+    var id by NativeAllTypes.id
+    var anInt by NativeAllTypes.anInt
+    var aDouble by NativeAllTypes.aDouble
+    var aBool by NativeAllTypes.aBool
+    var aText by NativeAllTypes.aText
+    var aDecimal by NativeAllTypes.aDecimal
+    var anInstant by NativeAllTypes.anInstant
+    var aJson by NativeAllTypes.aJson
+    var aLong by NativeAllTypes.aLong
+    var aFloat by NativeAllTypes.aFloat
+    var aShort by NativeAllTypes.aShort
+    var aDate by NativeAllTypes.aDate
+    var aTime by NativeAllTypes.aTime
+    var aDateTime by NativeAllTypes.aDateTime
+}
+
+object NativeAllTypes : Table<NativeCatalog, NativeAllTypesEntity>("native_all_types", ::NativeAllTypesEntity) {
+    val id by Column.UUID()
+    val anInt by Column.Int()
+    val aDouble by Column.Double()
+    val aBool by Column.Boolean()
+    val aText by Column.Text()
+    val aDecimal by Column.BigDecimal()
+    val anInstant by Column.Instant()
+    val aJson by Column.Json()
+    val aLong by Column.Long()
+    val aFloat by Column.Float()
+    val aShort by Column.Short()
+    val aDate by Column.LocalDate()
+    val aTime by Column.LocalTime()
+    val aDateTime by Column.LocalDateTime()
+
+    init {
+        id; anInt; aDouble; aBool; aText; aDecimal; anInstant; aJson
+        aLong; aFloat; aShort; aDate; aTime; aDateTime
+    }
+}
+
+private val productsDdl =
+    "CREATE TABLE IF NOT EXISTS `native_products` (`id` CHAR(36) NOT NULL, `qty` INT NOT NULL, `name` VARCHAR(255) NOT NULL, PRIMARY KEY (`id`))"
+
+private val allTypesDdl =
+    "CREATE TABLE IF NOT EXISTS `native_all_types` (`id` CHAR(36) NOT NULL, `anInt` INT NOT NULL, `aDouble` DOUBLE NOT NULL, `aBool` BOOLEAN NOT NULL, `aText` TEXT NOT NULL, `aDecimal` DECIMAL(20,4) NOT NULL, `anInstant` TIMESTAMP NOT NULL, `aJson` JSON NOT NULL, `aLong` BIGINT NOT NULL, `aFloat` FLOAT NOT NULL, `aShort` SMALLINT NOT NULL, `aDate` DATE NOT NULL, `aTime` TIME NOT NULL, `aDateTime` DATETIME NOT NULL, PRIMARY KEY (`id`))"

--- a/kormium-r2dbc/build.gradle.kts
+++ b/kormium-r2dbc/build.gradle.kts
@@ -23,7 +23,10 @@ kotlin {
                 api(project(":kormium-core"))
                 // PostgresDialect (the ::uuid cast) is reused verbatim for SQL rendering.
                 api(project(":kormium-postgres"))
+                // MySqlDialect + MySqlJvmTypeMapper for the MySQL r2dbc factory.
+                api(project(":kormium-mysql"))
                 implementation("org.postgresql:r2dbc-postgresql:1.0.7.RELEASE")
+                implementation("io.asyncer:r2dbc-mysql:1.3.0")
                 implementation("io.r2dbc:r2dbc-pool:1.0.2.RELEASE")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:1.10.2")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
@@ -34,6 +37,7 @@ kotlin {
                 implementation(kotlin("test"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
                 implementation("org.testcontainers:postgresql:1.20.4")
+                implementation("org.testcontainers:mysql:1.20.4")
             }
         }
     }

--- a/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/MySqlR2dbc.kt
+++ b/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/MySqlR2dbc.kt
@@ -1,0 +1,57 @@
+package io.github.kormium.r2dbc
+
+import io.github.kormium.KormiumConfig
+import io.github.kormium.MySqlDialect
+import io.github.kormium.MySqlJvmTypeMapper
+import io.github.kormium.mysqlVendorException
+import io.asyncer.r2dbc.mysql.MySqlConnectionConfiguration
+import io.asyncer.r2dbc.mysql.MySqlConnectionFactory
+import io.r2dbc.pool.ConnectionPool
+import io.r2dbc.pool.ConnectionPoolConfiguration
+
+/**
+ * Opens an async MySQL/MariaDB database over r2dbc-mysql with a reactive connection pool of
+ * [poolSize]. Mirrors [createR2dbcDatabase] (Postgres) but wires the MySQL pieces into the generic
+ * [R2dbcDatabase]:
+ *
+ *  - [MySqlDialect] for SQL rendering (backtick identifiers, MySQL LIMIT/OFFSET);
+ *  - [QuestionMarkParamMarker] so `:name` placeholders are rewritten to `?` (r2dbc-mysql's marker);
+ *  - [MySqlJvmTypeMapper] so UUID/JSON bind as text and date/times bind as native `java.time`
+ *    values (an [kotlinx.datetime.Instant] as a UTC `OffsetDateTime`), with the session pinned to
+ *    UTC so timestamps round-trip unchanged.
+ *
+ * Returns it tagged [Nothing] (covariance pins the catalog at the call site).
+ */
+fun createMySqlR2dbcDatabase(
+    host: String,
+    port: Int = 3306,
+    database: String,
+    user: String,
+    password: String,
+    poolSize: Int = 10,
+    config: KormiumConfig = KormiumConfig(),
+): R2dbcDatabase {
+    val connectionFactory = MySqlConnectionFactory.from(
+        MySqlConnectionConfiguration.builder()
+            .host(host)
+            .port(port)
+            .database(database)
+            .user(user)
+            .password(password)
+            .connectionTimeZone("UTC")
+            .forceConnectionTimeZoneToSession(true)
+            .build(),
+    )
+    val poolConfiguration = ConnectionPoolConfiguration.builder(connectionFactory)
+        .maxSize(poolSize)
+        .build()
+    return R2dbcDatabase(
+        ConnectionPool(poolConfiguration),
+        MySqlDialect,
+        MySqlJvmTypeMapper,
+        QuestionMarkParamMarker,
+        // MySQL reports integrity violations under SQLSTATE 23000; map by vendor code instead.
+        { e -> mysqlVendorException(e.message ?: "SQL error", e.errorCode, e.sqlState, e) },
+        config,
+    )
+}

--- a/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/NamedParams.kt
+++ b/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/NamedParams.kt
@@ -1,15 +1,27 @@
 package io.github.kormium.r2dbc
 
-/** A SQL string with its `:name` placeholders rewritten to Postgres `$N`, plus the names in order. */
+/** A SQL string with its `:name` placeholders rewritten to the driver's marker, plus the names in order. */
 internal class ParsedSql(val sql: String, val names: List<String>)
 
 /**
- * Rewrites korm's Spring-style `:name` placeholders to r2dbc-postgresql's positional
- * `$1, $2, ...` and records the names in occurrence order so values can be bound by
- * index. `::` casts (Postgres) and quoted string literals are left untouched. This is
- * the same parse as the JDBC NamedParamStatement, differing only in the emitted marker.
+ * Renders the positional bind marker for the 0-based parameter [index]. The placeholder syntax is
+ * driver-specific: r2dbc-postgresql wants `$1, $2, …`, r2dbc-mysql wants a bare `?`.
  */
-internal fun parseNamedParams(sql: String): ParsedSql {
+internal typealias ParamMarker = (index: Int) -> String
+
+/** r2dbc-postgresql positional markers: `$1, $2, …` (1-based in the SQL, bound by 0-based index). */
+internal val PostgresParamMarker: ParamMarker = { i -> "\$${i + 1}" }
+
+/** r2dbc-mysql positional markers: a bare `?` for every parameter, bound by 0-based index. */
+internal val QuestionMarkParamMarker: ParamMarker = { "?" }
+
+/**
+ * Rewrites korm's Spring-style `:name` placeholders to the driver's positional marker (via
+ * [marker]) and records the names in occurrence order so values can be bound by index. `::` casts
+ * (Postgres) and quoted string literals are left untouched. This is the same parse as the JDBC
+ * NamedParamStatement, differing only in the emitted marker.
+ */
+internal fun parseNamedParams(sql: String, marker: ParamMarker): ParsedSql {
     val out = StringBuilder(sql.length)
     val names = ArrayList<String>()
     var i = 0
@@ -59,7 +71,7 @@ internal fun parseNamedParams(sql: String): ParsedSql {
                 var j = i + 1
                 while (j < sql.length && (sql[j].isLetterOrDigit() || sql[j] == '_')) j++
                 names.add(sql.substring(i + 1, j))
-                out.append('$').append(names.size) // $1, $2, ... (1-based)
+                out.append(marker(names.size - 1)) // 0-based index for binding
                 i = j
             }
             else -> {

--- a/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/R2dbcDatabase.kt
+++ b/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/R2dbcDatabase.kt
@@ -30,6 +30,11 @@ class R2dbcDatabase internal constructor(
     private val pool: ConnectionPool,
     private val dialect: Dialect,
     private val typeMapper: TypeMapper,
+    // The driver's positional bind marker ($N for postgres, ? for mysql). Defaults to postgres so
+    // existing call sites are unchanged.
+    private val marker: ParamMarker = PostgresParamMarker,
+    // Backend-specific exception translation; defaults to the SQLSTATE mapping (Postgres).
+    private val translate: R2dbcExceptionTranslator = StandardR2dbcExceptionTranslator,
     override val config: KormiumConfig = KormiumConfig(),
 ) : SuspendDatabase<Nothing> {
 
@@ -40,7 +45,7 @@ class R2dbcDatabase internal constructor(
         val connection = pool.create().awaitSingle()
         try {
             if (transactional) connection.beginTransaction().awaitFirstOrNull()
-            val exec = R2dbcExecutor(connection, dialect, typeMapper)
+            val exec = R2dbcExecutor(connection, dialect, typeMapper, marker, translate)
             return try {
                 block(exec).also { if (transactional) connection.commitTransaction().awaitFirstOrNull() }
             } catch (e: Throwable) {
@@ -84,5 +89,12 @@ fun createR2dbcDatabase(
     val poolConfiguration = ConnectionPoolConfiguration.builder(connectionFactory)
         .maxSize(poolSize)
         .build()
-    return R2dbcDatabase(ConnectionPool(poolConfiguration), PostgresDialect, StandardTypeMapper, config)
+    return R2dbcDatabase(
+        ConnectionPool(poolConfiguration),
+        PostgresDialect,
+        StandardTypeMapper,
+        PostgresParamMarker,
+        StandardR2dbcExceptionTranslator,
+        config,
+    )
 }

--- a/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/R2dbcExecutor.kt
+++ b/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/R2dbcExecutor.kt
@@ -19,14 +19,27 @@ import kotlinx.coroutines.reactive.asFlow
  * conversion ([TypeMapper]) are reused verbatim from kormium-postgres; only the bind step
  * differs — `:name` is rewritten to `$N` and bound by index.
  */
+/**
+ * Translates a driver [R2dbcException] into a core exception. Backends differ in how they report
+ * constraint violations (Postgres via SQLSTATE, MySQL via vendor code under SQLSTATE 23000), so each
+ * supplies its own; [StandardR2dbcExceptionTranslator] maps the standard SQLSTATE.
+ */
+internal typealias R2dbcExceptionTranslator = (R2dbcException) -> Throwable
+
+/** The default translator: maps the SQLSTATE to a typed core exception (the Postgres path). */
+internal val StandardR2dbcExceptionTranslator: R2dbcExceptionTranslator =
+    { e -> sqlException(e.message ?: "SQL error", e.sqlState, e) }
+
 internal class R2dbcExecutor(
     private val connection: Connection,
     override val dialect: Dialect,
     override val typeMapper: TypeMapper,
+    private val marker: ParamMarker,
+    private val translate: R2dbcExceptionTranslator,
 ) : SuspendSqlExecutor {
 
     private fun prepare(sql: String, namedParameters: Map<String, Any?>): Statement {
-        val parsed = parseNamedParams(sql)
+        val parsed = parseNamedParams(sql, marker)
         val statement = connection.createStatement(parsed.sql)
         parsed.names.forEachIndexed { index, name ->
             // A missing key is a typo, not an explicit null: reject it so raw SQL fails fast
@@ -71,13 +84,13 @@ internal class R2dbcExecutor(
     override suspend fun executeUpdate(sql: String, namedParameters: Map<String, Any?>): Long =
         execute(sql, namedParameters)
 
-    // Map r2dbc's exceptions to korm's typed ones via the same SQLSTATE helper the JDBC
-    // backend uses (UniqueViolation 23505, ForeignKey 23503, ...).
+    // Map r2dbc's exceptions to korm's typed ones via the backend-supplied translator (SQLSTATE
+    // for Postgres, vendor code for MySQL).
     private suspend fun <T> translating(block: suspend () -> T): T =
         try {
             block()
         } catch (e: R2dbcException) {
-            throw sqlException(e.message ?: "SQL error", e.sqlState, e)
+            throw translate(e)
         }
 }
 

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/MySqlR2dbcIntegrationTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/MySqlR2dbcIntegrationTest.kt
@@ -1,0 +1,148 @@
+package io.github.kormium.r2dbc
+
+import io.github.kormium.Catalog
+import io.github.kormium.Column
+import io.github.kormium.Entity
+import io.github.kormium.Query
+import io.github.kormium.Table
+import io.github.kormium.UniqueViolationException
+import io.github.kormium.count
+import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.eq
+import io.github.kormium.suspendAutocommit
+import io.github.kormium.suspendTransaction
+import kotlinx.coroutines.runBlocking
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.MySQLContainer
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * End-to-end test of the async r2dbc-mysql backend against a real MySQL (Testcontainers). Mirrors
+ * the Postgres [R2dbcIntegrationTest]: suspendTransaction/suspendAutocommit →
+ * R2dbcDatabase.useConnection over the same Table DSL, with MySQL DDL and `?` bind markers. Skips
+ * gracefully when Docker isn't available. Integrity violations are mapped to typed exceptions by
+ * vendor code (MySQL reports them all under SQLSTATE 23000), like the JDBC and native drivers.
+ */
+class MySqlR2dbcIntegrationTest {
+
+    private val dockerAvailable = DockerClientFactory.instance().isDockerAvailable
+    private var container: MySQLContainer<*>? = null
+    private var db: SuspendDatabase<MyR2Catalog>? = null
+
+    @BeforeTest
+    fun setUp() {
+        if (!dockerAvailable) return
+        val mysql = MySQLContainer("mysql:8.0")
+            .withCommand("--default-authentication-plugin=mysql_native_password")
+        mysql.start()
+        container = mysql
+        db = createMySqlR2dbcDatabase(
+            host = mysql.host,
+            port = mysql.firstMappedPort,
+            database = mysql.databaseName,
+            user = mysql.username,
+            password = mysql.password,
+            poolSize = 4,
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        db?.close()
+        container?.stop()
+    }
+
+    @Test
+    fun crudRoundTrip() {
+        if (!dockerAvailable) return
+        val database = db!!
+        runBlocking {
+            val id = Uuid.random()
+            database.suspendTransaction {
+                MyWidgets.execSql(myWidgetsDdl)
+                MyWidgets.insert(MyWidget().apply {
+                    this.id = id
+                    this.name = "async-widget"
+                    this.qty = 7
+                })
+            }
+
+            val found = database.suspendAutocommit { MyWidgets.findById(id) }
+            assertEquals(id, found?.id)
+            assertEquals("async-widget", found?.name)
+            assertEquals(7, found?.qty)
+
+            val byName = database.suspendAutocommit { MyWidgets.find(Query(MyWidgets.name eq "async-widget")) }
+            assertEquals(1, byName.size)
+
+            assertTrue(database.suspendAutocommit { MyWidgets.count() } >= 1)
+        }
+    }
+
+    @Test
+    fun transactionRollsBackOnThrow() {
+        if (!dockerAvailable) return
+        val database = db!!
+        runBlocking {
+            database.suspendTransaction { MyWidgets.execSql(myWidgetsDdl) }
+            val id = Uuid.random()
+
+            assertFailsWith<IllegalStateException> {
+                database.suspendTransaction {
+                    MyWidgets.insert(MyWidget().apply {
+                        this.id = id
+                        this.name = "doomed"
+                        this.qty = 1
+                    })
+                    error("boom")
+                }
+            }
+
+            assertNull(database.suspendAutocommit { MyWidgets.findById(id) })
+        }
+    }
+
+    @Test
+    fun typedUniqueViolation() {
+        if (!dockerAvailable) return
+        val database = db!!
+        runBlocking {
+            database.suspendTransaction { MyWidgets.execSql(myWidgetsDdl) }
+            val id = Uuid.random()
+            database.suspendTransaction {
+                MyWidgets.insert(MyWidget().apply { this.id = id; this.name = "dup"; this.qty = 1 })
+            }
+            assertFailsWith<UniqueViolationException> {
+                database.suspendTransaction {
+                    MyWidgets.insert(MyWidget().apply { this.id = id; this.name = "dup2"; this.qty = 2 })
+                }
+            }
+        }
+    }
+}
+
+object MyR2Catalog : Catalog
+
+class MyWidget : Entity() {
+    var id by MyWidgets.id
+    var name by MyWidgets.name
+    var qty by MyWidgets.qty
+}
+
+object MyWidgets : Table<MyR2Catalog, MyWidget>("widgets", ::MyWidget) {
+    val id by Column.UUID().primaryKey()
+    val name by Column.Text()
+    val qty by Column.Int()
+
+    init { id; name; qty }
+}
+
+private val myWidgetsDdl =
+    "CREATE TABLE IF NOT EXISTS `widgets` (`id` CHAR(36) NOT NULL, `name` VARCHAR(255) NOT NULL, `qty` INT NOT NULL, PRIMARY KEY (`id`))"

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/NamedParamsTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/NamedParamsTest.kt
@@ -4,24 +4,32 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * Unit tests for the `:name` -> `$N` rewriter. No database needed — they assert the parsed
- * SQL text and the recovered parameter order directly. This parser is structurally shared
- * with the JDBC and Android SQLite parsers, so the comment/quote/cast cases below cover the
- * same logic in each.
+ * Unit tests for the `:name` -> positional-marker rewriter. No database needed — they assert the
+ * parsed SQL text and the recovered parameter order directly. This parser is structurally shared
+ * with the JDBC and Android SQLite parsers, so the comment/quote/cast cases below cover the same
+ * logic in each. Most cases use [PostgresParamMarker] (`$N`); [rewritesToMysqlQuestionMarks] covers
+ * the r2dbc-mysql `?` marker.
  */
 class NamedParamsTest {
 
     @Test
     fun rewritesNamedParamsByOccurrence() {
-        val parsed = parseNamedParams("SELECT * FROM t WHERE id = :id AND name = :name")
+        val parsed = parseNamedParams("SELECT * FROM t WHERE id = :id AND name = :name", PostgresParamMarker)
         assertEquals("SELECT * FROM t WHERE id = \$1 AND name = \$2", parsed.sql)
+        assertEquals(listOf("id", "name"), parsed.names)
+    }
+
+    @Test
+    fun rewritesToMysqlQuestionMarks() {
+        val parsed = parseNamedParams("SELECT * FROM t WHERE id = :id AND name = :name", QuestionMarkParamMarker)
+        assertEquals("SELECT * FROM t WHERE id = ? AND name = ?", parsed.sql)
         assertEquals(listOf("id", "name"), parsed.names)
     }
 
     @Test
     fun ignoresPlaceholderInLineComment() {
         // Regression (#7): ":debug" inside a -- comment must not become a parameter.
-        val parsed = parseNamedParams("SELECT 1 -- TODO: remove :debug later\nWHERE id = :id")
+        val parsed = parseNamedParams("SELECT 1 -- TODO: remove :debug later\nWHERE id = :id", PostgresParamMarker)
         assertEquals(listOf("id"), parsed.names)
         assertEquals("SELECT 1 -- TODO: remove :debug later\nWHERE id = \$1", parsed.sql)
     }
@@ -29,14 +37,14 @@ class NamedParamsTest {
     @Test
     fun ignoresPlaceholderInBlockComment() {
         // Regression (#7): ":skip" inside a /* */ comment must not become a parameter.
-        val parsed = parseNamedParams("SELECT /* :skip me */ :id FROM t")
+        val parsed = parseNamedParams("SELECT /* :skip me */ :id FROM t", PostgresParamMarker)
         assertEquals(listOf("id"), parsed.names)
         assertEquals("SELECT /* :skip me */ \$1 FROM t", parsed.sql)
     }
 
     @Test
     fun ignoresPlaceholderInQuotesAndCasts() {
-        val parsed = parseNamedParams("SELECT ':notparam', x::text, :real FROM t")
+        val parsed = parseNamedParams("SELECT ':notparam', x::text, :real FROM t", PostgresParamMarker)
         assertEquals(listOf("real"), parsed.names)
         assertEquals("SELECT ':notparam', x::text, \$1 FROM t", parsed.sql)
     }
@@ -45,14 +53,14 @@ class NamedParamsTest {
     fun ignoresPlaceholderAfterEscapedQuoteInLiteral() {
         // Regression (#47): a doubled '' is an escaped quote inside the string, so ':not_param'
         // stays part of the literal. Quote-toggling handles this correctly.
-        val parsed = parseNamedParams("SELECT 'it''s :not_param' AS v")
+        val parsed = parseNamedParams("SELECT 'it''s :not_param' AS v", PostgresParamMarker)
         assertEquals(emptyList(), parsed.names)
         assertEquals("SELECT 'it''s :not_param' AS v", parsed.sql)
     }
 
     @Test
     fun handlesMultipleEscapedQuotesThenRealParam() {
-        val parsed = parseNamedParams("SELECT 'a''b''c :x' AS v, :real FROM t")
+        val parsed = parseNamedParams("SELECT 'a''b''c :x' AS v, :real FROM t", PostgresParamMarker)
         assertEquals(listOf("real"), parsed.names)
         assertEquals("SELECT 'a''b''c :x' AS v, \$1 FROM t", parsed.sql)
     }

--- a/readme.md
+++ b/readme.md
@@ -8,8 +8,8 @@ Type-safe ORM and SQL DSL for Kotlin Multiplatform.
 
 Kormium gives you an Exposed-like Kotlin API for tables, entities, typed predicates,
 transactions, migrations, joins and aggregations, while keeping the core portable across
-JVM and Kotlin/Native. It ships PostgreSQL, SQLite, async r2dbc PostgreSQL and Ktor
-integration modules.
+JVM and Kotlin/Native. It ships PostgreSQL, MySQL/MariaDB, SQLite, async r2dbc
+(PostgreSQL and MySQL) and Ktor integration modules.
 
 ```kotlin
 object App : Catalog
@@ -79,8 +79,9 @@ dependencies {
     implementation(platform("io.github.kormium:kormium-bom:<version>"))
 
     implementation("io.github.kormium:kormium-postgres") // PostgreSQL, JVM + Native
+    // implementation("io.github.kormium:kormium-mysql")    // MySQL / MariaDB, JVM + Native
     // implementation("io.github.kormium:kormium-sqlite")   // SQLite, JVM + Native + Android
-    // implementation("io.github.kormium:kormium-r2dbc")    // async PostgreSQL, JVM only
+    // implementation("io.github.kormium:kormium-r2dbc")    // async PostgreSQL + MySQL, JVM only
 
     // implementation("io.github.kormium:kormium-observe")  // reactive Flow queries
     // implementation("io.github.kormium:kormium-migrate")  // SQL migration runner

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 rootProject.name = "kormium"
-include("kormium-core", "kormium-postgres", "kormium-jdbc", "kormium-sqlite", "kormium-r2dbc", "benchmarks")
+include("kormium-core", "kormium-postgres", "kormium-mysql", "kormium-jdbc", "kormium-sqlite", "kormium-r2dbc", "benchmarks")
 include("kormium-observe")
 include("kormium-migrate")
 include("kormium-ktor", "kormium-ktor-di", "kormium-ktor-koin")


### PR DESCRIPTION
## Summary

Adds a new **MySQL / MariaDB** engine `kormium-mysql`, mirroring `kormium-postgres`, across all three backends:

- **JVM / JDBC** over `mysql-connector-j` — typed parameter binding, vendor-code exception mapping (1062 → `UniqueViolationException`, 1452 → `ForeignKeyViolationException`, …), UTC-pinned session so `Instant` round-trips through `TIMESTAMP`.
- **Native (Linux/macOS)** over MariaDB Connector/C (`libmariadb`, API-compatible with `libmysqlclient`) via cinterop, using prepared statements (`mysql_stmt_*`); output columns bound as text. The suspend path offloads to the IO dispatcher (no portable non-blocking MySQL client API), as Postgres Native does on Windows. Windows native is not built (served by the JVM driver).
- **R2DBC** via `createMySqlR2dbcDatabase(...)` in the now-multi-backend `kormium-r2dbc` (`io.asyncer:r2dbc-mysql`).

## Core changes (backward-compatible)

The INSERT family was hardcoded to Postgres/SQLite syntax. `Dialect` gained write-path hooks — `renderLimitOffset`, `supportsReturning`, `renderInsertDefaultValues`, `renderUpsertSuffix`, `renderInsertOrIgnoreSuffix` — **all with defaults equal to the previous behaviour**, so Standard / Postgres / SQLite output is unchanged (verified by the unchanged `TableTest` SQL assertions). `MySqlDialect` overrides them:

- bare `OFFSET` without `LIMIT` is a MySQL syntax error → sentinel `LIMIT`;
- `INSERT ... DEFAULT VALUES` → `() VALUES ()`;
- `upsert` → `ON DUPLICATE KEY UPDATE`, `insertOrIgnore` → no-op upsert;
- MySQL has **no `RETURNING`**, so `insert/insertAll/upsert(returning = true)` re-select the row by primary key (throws if the table/entity has no PK).

`kormium-migrate` journal `id` is now `varchar(255)` (MySQL forbids a `TEXT` primary key), and `Migration` enforces the id length at construction. `kormium-mysql` is wired into the BOM and `publishableModules`.

## MySQL specifics

UUID stored as `CHAR(36)`, JSON as the native `JSON` type, session pinned to UTC, native connection set to `utf8mb4`. No transaction-scoped advisory lock (`GET_LOCK` is session-scoped), so `kormium-migrate` runs without one (as on SQLite).

## Testing

- **Native** suite green against a real MariaDB: all 14 column types, `returning` re-select, `upsert`/`insertOrIgnore`, unicode/emoji, typed unique violation, rollback.
- **Dialect** unit tests (no DB) pin the MySQL SQL rendering.
- **R2DBC MySQL** integration (Testcontainers): CRUD, rollback, typed unique violation.
- **Regression**: `core` (incl. `TableTest` SQL assertions), `migrate`, `sqlite` suites unchanged.
- CI gains a `mariadb:11` service + `libmariadb-dev` + `:kormium-mysql:linuxX64Test` and a Testcontainers `jvmTest`; this PR relies on CI to run the JVM JDBC integration end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)