### PR TITLE
Improve result mapping failure diagnostics (#40)

### DIFF
--- a/kormium-core/src/commonMain/kotlin/ColumnType.kt
+++ b/kormium-core/src/commonMain/kotlin/ColumnType.kt
@@ -33,6 +33,13 @@ interface ColumnType<T> {
      * a returned [JsonElement] is cast to `::jsonb` on Postgres). The default is identity.
      */
     fun toParam(value: T): Any? = value
+
+    /**
+     * A short human-readable name for this type, used only in diagnostics (e.g. result-mapping
+     * errors). The default derives it from the class name (`IntColumnType` → `Int`); [convert]
+     * and custom types may override for a clearer label.
+     */
+    val description: String get() = this::class.simpleName?.removeSuffix("ColumnType") ?: "custom"
 }
 
 /**
@@ -46,6 +53,7 @@ fun <Domain, Stored> ColumnType<Stored>.convert(
 ): ColumnType<Domain> = object : ColumnType<Domain> {
     override fun read(rs: ResultSet, index: Int): Domain? = this@convert.read(rs, index)?.let(fromStored)
     override fun toParam(value: Domain): Any? = this@convert.toParam(toStored(value))
+    override val description: String get() = "${this@convert.description} (converted)"
 }
 
 // ---- built-in column types (the 14 Kormium ships) ----

--- a/kormium-core/src/commonMain/kotlin/Join.kt
+++ b/kormium-core/src/commonMain/kotlin/Join.kt
@@ -148,15 +148,25 @@ infix fun <G : Catalog, A : Entity, B : Entity> Table<G, A>.leftJoin(other: Tabl
  */
 class ResultRow internal constructor(private val values: Map<Any, Any?>) {
     operator fun <Z> get(field: Selectable<Z>): Z {
+        val key = fieldKey(field)
+        if (key !in values) {
+            error("Field '$key' was not selected in this projection — add it to select(...), or use getOrNull.")
+        }
         @Suppress("UNCHECKED_CAST")
-        return (values[fieldKey(field)] as Z?)
-            ?: error("Selected field is NULL or was not selected; use getOrNull for nullable fields")
+        return (values[key] as Z?)
+            ?: error("Selected field '$key' is NULL; use getOrNull for nullable fields.")
     }
 
     fun <Z> getOrNull(field: Selectable<Z>): Z? {
         @Suppress("UNCHECKED_CAST")
         return values[fieldKey(field)] as Z?
     }
+
+    // Key-based accessors (the key is computed once by the caller, avoiding a second fieldKey()
+    // string-concat per column). containsKey distinguishes a selected-but-NULL value from a field
+    // the projection never selected, so hydrate can give the right diagnostic.
+    internal fun containsKey(key: Any): Boolean = key in values
+    internal fun getByKey(key: Any): Any? = values[key]
 }
 
 // Identifies a selected field. A Column's property delegate yields a fresh instance on each
@@ -197,7 +207,23 @@ private fun buildSelect(
 
 // Reads each field positionally into a ResultRow.
 private fun mapRow(fields: List<Selectable<*>>, rs: ResultSet, typeMapper: TypeMapper): ResultRow =
-    ResultRow(fields.withIndex().associate { (i, f) -> fieldKey(f) to f.read(rs, i, typeMapper) })
+    ResultRow(fields.withIndex().associate { (i, f) -> fieldKey(f) to readSelectable(f, i, rs, typeMapper) })
+
+// Reads one selected field, wrapping any backend/conversion failure in a ResultMappingException
+// that names the source (column+table+expected type, or the expression) and preserves the cause.
+private fun readSelectable(field: Selectable<*>, index: Int, rs: ResultSet, typeMapper: TypeMapper): Any? =
+    try {
+        field.read(rs, index, typeMapper)
+    } catch (e: ResultMappingException) {
+        throw e
+    } catch (e: Throwable) {
+        val what = if (field is Column<*, *, *>) {
+            "column '${field.name}' of table '${field.tableRef.tableName}' (expected Korm type ${field.columnType.description})"
+        } else {
+            "selected expression"
+        }
+        throw ResultMappingException("Failed to read $what at result index $index: ${e.message}", cause = e)
+    }
 
 // ---- entity-pair hydration (shared by Scope and SuspendScope) ----
 
@@ -205,8 +231,19 @@ private fun mapRow(fields: List<Selectable<*>>, rs: ResultSet, typeMapper: TypeM
 internal fun pairSelectFields(left: Table<*, *>, right: Table<*, *>): List<Selectable<*>> =
     (left.getFieldDisplayNames().values + right.getFieldDisplayNames().values).toList()
 
-private fun <T : Entity> Table<*, T>.hydrateFrom(row: ResultRow): T =
-    hydrate(getFieldDisplayNames().mapValues { (_, c) -> row.getOrNull(c) }.toMutableMap())
+private fun <T : Entity> Table<*, T>.hydrateFrom(row: ResultRow): T {
+    val columns = getFieldDisplayNames()
+    // One pass, one map allocation, one fieldKey() per column; the absent set is allocated only if
+    // a column is actually missing (the common all-columns-selected case stays allocation-free).
+    val fields = HashMap<String, Any?>(columns.size * 2)
+    var absent: MutableSet<String>? = null
+    for ((fieldName, c) in columns) {
+        val key = fieldKey(c)
+        if (!row.containsKey(key)) (absent ?: mutableSetOf<String>().also { absent = it }).add(fieldName)
+        fields[fieldName] = row.getByKey(key)
+    }
+    return hydrate(fields, absentFields = absent ?: emptySet())
+}
 
 internal fun <A : Entity, B : Entity> hydrateInnerPairs(
     left: Table<*, A>,

--- a/kormium-core/src/commonMain/kotlin/Table.kt
+++ b/kormium-core/src/commonMain/kotlin/Table.kt
@@ -23,14 +23,25 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
      * database boundary when a column the entity declares non-null came back as SQL NULL — that
      * is a schema mismatch or a bad row, and would otherwise surface as a confusing null only when
      * the property is later read. Nullable columns hydrate NULL normally.
+     *
+     * [absentFields] are entity fields that were not present in the result at all (e.g. a column a
+     * projection/join did not select), as opposed to a column that was selected and came back NULL;
+     * the two get different, actionable messages.
      */
-    internal fun hydrate(fields: MutableMap<String, Any?>): T {
+    internal fun hydrate(fields: MutableMap<String, Any?>, absentFields: Set<String> = emptySet()): T {
         for ((fieldName, column) in fieldDisplayName) {
             if (!column.nullable && fields[fieldName] == null) {
+                val expected = column.columnType.description
                 throw ResultMappingException(
-                    "Column '${column.name}' of table '$tableName' is non-null, but the database " +
-                        "returned NULL for it (entity field '$fieldName'). The row or the schema does " +
-                        "not match the entity definition.",
+                    if (fieldName in absentFields) {
+                        "Column '${column.name}' of table '$tableName' is non-null but was not selected " +
+                            "(entity field '$fieldName', expected Korm type $expected). Add it to the " +
+                            "projection/SELECT, or read the full row, before mapping into this entity."
+                    } else {
+                        "Column '${column.name}' of table '$tableName' is non-null, but the database " +
+                            "returned NULL for it (entity field '$fieldName', expected Korm type $expected). " +
+                            "The row or the schema does not match the entity definition."
+                    },
                 )
             }
         }
@@ -72,11 +83,27 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         val fields = HashMap<String, Any?>(fieldDisplayName.size * 2)
         var index = 0
         for ((fieldName, column) in fieldDisplayName) {
-            fields[fieldName] = column.columnType.read(rs, index)
+            fields[fieldName] = readColumn(column, fieldName, rs, index)
             index++
         }
         return hydrate(fields)
     }
+
+    // Reads one column's value, wrapping any backend/conversion failure in a ResultMappingException
+    // that names the table, SQL column, entity field, expected Korm type and result index — and
+    // preserves the original error as the cause.
+    private fun readColumn(column: Column<*, *, T>, fieldName: String, rs: ResultSet, index: Int): Any? =
+        try {
+            column.columnType.read(rs, index)
+        } catch (e: ResultMappingException) {
+            throw e
+        } catch (e: Throwable) {
+            throw ResultMappingException(
+                "Failed to read column '${column.name}' of table '$tableName' (entity field '$fieldName', " +
+                    "expected Korm type ${column.columnType.description}, result index $index): ${e.message}",
+                cause = e,
+            )
+        }
 
     // Only the columns the entity actually assigned (present in its fields map),
     // so update() can tell "leave untouched" (absent) from "set to NULL" (present and null).

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteQueryCoverageTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteQueryCoverageTest.kt
@@ -113,6 +113,31 @@ class SqliteQueryCoverageTest {
         }
     }
 
+    /**
+     * Reading a field that the projection did not select must fail with clear guidance ("was not
+     * selected — add it to select(...)"), distinct from the message for a selected-but-NULL field.
+     */
+    @Test
+    fun readingUnselectedProjectionFieldGivesActionableError() {
+        val deptId = Uuid.random()
+        db.transaction {
+            QcDepts.execSql(qcDeptsDdl)
+            QcEmps.execSql(qcEmpsDdl)
+            QcDepts.insert(QcDept().apply { id = deptId; name = "Ops" })
+            QcEmps.insert(QcEmp().apply { id = Uuid.random(); this.deptId = deptId; name = "Lin" })
+        }
+        val row = db.autocommit {
+            (QcDepts innerJoin QcEmps on (QcDepts.id eq QcEmps.deptId)).select(QcDepts.name).single()
+        }
+        val ex = assertFailsWith<IllegalStateException> { row[QcEmps.id] }
+        val msg = ex.message ?: ""
+        assertTrue("not selected" in msg, "should explain the field was not selected: $msg")
+        db.transaction {
+            QcEmps.deleteWhere { where { QcEmps.deptId eq deptId } }
+            QcDepts.deleteWhere(Query(QcDepts.id eq deptId))
+        }
+    }
+
     // ---- 2. Aggregations + HAVING ----------------------------------------------------------
 
     /** count/sum/avg/min/max over a single group, all read from one row. */

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteResultMappingTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteResultMappingTest.kt
@@ -12,6 +12,7 @@ import io.github.kormium.transaction
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
@@ -39,6 +40,43 @@ class SqliteResultMappingTest {
         }
         val msg = ex.message ?: ""
         assertTrue("rm_items" in msg && "name" in msg, "should name table+column: $msg")
+        // Diagnostics now also name the entity field and the expected Korm column type.
+        assertTrue("'name'" in msg && "Text" in msg, "should name entity field + expected type: $msg")
+    }
+
+    @Test
+    fun typeConversionFailureNamesColumnAndPreservesCause() {
+        val id = Uuid.random()
+        db.transaction {
+            RmTyped.execSql(rmTypedDdl)
+            // Plant a non-parseable UUID in the non-null `ref` column.
+            executeUpdate(
+                "INSERT INTO rm_typed (id, ref, status) VALUES (:id, :ref, :status)",
+                mapOf("id" to id.toString(), "ref" to "not-a-uuid", "status" to "ACTIVE"),
+            )
+        }
+        val ex = assertFailsWith<ResultMappingException> { db.autocommit { RmTyped.findById(id) } }
+        val msg = ex.message ?: ""
+        assertTrue("rm_typed" in msg && "ref" in msg, "should name table+column: $msg")
+        assertTrue("Uuid" in msg, "should name expected Korm type: $msg")
+        assertNotNull(ex.cause, "the backend/parse failure must be preserved as the cause")
+    }
+
+    @Test
+    fun invalidEnumValueNamesColumnAndConvertedType() {
+        val id = Uuid.random()
+        db.transaction {
+            RmTyped.execSql(rmTypedDdl)
+            executeUpdate(
+                "INSERT INTO rm_typed (id, ref, status) VALUES (:id, :ref, :status)",
+                mapOf("id" to id.toString(), "ref" to Uuid.random().toString(), "status" to "BOGUS"),
+            )
+        }
+        val ex = assertFailsWith<ResultMappingException> { db.autocommit { RmTyped.findById(id) } }
+        val msg = ex.message ?: ""
+        assertTrue("rm_typed" in msg && "status" in msg, "should name table+column: $msg")
+        assertTrue("converted" in msg, "should mark the type as a converted ColumnType: $msg")
+        assertNotNull(ex.cause, "the underlying enum-decode failure must be preserved as the cause")
     }
 
     @Test
@@ -74,3 +112,23 @@ object RmItems : Table<RmCat, RmItem>("rm_items", ::RmItem) {
 // ...but the DDL allows NULL in "name", so a raw insert can plant a contract-violating row.
 private val rmDdlNameNullable =
     """CREATE TABLE IF NOT EXISTS "rm_items" ("id" TEXT NOT NULL, "name" TEXT, "note" TEXT, PRIMARY KEY ("id"))"""
+
+enum class RmStatus { ACTIVE, ARCHIVED }
+
+class RmTypedItem : Entity() {
+    var id by RmTyped.id
+    var ref by RmTyped.ref
+    var status by RmTyped.status
+}
+
+object RmTyped : Table<RmCat, RmTypedItem>("rm_typed", ::RmTypedItem) {
+    val id by Column.UUID().primaryKey()
+    val ref by Column.UUID()              // a second UUID column, to plant non-parseable text in
+    val status by Column.enum<RmStatus>() // a convert-based (text) column type
+
+    init { id; ref; status }
+}
+
+// All columns TEXT so a raw insert can plant values that violate the entity's typed contract.
+private val rmTypedDdl =
+    """CREATE TABLE IF NOT EXISTS "rm_typed" ("id" TEXT NOT NULL, "ref" TEXT NOT NULL, "status" TEXT NOT NULL, PRIMARY KEY ("id"))"""


### PR DESCRIPTION
Closes #40.

## What

Result-mapping failures now point straight at the schema/API mismatch instead of leaking a raw backend error.

- **Per-column reads wrapped** (`mapToDao` + join projections): a backend/conversion failure throws `ResultMappingException` naming the **table, SQL column, entity field, expected Korm column type, result index**, with the original error preserved as the **cause**.
- **Non-null ← NULL** message now also names the entity field and expected type, and distinguishes a *database NULL* from a column that was *not selected* (projection guidance).
- **`ResultRow.get`** separates "field was not selected" from "selected field is NULL", each with actionable guidance.
- New **`ColumnType.description`** (default from class name; `convert`/enum override) feeds the "expected Korm type" in messages. Source-compatible interface addition.

## Performance

Runtime-only. Happy path is within noise (try/catch is free when not throwing; `emptySet()` is a singleton; message/`description` computed only on the error path). Join-pair hydration was rewritten to a single pass — **one** map allocation and one `fieldKey()` per column — so it's actually slightly cheaper than before.

## Tests

SQLite (JVM + native): non-null ← NULL, type-conversion failure (bad UUID), invalid enum value, and unselected-projection-field access.

Example message:
```
Failed to read column 'ref' of table 'rm_typed' (entity field 'ref',
expected Korm type Uuid, result index 1): Invalid UUID string: not-a-uuid
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)