### PR TITLE
docs: AI-agent docs (llms.txt + AGENTS.md) and AI-oriented README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,204 @@
+# Kormium for AI agents
+
+Type-safe Kotlin Multiplatform ORM / SQL DSL. This file is the canonical, copy-ready
+reference: prefer the forms shown here over any you might infer. Package is
+`io.github.kormium`. Full docs in [`docs/`](docs/README.md); deeper examples in
+[`samples/`](samples/README.md).
+
+## Mental model (read this first)
+
+- A `Catalog` is a compile-time database identity; a `Database<G>` is an instance of it.
+- A `Table<G, T>` is a pure schema descriptor; `T : Entity` holds the row's values.
+- **All queries run inside a scope**: `db.transaction { ... }` (BEGIN/COMMIT/ROLLBACK) or
+  `db.autocommit { ... }` (one pinned connection, no explicit tx — use for reads). Table
+  operations (`find`, `insert`, `update`, joins, ...) **only exist inside that block** — they
+  are scope extensions, not global methods on the table.
+- Suspend mirror: `db.suspendTransaction { ... }` / `db.suspendAutocommit { ... }` with the
+  same API. (`kormium-r2dbc` is true async; JDBC / SQLite / native libpq+libmariadb are
+  offloaded blocking on virtual threads.)
+- **No session, no dirty checking, no lazy loading.** Behavior is local: the SQL is exactly
+  what the DSL renders, and an `update` writes only the fields you assigned.
+
+## Define a schema
+
+```kotlin
+import io.github.kormium.*
+
+object App : Catalog
+
+object Users : Table<App, User>("users", ::User) {
+    val id by Column.UUID().primaryKey()
+    val name by Column.Text()
+    val age by Column.Int()
+    val note by Column.Text().nullable()   // nullable -> entity property is String?
+}
+
+class User : Entity() {
+    var id by Users.id        // non-null column -> non-null property (no `!!` needed)
+    var name by Users.name
+    var age by Users.age
+    var note by Users.note    // String?
+}
+```
+
+Kormium does not own schema management. Create/evolve schema with `kormium-migrate` (below) or
+any migration tool; a `Table` only describes the row↔entity mapping.
+
+## Connect
+
+```kotlin
+import io.github.kormium.database.createDatabase
+
+// PostgreSQL (kormium-postgres), JVM + Native:
+val db: Database<App> = createDatabase(
+    host = "localhost", port = 5432, database = "postgres", user = "postgres", password = "password",
+)
+// MySQL / MariaDB (kormium-mysql): same createDatabase(...), port = 3306.
+// SQLite (kormium-sqlite):   createSqliteDatabase(path = ":memory:")
+// Async PostgreSQL (kormium-r2dbc):  createR2dbcDatabase(...)
+// Async MySQL (kormium-r2dbc):       createMySqlR2dbcDatabase(...)
+```
+
+## Read — the canonical single-table form
+
+```kotlin
+val adults: List<User> = db.autocommit {
+    Users.find {
+        where { Users.age gtEq 18 }
+        where { Users.name like "A%" }   // multiple where { } blocks AND together
+        orderBy DESC Users.age
+        limit = 50
+        offset = 0
+    }
+}
+
+val ada: User? = db.autocommit { Users.findById(uuid) }   // targets the primary key
+val all: List<User> = db.autocommit { Users.all() }
+val n: Long       = db.autocommit { Users.count { where { Users.age gtEq 18 } } }
+```
+
+Predicates: `eq`, `neq`, `gt`, `gtEq`, `less`, `lessEq`, `like`, `inList(...)`,
+`eq null` / `neq null` (render as `IS [NOT] NULL`), combined with `and` / `or` / `not(...)`.
+Values are typed (`Users.age eq 18`, not `"18"`) and always bound as parameters. An empty
+`inList` renders to `FALSE` (matches no rows), never invalid SQL.
+
+For a reusable query, build a `Query` value instead of a block:
+`Users.find(Query(Users.age gtEq 18))`. Every `find` / `count` / `update` / `deleteWhere`
+accepts either form.
+
+## Write
+
+```kotlin
+db.transaction {
+    Users.insert(user)                       // INSERT, returns the entity you passed (fast path)
+    Users.insert(user, returning = true)     // INSERT ... RETURNING for DB-generated values
+    Users.insertAll(listOf(a, b, c))
+
+    Users.update(User().apply { age = 37 }) { where { Users.id eq id } }   // only assigned fields
+    Users.deleteWhere { where { Users.name eq "Ada" } }
+
+    Users.upsert(user, conflict = listOf(Users.id), update = patch)        // INSERT ... ON CONFLICT
+    Users.insertOrIgnore(user, conflict = listOf(Users.id))
+}
+```
+
+`update` writes only the properties you assigned on the patch entity; untouched ones are left
+alone. Assigning `null` *does* write SQL `NULL`. (This is why concurrent partial updates do
+not clobber each other — Kormium never reloads-and-rewrites the whole row.)
+
+## Joins
+
+```kotlin
+// Columns from a join: select(), then read by the column you selected.
+db.autocommit {
+    (Users innerJoin Orders on (Users.id eq Orders.userId))
+        .where(Users.age gtEq 18)            // .where(expr) on a join, NOT a where { } block
+        .select()
+        .map { row -> row[Users.name] to row[Orders.total] }
+}
+
+// Project straight into your own type:
+db.autocommit {
+    (Users innerJoin Orders on (Users.id eq Orders.userId))
+        .select(Users.name, Orders.total) { row -> UserSpend(row[Users.name], row[Orders.total]) }
+}
+
+// Two-table join -> entity pairs:
+val pairs: List<Pair<User, Order>> = db.autocommit {
+    (Users innerJoin Orders on (Users.id eq Orders.userId)).find()
+}
+
+// leftJoin keeps the right side nullable; find() returns Pair<User, Order?>:
+val left: List<Pair<User, Order?>> = db.autocommit {
+    (Users leftJoin Orders on (Users.id eq Orders.userId)).find()
+}
+```
+
+Read nullable right-side fields in `select(...)` with `row.getOrNull(col)`; `row[col]` throws
+on NULL/absent. The entity-`Pair` mapping is intentionally limited to two-table joins — for
+three or more tables use the `select(...)` projection forms.
+
+## Aggregates
+
+Keep aggregate expressions in `val`s and read rows with the **same** `val` — aggregates are
+keyed by expression identity.
+
+```kotlin
+val orders = count()
+val total  = Orders.total.sum()
+
+db.autocommit {
+    (Users innerJoin Orders on (Users.id eq Orders.userId))
+        .groupBy(Users.id)
+        .having(total gt Value(BigDecimal.fromInt(100)))
+        .select(Users.name, orders, total)
+}.forEach { row ->
+    println("${row[Users.name]}: ${row[orders]} orders, ${row[total]}")
+}
+```
+
+Aggregates: `count()` → `Long`, `col.count()` → `Long`, `col.min()` / `col.max()` → the
+column's type, `col.sum()` (integer columns widen to `Long`), `col.avg()` → `Double`.
+Single-table grouping starts from `Table.query()`:
+`Users.query().groupBy(Users.age).distinct().select(Users.age)`.
+
+## Migrations (kormium-migrate)
+
+```kotlin
+import io.github.kormium.migrate.Migration
+import io.github.kormium.migrate.migrate
+
+db.migrate(listOf(
+    Migration("001-create-users", """
+        CREATE TABLE "users" ("id" uuid PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL);
+    """),
+))
+```
+
+Ordered, idempotent, checksum-verified; applied ids recorded in `kormium_migrations`. For SQL
+the `;` splitter can't handle, pass statements explicitly: `Migration("002", listOf(a, b))`.
+
+## Which form for what
+
+| Task | Use |
+|------|-----|
+| Filtered read, one table | `Table.find { where { } orderBy limit }` |
+| By primary key | `Table.findById(id)` |
+| Reusable / prebuilt query | `Table.find(Query(...))` |
+| Two-table join as entities | `(A innerJoin B on ...).find()` |
+| Columns / aggregates from a join | `.select(...)` + `row[col]` / `row[agg]` |
+| 3+ table join | `.select(...)` projection forms |
+| Single-table grouping | `Table.query().groupBy(...).select(...)` |
+| Upsert / ignore-on-conflict | `Table.upsert(...)` / `Table.insertOrIgnore(...)` |
+
+## Gotchas
+
+- Operations are scope extensions — they don't compile outside `db.transaction { }` /
+  `db.autocommit { }` (or the `suspend*` variants).
+- A `Table<G, _>` can only be used in a `Database<G>` scope; mixing catalogs is a compile error.
+- `findById` targets the primary key and throws on a composite key — use `find(Query(col eq v))`.
+- Predicate names are `less` / `lessEq` (not `lt` / `ltEq`) and `neq` (not `ne`).
+- Read nullable join columns with `getOrNull`; `row[col]` throws on NULL/absent.
+- Not modeled by the typed DSL: subqueries, `UNION`, CTEs, window functions, `RIGHT`/`FULL`/
+  `CROSS`/self-joins, `BETWEEN`, `ILIKE`/regex, arithmetic/`CASE`/`COALESCE`, `RETURNING` on
+  `UPDATE`/`DELETE`, `FOR UPDATE`. Drop to `RawExpression` or `execute(...)` for those.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,44 @@
+# Kormium
+
+> Type-safe ORM and SQL DSL for Kotlin Multiplatform. Tables, entities, typed predicates,
+> transactions, joins, aggregations and migrations, with compile-time database↔table safety.
+> No session, no dirty-checking, no lazy loading — the DSL renders to predictable,
+> parameterized SQL you can reason about locally. Backends: PostgreSQL (JDBC + native libpq),
+> MySQL/MariaDB (JDBC + native libmariadb), SQLite, async r2dbc (PostgreSQL + MySQL), plus
+> Ktor integration. Targets: JVM (JDK 21+), Kotlin/Native, and web (Kotlin/JS + Wasm).
+> Package `io.github.kormium`.
+
+Why this matters for an AI agent: Kormium is built to be cheap and correct to write *with*
+a coding agent. Queries are typed expressions, so mistakes the model would otherwise ship as
+runtime SQL bugs (wrong column, wrong type, `'18'` vs `18`) become compile errors the agent
+can see and fix in its own loop. There is no hidden persistence context to reason about —
+what is in the code is what runs. Lead with the idiomatic forms in `AGENTS.md`; prefer them
+over any API you might infer.
+
+All queries run inside `db.transaction { }` or `db.autocommit { }` (suspend mirrors:
+`db.suspendTransaction { }` / `db.suspendAutocommit { }`). Table operations (`find`, `insert`,
+`update`, joins, ...) are scope extensions that only exist inside that block — not global
+methods on the table.
+
+## Start here
+
+- [AGENTS.md](AGENTS.md): canonical, copy-ready snippets for every common task (read this first)
+- [Quick start](docs/quick-start.md): minimal end-to-end setup
+- [Tables and entities](docs/tables-and-entities.md): columns, nullability, primary keys, update semantics
+
+## Reference
+
+- [Queries, joins and aggregations](docs/queries.md): `find { where { } }`, joins, aggregates, supported/unsupported SQL
+- [Transactions, suspend API and migrations](docs/transactions-and-migrations.md): scopes, savepoints, `db.migrate(...)`
+- [Backends and platform support](docs/backends.md): PostgreSQL / MySQL / SQLite / r2dbc driver setup, JVM / Native / web targets
+- [Ktor integration](docs/ktor.md): per-DI-framework artifacts and request-scoped helpers
+- [Installation](docs/installation.md): Gradle, BOM, native system libraries
+- [API ergonomics](docs/api-ergonomics.md): the public API direction and naming rules
+- [API cookbook](docs/api-cookbook.md): task-oriented recipes
+- [Observability](docs/observability.md): logging and metrics hooks
+- [Production guide](docs/production-guide.md): pooling, isolation, operational guidance
+- [Compatibility policy](docs/compatibility.md): SemVer and pre-1.0 breaking-change policy
+
+## Examples
+
+- [samples/](samples/README.md): runnable projects (CRUD, Ktor DI/Koin, sharding, read-through cache, r2dbc, Wasm web)

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,26 @@ val adults = db.autocommit {
   tables it reads change — for Compose Multiplatform and Android UIs.
 - **Server integration.** Ktor helpers are split into DI-agnostic, Ktor DI and Koin
   artifacts.
+- **AI-agent friendly.** The typed DSL turns "wrong column / wrong type / unbound value"
+  from runtime SQL bugs into compile errors an agent can fix in its own loop — and there is
+  no session or lazy-loading state to reason about. See [Built for AI coding agents](#built-for-ai-coding-agents).
+
+## Built for AI coding agents
+
+Kormium is designed to be cheap and correct to write *with* a coding agent, not just by hand.
+
+- **The compiler is the agent's guardrail.** Queries are typed expressions, so the mistakes
+  a model would otherwise ship as runtime SQL — a misspelled column, `'18'` instead of `18`,
+  a type that doesn't match — fail at compile time, inside the generate→compile→fix loop the
+  agent already runs.
+- **No hidden state to hallucinate.** There is no persistence context, dirty checking, flush
+  order or lazy proxy. What the code says is what runs, so the model reasons locally instead
+  of guessing at session behavior.
+- **Guessable, consistent API.** `find` / `insert` / `insertAll` / `update` / `deleteWhere`
+  read like the SQL they emit, and the Exposed-style DSL is close to forms models already know.
+- **Drop-in context for the model.** [`AGENTS.md`](AGENTS.md) is a canonical, copy-ready
+  snippet reference, and [`llms.txt`](llms.txt) indexes the docs for ingestion — point your
+  agent at them so it leads with the idiomatic path instead of low-level escape hatches.
 
 ## Status
 


### PR DESCRIPTION
## Why

Make Kormium cheap and correct to use *with* a coding agent, and say so where people look first. A typed DSL turns wrong-column / wrong-type / unbound-value mistakes into compile errors inside the agent's own loop, and there is no session / lazy-loading state to reason about — that's a real differentiator worth surfacing.

## Changes

- **`llms.txt`** — doc index for LLM ingestion, leading with `AGENTS.md`. Current 0.9.0 surface: PostgreSQL/MySQL/SQLite/r2dbc, JVM/Native/web, `io.github.kormium`.
- **`AGENTS.md`** — canonical, copy-ready snippets for every common task, matched to the **current** API (predicates `eq/neq/gt/gtEq/less/lessEq`, aggregates keyed by expression identity, two-table `find()` pairs, `upsert`/`insertOrIgnore`, `db.migrate`, the "which form for what" table and gotchas).
- **`readme.md`** — new "Built for AI coding agents" section + a Why-Kormium bullet.

Docs only — no API changes.

## Notes

- Supersedes the docs portion of #52 (which was 105 commits stale and pre-rebrand). The two code ideas in #52 — structural result keys (`resultKey()`) and `ResultRow.entity()` for 3+ table joins — are still unlanded and will be re-done on current `main` as a separate change; #52 stays open until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)