### PR TITLE
fix(core): make Entity.isSet/unset type-safe (#33)

### DIFF
--- a/kormium-core/src/commonMain/kotlin/Entity.kt
+++ b/kormium-core/src/commonMain/kotlin/Entity.kt
@@ -24,19 +24,23 @@ abstract class Entity protected constructor() {
     internal fun replaceFields(fields: MutableMap<String, Any?>) {
         this.fields = fields
     }
+}
 
-    /**
-     * True when [column] has an assigned or loaded value on this entity, including an
-     * explicit `null`. Use it to tell "set to null" from "never assigned".
-     */
-    fun isSet(column: Column<*, *, *>): Boolean = fields.containsKey(column.fieldKey)
+/**
+ * True when [column] has an assigned or loaded value on this entity, including an
+ * explicit `null`. Use it to tell "set to null" from "never assigned".
+ *
+ * The column must belong to this entity's type: `user.isSet(Orders.id)` is a compile error.
+ */
+fun <N : Entity> N.isSet(column: Column<*, *, N>): Boolean = fields.containsKey(column.fieldKey)
 
-    /**
-     * Removes [column]'s value, returning it to absent state (so it is omitted from
-     * INSERT/UPDATE again). `entity.note = null` means explicit null; `entity.unset(T.note)`
-     * means absent.
-     */
-    fun unset(column: Column<*, *, *>) {
-        fields.remove(column.fieldKey)
-    }
+/**
+ * Removes [column]'s value, returning it to absent state (so it is omitted from
+ * INSERT/UPDATE again). `entity.note = null` means explicit null; `entity.unset(T.note)`
+ * means absent.
+ *
+ * The column must belong to this entity's type: `user.unset(Orders.id)` is a compile error.
+ */
+fun <N : Entity> N.unset(column: Column<*, *, N>) {
+    fields.remove(column.fieldKey)
 }

--- a/kormium-core/src/commonTest/kotlin/TableTest.kt
+++ b/kormium-core/src/commonTest/kotlin/TableTest.kt
@@ -95,6 +95,10 @@ class TableTest {
         assertEquals(listOf(TestTable.id), TestTable.primaryKey)
     }
 
+    // Regression (#33): isSet/unset take `Column<*, *, N>`, so a column from a differently-typed
+    // table is rejected at COMPILE time — `TestEntity().isSet(TestOrders.orderId)` does not compile
+    // (TestOrders' columns carry TestOrderEntity, not TestEntity). That guarantee can't be expressed
+    // as a runtime test; this test pins the absent/explicit-null/value semantics that stay unchanged.
     @Test
     fun testIsSetAndUnset() {
         val e = TestEntity()
@@ -110,6 +114,13 @@ class TableTest {
         // A concrete value is set.
         e.text = "hi"
         assertTrue(e.isSet(TestTable.text))
+        // A column from another entity of the same catalog also type-checks only for its own entity.
+        val order = TestOrderEntity()
+        assertFalse(order.isSet(TestOrders.orderId))
+        order.orderId = Uuid.random()
+        assertTrue(order.isSet(TestOrders.orderId))
+        order.unset(TestOrders.orderId)
+        assertFalse(order.isSet(TestOrders.orderId))
     }
 
     @Test


### PR DESCRIPTION
Closes #33.

## Problem

`Entity.isSet`/`unset` took `Column<*, *, *>`, erasing the entity type. A column from another table type-checked against any entity, so `user.unset(Orders.id)` compiled — and when `fieldKey`s overlap (`id`, `name`) it silently mutated the wrong entity's state.

## Change

Bind the column's entity type to the receiver by converting both to extension functions:

```kotlin
fun <N : Entity> N.isSet(column: Column<*, *, N>): Boolean
fun <N : Entity> N.unset(column: Column<*, *, N>)
```

`Column` already carries the entity as its third type parameter (`Column<Z, T : Table<*, N>, N>`); the previous star projection just discarded it. `N` is invariant, so a foreign column can't be coerced. Bodies are identical — absent / explicit-null / value semantics are unchanged.

## Acceptance criteria

- ✅ `user.unset(Users.note)` compiles.
- ✅ `user.unset(Orders.id)` does not compile — verified: `Argument type mismatch: actual type is 'Column.NotNullColumn<Uuid, TestOrders, TestOrderEntity>', but 'Column<*, *, TestEntity>' was expected.`
- ✅ Absent vs explicit-null semantics unchanged (`testIsSetAndUnset`).
- ✅ Coverage: runtime test extended; compile-time guarantee documented as a comment, matching the existing #32 convention (it cannot be a runtime test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)