### PR TITLE
feat: structural result keys so aggregates read without a `val`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,8 +140,9 @@ three or more tables use the `select(...)` projection forms.
 
 ## Aggregates
 
-Keep aggregate expressions in `val`s and read rows with the **same** `val` — aggregates are
-keyed by expression identity.
+Aggregates are keyed structurally, so you read a row with the same expression you selected —
+a freshly built one works (`row[Orders.total.sum()]`). A `val` is handy for reuse (in
+`having(...)` and when reading), not required.
 
 ```kotlin
 val orders = count()

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -188,8 +188,10 @@ mapping is intentionally limited to two-table joins.
 
 ## Aggregations
 
-Keep aggregate expressions in `val`s and reuse those values when reading rows. Aggregates
-are keyed by expression identity.
+Aggregates are keyed structurally (by the function over their target), so you read a row back
+with the same expression you selected — a freshly built one works, e.g. `row[Orders.total.sum()]`.
+A `val` is handy when you reuse the expression (in `having(...)` and again when reading), but it
+is no longer required.
 
 ```kotlin
 val orders = count()

--- a/kormium-core/src/commonMain/kotlin/Aggregate.kt
+++ b/kormium-core/src/commonMain/kotlin/Aggregate.kt
@@ -6,10 +6,11 @@ import kotlin.jvm.JvmName
 // Aggregates are Selectable (appear in SELECT and are read from a ResultRow) and, since
 // Selectable is an Expression, can also appear in `having(...)` (e.g. `total gt Value(100)`).
 
-/** `COUNT(*)` — the number of rows in the group. Hold the result in a `val` to read it. */
+/** `COUNT(*)` — the number of rows in the group. */
 fun count(): Selectable<Long> = object : Selectable<Long> {
     override fun toSql(builder: ParamBuilder) = "COUNT(*)"
     override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Long? = rs.getLong(index)
+    override fun resultKey() = "COUNT(*)"
 }
 
 /** `COUNT(column)` — the non-null values of the column in the group. */
@@ -18,6 +19,7 @@ fun Column<*, *, *>.count(): Selectable<Long> {
     return object : Selectable<Long> {
         override fun toSql(builder: ParamBuilder) = "COUNT(${column.toSql(builder)})"
         override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Long? = rs.getLong(index)
+        override fun resultKey() = "COUNT(${column.resultKey()})"
     }
 }
 
@@ -49,12 +51,14 @@ fun Column<kotlin.Long, *, *>.sum(): Selectable<Long> = LongAggregate(this)
 private class ColumnAggregate<Z>(private val fn: String, private val column: Column<Z, *, *>) : Selectable<Z> {
     override fun toSql(builder: ParamBuilder) = "$fn(${column.toSql(builder)})"
     override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Z? = column.read(rs, index, typeMapper)
+    override fun resultKey() = "$fn(${column.resultKey()})"
 }
 
 // SUM(column) read as a Long (the server-side bigint width), regardless of the column's own type.
 private class LongAggregate(private val column: Column<*, *, *>) : Selectable<Long> {
     override fun toSql(builder: ParamBuilder) = "SUM(${column.toSql(builder)})"
     override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Long? = rs.getLong(index)
+    override fun resultKey() = "SUM(${column.resultKey()})"
 }
 
 /** `AVG(column)` as a Double. */
@@ -63,5 +67,6 @@ fun Column<*, *, *>.avg(): Selectable<Double> {
     return object : Selectable<Double> {
         override fun toSql(builder: ParamBuilder) = "AVG(${column.toSql(builder)})"
         override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Double? = rs.getDouble(index)
+        override fun resultKey() = "AVG(${column.resultKey()})"
     }
 }

--- a/kormium-core/src/commonMain/kotlin/Column.kt
+++ b/kormium-core/src/commonMain/kotlin/Column.kt
@@ -59,6 +59,10 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
     override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Z? =
         columnType.read(rs, index)
 
+    // The property delegate yields a fresh Column per access, so identity can't key a result row;
+    // table+SQL-name is the stable, dialect-independent key (aggregates embed this for their target).
+    override fun resultKey(): Any = "${table.tableName}.$name"
+
     // Converts a domain value to its bound form (e.g. enum -> name, @Serializable -> JsonElement)
     // before it reaches the ParamBuilder. Null passes through; built-in types are identity.
     @Suppress("UNCHECKED_CAST")

--- a/kormium-core/src/commonMain/kotlin/Join.kt
+++ b/kormium-core/src/commonMain/kotlin/Join.kt
@@ -11,6 +11,14 @@ import io.github.kormium.resultset.ResultSet
 interface Selectable<Z> : Expression {
     /** Reads this field's value from the result row at [index]. */
     fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z?
+
+    /**
+     * A stable, structural key identifying this field in a [ResultRow] — independent of the
+     * instance and the dialect. Two selectables that select the same thing share a key, so a row
+     * can be read with a freshly built field (`row[Orders.total.sum()]`) without hoisting it into
+     * a `val`. Columns key by `table.name`; aggregates by their function over their target's key.
+     */
+    fun resultKey(): Any
 }
 
 internal enum class JoinType(val sql: String) { INNER("INNER JOIN"), LEFT("LEFT JOIN") }
@@ -169,11 +177,10 @@ class ResultRow internal constructor(private val values: Map<Any, Any?>) {
     internal fun getByKey(key: Any): Any? = values[key]
 }
 
-// Identifies a selected field. A Column's property delegate yields a fresh instance on each
-// access, so instance identity can't be used — key columns by table+name instead; aggregates
-// (held by the caller in a val) are keyed by instance.
-internal fun fieldKey(field: Selectable<*>): Any =
-    if (field is Column<*, *, *>) "${field.tableRef.tableName}.${field.name}" else field
+// Identifies a selected field by its structural key, so a row reads back regardless of which
+// instance is used — both a Column's property delegate and an aggregate factory yield a fresh
+// instance on each access, so instance identity can't be used.
+internal fun fieldKey(field: Selectable<*>): Any = field.resultKey()
 
 // Qualifies a table reference.
 internal fun Table<*, *>.qualifiedName(dialect: Dialect): String {

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -252,6 +252,32 @@ class SqliteIntegrationTest {
         db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
     }
 
+    /**
+     * Aggregates are keyed structurally, so a row reads back with a freshly built aggregate
+     * instance — no need to hoist it into a `val` shared between select and read.
+     */
+    @Test
+    fun testAggregateReadsWithFreshInstance() {
+        val tag = "fresh-${Uuid.random()}"
+        db.transaction {
+            Products.execSql(productsDdl)
+            Products.insertAll(List(3) {
+                Product().apply {
+                    this.id = Uuid.random(); this.price = BigDecimal.fromInt(0); this.qty = 10
+                    this.displayName = tag; this.note = null; this.rank = null
+                }
+            })
+        }
+        val row = db.autocommit {
+            // Selected with one aggregate instance...
+            Products.query().where(Products.displayName eq tag).select(count(), Products.qty.sum()).single()
+        }
+        // ...read back with brand-new, separate instances.
+        assertEquals(3L, row[count()])
+        assertEquals(30L, row[Products.qty.sum()])
+        db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
+    }
+
     /** An exception out of a transaction block rolls back every statement in it. */
     @Test
     fun testTransactionRollsBackOnException() {


### PR DESCRIPTION
## Why

Reading an aggregate back from a `ResultRow` required holding it in a `val` and reusing that exact instance — `row[count()]` with a fresh `count()` silently missed, because aggregates were keyed by **instance identity**. That's a real footgun for everyone, and especially for a coding agent generating queries (it naturally writes `row[Orders.total.sum()]`).

## What

`ResultRow` keying moves from identity to a **structural key** via `Selectable.resultKey()`:

- columns key by `"table.name"`,
- aggregates by `"FN(target)"` (e.g. `"SUM(orders.total)"`).

`fieldKey()` collapses to `field.resultKey()`; the old `if (field is Column) … else field` special-case is gone. A `val` is still handy for reuse (in `having(...)` and when reading), but no longer required.

## Changes

- `Selectable` gains `fun resultKey(): Any`; implemented by `Column` and the five aggregate forms (`count()`, `Column.count()`, MIN/MAX/SUM via `ColumnAggregate`, integer `SUM` via `LongAggregate`, `avg()`).
- New SQLite integration test reads `count()` and `sum()` back through **brand-new instances**.
- `docs/queries.md` + `AGENTS.md` drop the "keep it in a `val`" caveat.

## API note

This adds an abstract member to the public `Selectable` interface — source-breaking for any external implementation of it. Landing on `release/0.9.0` (unreleased) so it isn't a breaking change for published users. `Selectable` is effectively an internal extension point (Column + aggregates); external impls aren't expected.

## Tests

`:kormium-sqlite:jvmTest` (incl. the new `testAggregateReadsWithFreshInstance`) and `:kormium-core:jvmTest` green locally.

First of two PRs from the #52 code ideas; the second adds `ResultRow.entity()` for 3+ table joins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)