### PR TITLE
fix(samples): update repository sample for suspendTransaction signature

### DIFF
--- a/samples/repository/src/commonMain/kotlin/Repository.kt
+++ b/samples/repository/src/commonMain/kotlin/Repository.kt
@@ -37,7 +37,7 @@ abstract class Repository<G : Catalog, T : Entity>(
     protected suspend fun <R> read(block: suspend SuspendScope<G>.() -> R): R = db.suspendAutocommit(block)
 
     /** Run a write in a transaction on this database. Use in subclasses for custom mutations. */
-    protected suspend fun <R> write(block: suspend SuspendScope<G>.() -> R): R = db.suspendTransaction(block)
+    protected suspend fun <R> write(block: suspend SuspendScope<G>.() -> R): R = db.suspendTransaction(block = block)
 }
 
 // For unit-testing services against an interface (mocking), declare a domain interface your


### PR DESCRIPTION
## Why

The last CI run on `main` (merge of #80) failed at the **SQLite sample tests** step — actually a compile error, not a test failure:

```
samples/repository/src/commonMain/kotlin/Repository.kt:40
Argument type mismatch: actual type is 'suspend SuspendScope<G>.() -> R', but 'TransactionIsolation?' was expected.
No value passed for parameter 'block'.
```

PR #35 (portable transaction isolation) added `isolation` and `readOnly` params before `block` in `suspendTransaction`. The repository sample still called it positionally (`suspendTransaction(block)`), so the lambda bound to `isolation`.

## Fix

Pass the block by name: `db.suspendTransaction(block = block)`.

Verified `:samples:repository:compileKotlinJvm` compiles locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)