### PR TITLE
Expression-form UPDATE + DSL scope safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ All notable changes to Kormium are documented here. The format is based on
   `samples/cross-instance-cache`. Delivery is best-effort (rely on a cache TTL as the safety net).
   The shared `encodeTablePayload`/`decodeTablePayload` wire format lets JDBC and r2dbc instances
   interoperate on one channel.
+- **Expression-form `UPDATE`.** `Table.update { }` assigns a SQL [Expression] to each column, so a
+  column can be updated from its own value without raw SQL: `Posts.update { Posts.views set
+  (Posts.views + 1); where { Posts.id eq id } }` renders `SET "views" = "views" + $1`. Literals
+  (`col set false`) bind as parameters; arithmetic composes (`(col + 2) * 3`, `col * col`) and works
+  in `where` too. Complements the existing entity-patch `update(entity)` form.
+- **PostgreSQL Native: true-async on Windows too.** `WindowsSocketReactor` (WSAPoll over the
+  in-flight sockets + a loopback-UDP wake socket) gives mingwX64 the same non-blocking suspend path
+  Linux/macOS got in 0.6.0, instead of the blocking offload. Kotlin/Native doesn't expose WSAPoll
+  and a direct cinterop on `<winsock2.h>` yields empty bindings, so a project-owned `winsock_shim.h`
+  wraps the calls behind a small static-inline `ksock_*` C API that cinterop compiles into the stub
+  klib (no separate link step beyond `-lws2_32`). Verified on a native Windows host.
+
+### Changed
+- **Core: DSL scope safety (`@DslMarker`) and `EXACTLY_ONCE` contracts.** `Scope`, `SuspendScope`
+  and `QueryBuilder` are marked `@KormiumDsl`, so an outer-scope member can no longer be called
+  implicitly from inside a `find`/`count`/`update` builder block (an accidental mutation inside a
+  read block is now a compile error; reach the outer receiver deliberately with `this@transaction`).
+  `transaction`/`autocommit`/`savepoint` (sync + suspend) gained `callsInPlace(EXACTLY_ONCE)`
+  contracts, so a `val` initialised inside the block smart-casts afterwards. Both are additive.
 
 ## [0.7.0] — MySQL / MariaDB engine
 

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -156,6 +156,86 @@ fun Column<*, *, *>.isNotNull(): Expression = IsNullOp(this, true)
 infix fun Column<*, *, *>.eq(value: Nothing?): Expression = IsNullOp(this, false)
 infix fun Column<*, *, *>.neq(value: Nothing?): Expression = IsNullOp(this, true)
 
+/**
+ * A typed numeric operand: a [Column] participates via the operators below, and every arithmetic
+ * result is itself a [NumericExpr] of the same type [Z], so expressions chain and nest while
+ * staying type-checked (`(base + bonus) * 2`). Carrying [columnType] lets a literal on either side
+ * bind through the originating column's converter rather than a guessed mapping.
+ */
+interface NumericExpr<Z> : Expression {
+    val columnType: ColumnType<Z>
+}
+
+/**
+ * Arithmetic node: renders `left op right`, binding any literal as a parameter. A nested
+ * [ArithmeticOp] operand is parenthesized so SQL precedence matches the Kotlin expression that
+ * built it (`(a + b) * c`, not `a + b * c`).
+ */
+class ArithmeticOp<Z>(
+    private val left: Expression,
+    private val right: Expression,
+    private val opSign: String,
+    override val columnType: ColumnType<Z>,
+) : NumericExpr<Z> {
+    override fun toSql(builder: ParamBuilder): String = "${render(left, builder)} $opSign ${render(right, builder)}"
+
+    private fun render(expr: Expression, builder: ParamBuilder): String {
+        val sql = expr.toSql(builder)
+        return if (expr is ArithmeticOp<*>) "($sql)" else sql
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <Z> ColumnType<Z>.lit(value: Z): Value = Value(if (value == null) null else (this as ColumnType<Any?>).toParam(value))
+
+// Arithmetic is generic over the column's value type Z and closed under itself: each operator takes
+// a same-typed literal `Z`, a same-typed `Column`, or another `NumericExpr<Z>`, and returns a
+// `NumericExpr<Z>`. So a wrong-typed operand is a compile error, and results nest (the left operand
+// always carries the result's column type). Usable in `WHERE` or an `update { }` `set`.
+operator fun <Z> Column<Z, *, *>.plus(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "+", columnType)
+operator fun <Z> Column<Z, *, *>.plus(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "+", columnType)
+operator fun <Z> Column<Z, *, *>.plus(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "+", columnType)
+operator fun <Z> NumericExpr<Z>.plus(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "+", columnType)
+operator fun <Z> NumericExpr<Z>.plus(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "+", columnType)
+operator fun <Z> NumericExpr<Z>.plus(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "+", columnType)
+
+operator fun <Z> Column<Z, *, *>.minus(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "-", columnType)
+operator fun <Z> Column<Z, *, *>.minus(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "-", columnType)
+operator fun <Z> Column<Z, *, *>.minus(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "-", columnType)
+operator fun <Z> NumericExpr<Z>.minus(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "-", columnType)
+operator fun <Z> NumericExpr<Z>.minus(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "-", columnType)
+operator fun <Z> NumericExpr<Z>.minus(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "-", columnType)
+
+operator fun <Z> Column<Z, *, *>.times(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "*", columnType)
+operator fun <Z> Column<Z, *, *>.times(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "*", columnType)
+operator fun <Z> Column<Z, *, *>.times(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "*", columnType)
+operator fun <Z> NumericExpr<Z>.times(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "*", columnType)
+operator fun <Z> NumericExpr<Z>.times(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "*", columnType)
+operator fun <Z> NumericExpr<Z>.times(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "*", columnType)
+
+operator fun <Z> Column<Z, *, *>.div(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "/", columnType)
+operator fun <Z> Column<Z, *, *>.div(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "/", columnType)
+operator fun <Z> Column<Z, *, *>.div(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "/", columnType)
+operator fun <Z> NumericExpr<Z>.div(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "/", columnType)
+operator fun <Z> NumericExpr<Z>.div(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "/", columnType)
+operator fun <Z> NumericExpr<Z>.div(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "/", columnType)
+
+operator fun <Z> Column<Z, *, *>.rem(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "%", columnType)
+operator fun <Z> Column<Z, *, *>.rem(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
+operator fun <Z> Column<Z, *, *>.rem(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
+operator fun <Z> NumericExpr<Z>.rem(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "%", columnType)
+operator fun <Z> NumericExpr<Z>.rem(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
+operator fun <Z> NumericExpr<Z>.rem(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
+
+// Compare a nested arithmetic expression to a same-typed literal: `(likes - dislikes) gtEq 100`.
+// (NumericExpr-vs-Column/Expression already works through the generic comparison operators.)
+infix fun <Z> NumericExpr<Z>.eq(value: Z): Expression = EqOp(this, columnType.lit(value))
+infix fun <Z> NumericExpr<Z>.neq(value: Z): Expression = NeqOp(this, columnType.lit(value))
+infix fun <Z> NumericExpr<Z>.less(value: Z): Expression = LessOp(this, columnType.lit(value))
+infix fun <Z> NumericExpr<Z>.lessEq(value: Z): Expression = LessEqOp(this, columnType.lit(value))
+infix fun <Z> NumericExpr<Z>.gt(value: Z): Expression = GreaterOp(this, columnType.lit(value))
+infix fun <Z> NumericExpr<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, columnType.lit(value))
+
 /** Groups an expression in parentheses so it composes safely with surrounding `AND`/`OR`. */
 class ParenExpression(private val expr: Expression) : Expression {
     override fun toSql(builder: ParamBuilder): String = "(${expr.toSql(builder)})"

--- a/kormium-core/src/commonMain/kotlin/KormiumDsl.kt
+++ b/kormium-core/src/commonMain/kotlin/KormiumDsl.kt
@@ -1,0 +1,23 @@
+package io.github.kormium
+
+/**
+ * Scope-control marker for Kormium's builder DSLs (see [Scope], [SuspendScope], [QueryBuilder]).
+ *
+ * Because these receivers nest — a `find { }` / `count { }` / `update { }` block runs with a
+ * [QueryBuilder] receiver while the surrounding [Scope] receiver stays in lexical scope — Kotlin
+ * would otherwise let an outer-scope member be called implicitly from the inner block, e.g.
+ * a mutation inside a read-only query block:
+ *
+ * ```kotlin
+ * Users.find {
+ *     where { Users.age gtEq 18 }
+ *     Users.insert(someUser) // Scope.insert: a compile error with this marker
+ * }
+ * ```
+ *
+ * [DslMarker] restricts each block to its nearest receiver, turning such accidental cross-scope
+ * calls into compile errors; reaching the outer receiver on purpose still works via an explicit
+ * `this@transaction` qualifier.
+ */
+@DslMarker
+annotation class KormiumDsl

--- a/kormium-core/src/commonMain/kotlin/QueryBuilder.kt
+++ b/kormium-core/src/commonMain/kotlin/QueryBuilder.kt
@@ -17,6 +17,7 @@ package io.github.kormium
  * It is a thin, ergonomic layer over [Query]: an empty block builds `Query()` (no `WHERE`,
  * no ordering, no limit/offset). [Query] stays available for reusable/prebuilt queries.
  */
+@KormiumDsl
 class QueryBuilder {
     private val conditions = mutableListOf<Expression>()
     private val orderings = LinkedHashMap<Column<*, *, *>, AscDescOrder>()

--- a/kormium-core/src/commonMain/kotlin/Scope.kt
+++ b/kormium-core/src/commonMain/kotlin/Scope.kt
@@ -114,6 +114,18 @@ class Scope<G : Catalog> internal constructor(
         return updateRows(QueryBuilder().apply(block).build(), entity, exec)
     }
 
+    /**
+     * Expression form of [update]: assign each column a SQL [Expression], enabling atomic
+     * self-referential updates without raw SQL — `Posts.views set (Posts.views + 1)`. Multiple
+     * `where { }` blocks AND together; an empty `where` updates every row. Returns the affected
+     * row count. See [UpdateBuilder].
+     */
+    fun <T : Entity> Table<G, T>.update(block: UpdateBuilder.() -> Unit): Long {
+        markWritten()
+        val builder = UpdateBuilder().apply(block)
+        return updateRows(builder.buildWhere(), builder.buildAssignments(), exec)
+    }
+
     /** Deletes rows matching [query]; returns the affected row count. */
     fun <T : Entity> Table<G, T>.deleteWhere(query: Query): Long {
         markWritten()

--- a/kormium-core/src/commonMain/kotlin/Scope.kt
+++ b/kormium-core/src/commonMain/kotlin/Scope.kt
@@ -2,6 +2,9 @@ package io.github.kormium
 
 import io.github.kormium.database.Database
 import io.github.kormium.resultset.ResultSet
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * The receiver inside a [transaction] / [autocommit] block. It pins one connection
@@ -9,6 +12,7 @@ import io.github.kormium.resultset.ResultSet
  * so using a table from a different catalog is a compile error. Raw SQL run through
  * [execute] / [executeUpdate] goes to the same pinned connection.
  */
+@KormiumDsl
 class Scope<G : Catalog> internal constructor(
     private val exec: SqlExecutor,
     /** The owning database's configuration (e.g. the default [BatchInsertMode]). */
@@ -209,7 +213,9 @@ class Scope<G : Catalog> internal constructor(
      * [IllegalStateException] (a savepoint without a surrounding transaction is a server
      * error on PostgreSQL and backend-dependent elsewhere).
      */
+    @OptIn(ExperimentalContracts::class)
     fun <R> savepoint(block: Scope<G>.() -> R): R {
+        contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
         check(transactional) { "savepoint { } requires a transaction; use transaction { }, not autocommit { }" }
         val name = "korm_sp_${savepointCounter++}"
         exec.executeUpdate("SAVEPOINT $name")
@@ -228,7 +234,9 @@ class Scope<G : Catalog> internal constructor(
  * catalog [G]. Calling another database's `transaction` inside opens an independent
  * transaction (separate connection); use [Scope.savepoint] for a nested unit.
  */
+@OptIn(ExperimentalContracts::class)
 fun <G : Catalog, R> Database<G>.transaction(block: Scope<G>.() -> R): R {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
     // The dirty-table set outlives the block so we can fire it after the commit returns.
     val dirty = mutableSetOf<String>()
     val result = usePinned(transactional = true) { Scope<G>(it, config, dirty, transactional = true).block() }
@@ -241,7 +249,9 @@ fun <G : Catalog, R> Database<G>.transaction(block: Scope<G>.() -> R): R {
  * Runs [block] on a pinned connection in autocommit (no surrounding transaction) —
  * the cheap path for reads / single statements.
  */
+@OptIn(ExperimentalContracts::class)
 fun <G : Catalog, R> Database<G>.autocommit(block: Scope<G>.() -> R): R {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
     val dirty = mutableSetOf<String>()
     val result = usePinned(transactional = false) { Scope<G>(it, config, dirty, transactional = false).block() }
     writeListeners.fire(dirty)

--- a/kormium-core/src/commonMain/kotlin/SuspendScope.kt
+++ b/kormium-core/src/commonMain/kotlin/SuspendScope.kt
@@ -2,6 +2,9 @@ package io.github.kormium
 
 import io.github.kormium.database.SuspendDatabase
 import io.github.kormium.resultset.ResultSet
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * The suspend counterpart of [Scope], the receiver inside a [suspendTransaction] /
@@ -11,6 +14,7 @@ import io.github.kormium.resultset.ResultSet
  * the connection stays pinned. Raw SQL run through [execute] / [executeUpdate] goes to
  * the same pinned connection.
  */
+@KormiumDsl
 class SuspendScope<G : Catalog> internal constructor(
     private val exec: SuspendSqlExecutor,
     /** The owning database's configuration (e.g. the default [BatchInsertMode]). */
@@ -188,7 +192,9 @@ class SuspendScope<G : Catalog> internal constructor(
      * [IllegalStateException] (a savepoint without a surrounding transaction is a server
      * error on PostgreSQL and backend-dependent elsewhere).
      */
+    @OptIn(ExperimentalContracts::class)
     suspend fun <R> savepoint(block: suspend SuspendScope<G>.() -> R): R {
+        contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
         check(transactional) { "savepoint { } requires a transaction; use suspendTransaction { }, not suspendAutocommit { }" }
         val name = "korm_sp_${savepointCounter++}"
         exec.executeUpdate("SAVEPOINT $name")
@@ -207,7 +213,9 @@ class SuspendScope<G : Catalog> internal constructor(
  * suspend while the connection stays pinned. Whether this is true async or a blocking
  * driver offloaded to a dispatcher depends on the backend's [SuspendDatabase.useConnection].
  */
+@OptIn(ExperimentalContracts::class)
 suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendTransaction(block: suspend SuspendScope<G>.() -> R): R {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
     val dirty = mutableSetOf<String>()
     val result = useConnection(transactional = true) { SuspendScope<G>(it, config, dirty, transactional = true).block() }
     writeListeners.fire(dirty)
@@ -219,7 +227,9 @@ suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendTransaction(block: suspen
  * Runs [block] on a pinned connection in autocommit (no surrounding transaction) — the
  * suspend counterpart of [autocommit], the cheap path for reads / single statements.
  */
+@OptIn(ExperimentalContracts::class)
 suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendAutocommit(block: suspend SuspendScope<G>.() -> R): R {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
     val dirty = mutableSetOf<String>()
     val result = useConnection(transactional = false) { SuspendScope<G>(it, config, dirty, transactional = false).block() }
     writeListeners.fire(dirty)

--- a/kormium-core/src/commonMain/kotlin/SuspendScope.kt
+++ b/kormium-core/src/commonMain/kotlin/SuspendScope.kt
@@ -96,6 +96,13 @@ class SuspendScope<G : Catalog> internal constructor(
         return updateRows(QueryBuilder().apply(block).build(), entity, exec)
     }
 
+    /** Expression form of [update]: `Posts.views set (Posts.views + 1)`; see [Scope.update]. */
+    suspend fun <T : Entity> Table<G, T>.update(block: UpdateBuilder.() -> Unit): Long {
+        markWritten()
+        val builder = UpdateBuilder().apply(block)
+        return updateRows(builder.buildWhere(), builder.buildAssignments(), exec)
+    }
+
     /** Deletes rows matching [query]; returns the affected row count. */
     suspend fun <T : Entity> Table<G, T>.deleteWhere(query: Query): Long {
         markWritten()

--- a/kormium-core/src/commonMain/kotlin/Table.kt
+++ b/kormium-core/src/commonMain/kotlin/Table.kt
@@ -266,6 +266,23 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         return sql.trimIndent() to builder.params
     }
 
+    private fun updateSql(query: Query, assignments: Map<Column<*, *, *>, Expression>, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
+        val builder = paramBuilder(dialect, typeMapper)
+        // Order matters: render SET (collecting binds) before WHERE so placeholders are numbered
+        // left-to-right as they appear in the statement.
+        val setClause = assignments.entries.joinToString(", ") { (column, expr) ->
+            "${dialect.quoteIdentifier(column.name)} = ${expr.toSql(builder)}"
+        }
+        // WHERE only: a plain UPDATE doesn't take ORDER BY / LIMIT / OFFSET (invalid in Postgres).
+        val queryStr = query.toWhereSql(builder)
+        val sql = """
+            UPDATE ${qualifiedTableName(dialect)}
+            SET $setClause
+           $queryStr
+        """
+        return sql.trimIndent() to builder.params
+    }
+
     private fun deleteSql(query: Query, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
         val builder = paramBuilder(dialect, typeMapper)
         // WHERE only: a plain DELETE doesn't take ORDER BY / LIMIT / OFFSET (invalid in Postgres).
@@ -360,6 +377,11 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         return exec.executeUpdate(sql = sql, namedParameters = params)
     }
 
+    internal fun updateRows(query: Query, assignments: Map<Column<*, *, *>, Expression>, exec: SqlExecutor): Long {
+        val (sql, params) = updateSql(query, assignments, exec.dialect, exec.typeMapper)
+        return exec.executeUpdate(sql = sql, namedParameters = params)
+    }
+
     internal fun deleteRows(query: Query, exec: SqlExecutor): Long {
         val (sql, params) = deleteSql(query, exec.dialect, exec.typeMapper)
         return exec.executeUpdate(sql = sql, namedParameters = params)
@@ -445,6 +467,11 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
 
     internal suspend fun updateRows(query: Query, entity: T, exec: SuspendSqlExecutor): Long {
         val (sql, params) = updateSql(query, entity, exec.dialect, exec.typeMapper)
+        return exec.executeUpdate(sql = sql, namedParameters = params)
+    }
+
+    internal suspend fun updateRows(query: Query, assignments: Map<Column<*, *, *>, Expression>, exec: SuspendSqlExecutor): Long {
+        val (sql, params) = updateSql(query, assignments, exec.dialect, exec.typeMapper)
         return exec.executeUpdate(sql = sql, namedParameters = params)
     }
 

--- a/kormium-core/src/commonMain/kotlin/UpdateBuilder.kt
+++ b/kormium-core/src/commonMain/kotlin/UpdateBuilder.kt
@@ -1,0 +1,51 @@
+package io.github.kormium
+
+/**
+ * Builder behind the expression form of `UPDATE`:
+ *
+ * ```kotlin
+ * Posts.update {
+ *     Posts.views set (Posts.views + 1)   // SET "views" = "views" + 1
+ *     Posts.pinned set false              // SET "pinned" = $1
+ *     where { Posts.id eq postId }
+ * }
+ * ```
+ *
+ * Unlike the entity form ([Scope.update] with a patch entity), each `SET` target is assigned an
+ * [Expression], so a column can be updated from its own value (atomic `n = n + 1`) without raw SQL.
+ * `UPDATE` takes no `ORDER BY` / `LIMIT` / `OFFSET`, so this builder exposes only `set` and `where`.
+ */
+@KormiumDsl
+class UpdateBuilder {
+    private val assignments = LinkedHashMap<Column<*, *, *>, Expression>()
+    private val conditions = mutableListOf<Expression>()
+
+    /** `Posts.views set (Posts.views + 1)`: assigns a SQL [Expression] to this column. */
+    infix fun <Z> Column<Z, *, *>.set(value: Expression) {
+        assignments[this] = value
+    }
+
+    /** `Posts.pinned set false`: assigns a literal value, bound as a parameter. */
+    infix fun <Z> Column<Z, *, *>.set(value: Z) {
+        assignments[this] = Value(bindParam(value))
+    }
+
+    /** Adds a predicate; multiple `where { ... }` calls combine with `AND` (see [QueryBuilder.where]). */
+    fun where(block: () -> Expression) {
+        conditions += block()
+    }
+
+    internal fun buildAssignments(): Map<Column<*, *, *>, Expression> {
+        require(assignments.isNotEmpty()) { "update { } needs at least one set(...)" }
+        return assignments
+    }
+
+    internal fun buildWhere(): Query {
+        val whereExpression = when (conditions.size) {
+            0 -> null
+            1 -> conditions[0]
+            else -> conditions.map { ParenExpression(it) as Expression }.reduce { acc, e -> AndOp(acc, e) }
+        }
+        return Query(whereExpression = whereExpression)
+    }
+}

--- a/kormium-core/src/commonTest/kotlin/TableTest.kt
+++ b/kormium-core/src/commonTest/kotlin/TableTest.kt
@@ -226,6 +226,66 @@ class TableTest {
     }
 
     @Test
+    fun testExpressionUpdateAtomicIncrement() {
+        val uuid = Uuid.random()
+        databaseMockObj.result = 1L
+        val affected = db.transaction {
+            TestTable.update {
+                TestTable.position set (TestTable.position + 1)
+                where { TestTable.id eq uuid }
+            }
+        }
+        assertEquals(1L, affected)
+        val sql = remoteNewLinesAndSpaces(databaseMockObj.internalSql)
+        assertTrue(sql.contains("""UPDATE"products"SET"position"="position"+:p0"""), sql)
+        assertTrue(sql.contains("""WHERE"id"=:p1"""), sql)
+        assertEquals(1, databaseMockObj.internalParams["p0"])
+        databaseMockObj.result = null
+    }
+
+    @Test
+    fun testExpressionUpdateNestedArithmeticAndMixedAssignments() {
+        databaseMockObj.result = 1L
+        db.transaction {
+            TestTable.update {
+                TestTable.position set ((TestTable.position + 2) * 3)
+                TestTable.text set "x"
+            }
+        }
+        val sql = remoteNewLinesAndSpaces(databaseMockObj.internalSql)
+        // The nested arithmetic operand is parenthesized; assignments keep their order.
+        assertTrue(sql.contains("""SET"position"=("position"+:p0)*:p1,"text"=:p2"""), sql)
+        databaseMockObj.result = null
+    }
+
+    @Test
+    fun testExpressionUpdateColumnTimesColumn() {
+        databaseMockObj.result = 1L
+        db.transaction { TestTable.update { TestTable.position set (TestTable.position * TestTable.position) } }
+        assertTrue(
+            remoteNewLinesAndSpaces(databaseMockObj.internalSql).contains("""SET"position"="position"*"position""""),
+            databaseMockObj.internalSql,
+        )
+        databaseMockObj.result = null
+    }
+
+    @Test
+    fun testArithmeticInWhereClause() {
+        db.transaction { TestTable.find { where { (TestTable.position + 1) gtEq 10 } } }
+        assertTrue(
+            remoteNewLinesAndSpaces(databaseMockObj.internalSql).contains(""""position"+:p0>=:p1"""),
+            databaseMockObj.internalSql,
+        )
+    }
+
+    @Test
+    fun testExpressionUpdateRejectsEmptySet() {
+        assertFailsWith<IllegalArgumentException> {
+            db.transaction { TestTable.update { where { TestTable.id eq Uuid.random() } } }
+        }
+    }
+
+    @Test
     fun testDeleteBlockDslReturnsAffectedRows() {
         databaseMockObj.result = 2L
         val affected = db.transaction { TestTable.deleteWhere { where { TestTable.position eq 5 } } }

--- a/kormium-core/src/commonTest/kotlin/WriteListenerTest.kt
+++ b/kormium-core/src/commonTest/kotlin/WriteListenerTest.kt
@@ -69,6 +69,16 @@ class WriteListenerTest {
     }
 
     @Test
+    fun transactionContractAllowsValInitialization() {
+        // Compiles only because transaction declares callsInPlace(block, EXACTLY_ONCE):
+        // the contract lets a val be assigned inside the block and read after.
+        val (db, _) = freshDb()
+        val collected: String
+        db.transaction { collected = TestTable.tableName }
+        assertEquals("products", collected)
+    }
+
+    @Test
     fun removedListenerStopsReceiving() {
         val (db, _) = freshDb()
         var count = 0


### PR DESCRIPTION
Two core DSL additions queued for 0.8.0.

## Expression-form `UPDATE`
`Table.update { }` assigns a SQL `Expression` to each column, so a column can be updated from its own value without raw SQL:

```kotlin
Posts.update {
    Posts.views set (Posts.views + 1)   // SET "views" = "views" + $1
    Posts.pinned set false              // literal -> bound parameter
    where { Posts.id eq id }
}
```

- Arithmetic composes (`(col + 2) * 3`, `col * col`) and works in `where {}` too.
- Literals bind as parameters; `update {}` requires at least one `set(...)`.
- Complements the entity-patch `update(entity)` form; wired through `Scope`/`SuspendScope.update(block)` → `Table.updateSql(assignments)`/`updateRows(assignments)`.
- `TableTest` covers atomic increment, nested arithmetic, mixed literal/expression SET, arithmetic-in-WHERE, and empty-set rejection.

## DSL scope safety (`@DslMarker`) + `EXACTLY_ONCE` contracts
(Separate commit.) `Scope`/`SuspendScope`/`QueryBuilder` marked `@KormiumDsl` so an outer-scope member can't be called implicitly from inside a builder block — an accidental mutation inside a read block is now a compile error (reach the outer receiver with `this@transaction`). `transaction`/`autocommit`/`savepoint` gain `callsInPlace(EXACTLY_ONCE)` contracts for post-block smart-casts. Additive.

## Verification
jvm + native + metadata compile; core tests pass on JVM (18) and Native (45), including the new UPDATE tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)