### PR TITLE
feat: ResultRow.entity(table) for three-or-more-table joins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,11 +132,20 @@ val pairs: List<Pair<User, Order>> = db.autocommit {
 val left: List<Pair<User, Order?>> = db.autocommit {
     (Users leftJoin Orders on (Users.id eq Orders.userId)).find()
 }
+
+// 3+ tables -> select() + row.entity(table), each side a whole entity:
+val triples: List<Triple<User, Order, Item>> = db.autocommit {
+    (Users innerJoin Orders on (Users.id eq Orders.userId)
+           innerJoin Items  on (Orders.id eq Items.orderId))
+        .select()
+        .map { Triple(it.entity(Users), it.entity(Orders), it.entity(Items)) }
+}
 ```
 
 Read nullable right-side fields in `select(...)` with `row.getOrNull(col)`; `row[col]` throws
-on NULL/absent. The entity-`Pair` mapping is intentionally limited to two-table joins — for
-three or more tables use the `select(...)` projection forms.
+on NULL/absent. `find()`'s entity-`Pair` is the two-table convenience over `entity()`; for a
+LEFT join, `entity()` still hydrates the right side (NULL columns), so detect unmatched rows
+with `row.getOrNull(Right.id) == null`.
 
 ## Aggregates
 
@@ -188,7 +197,7 @@ the `;` splitter can't handle, pass statements explicitly: `Migration("002", lis
 | Reusable / prebuilt query | `Table.find(Query(...))` |
 | Two-table join as entities | `(A innerJoin B on ...).find()` |
 | Columns / aggregates from a join | `.select(...)` + `row[col]` / `row[agg]` |
-| 3+ table join | `.select(...)` projection forms |
+| 3+ table join as entities | `.select()` + `row.entity(table)` |
 | Single-table grouping | `Table.query().groupBy(...).select(...)` |
 | Upsert / ignore-on-conflict | `Table.upsert(...)` / `Table.insertOrIgnore(...)` |
 

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -183,8 +183,22 @@ rows.forEach { row ->
 }
 ```
 
-Joining a third table keeps the `select(...)` projection forms. The two-entity `Pair`
-mapping is intentionally limited to two-table joins.
+For three or more tables, read each side as a whole entity with `row.entity(table)` over a
+plain `select()`:
+
+```kotlin
+val triples: List<Triple<User, Order, Item>> = db.autocommit {
+    (Users innerJoin Orders on (Users.id eq Orders.userId)
+           innerJoin Items  on (Orders.id eq Items.orderId))
+        .select()
+        .map { Triple(it.entity(Users), it.entity(Orders), it.entity(Items)) }
+}
+```
+
+`entity(table)` rebuilds any joined table's entity from the row, so it scales to any number of
+tables. The two-entity `Pair` mapping of `find()` is the two-table convenience over it; for a
+`LEFT` join, `entity()` still hydrates the right side (its columns are NULL), so detect an
+unmatched row yourself with `row.getOrNull(Right.id) == null`.
 
 ## Aggregations
 

--- a/kormium-core/src/commonMain/kotlin/Join.kt
+++ b/kormium-core/src/commonMain/kotlin/Join.kt
@@ -177,6 +177,18 @@ class ResultRow internal constructor(private val values: Map<Any, Any?>) {
     internal fun getByKey(key: Any): Any? = values[key]
 }
 
+/**
+ * Reconstructs [table]'s entity from this row. Works for any number of joined tables, so a
+ * three-or-more-table join reads as whole entities — `select()` (all columns), then
+ * `map { Triple(it.entity(A), it.entity(B), it.entity(C)) }`. Columns the projection didn't
+ * select read back as absent.
+ *
+ * For a `LEFT JOIN`, a row with no match still hydrates the right table here (its columns are
+ * NULL); detect the unmatched case yourself, e.g. `row.getOrNull(Right.id) == null`. The
+ * two-table `find()` does this for you and returns `Pair<A, B?>`.
+ */
+fun <T : Entity> ResultRow.entity(table: Table<*, T>): T = table.hydrateFrom(this)
+
 // Identifies a selected field by its structural key, so a row reads back regardless of which
 // instance is used — both a Column's property delegate and an aggregate factory yield a fresh
 // instance on each access, so instance identity can't be used.

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -10,6 +10,7 @@ import io.github.kormium.autocommit
 import io.github.kormium.count
 import io.github.kormium.createSqliteDatabase
 import io.github.kormium.database.Database
+import io.github.kormium.entity
 import io.github.kormium.eq
 import io.github.kormium.gtEq
 import io.github.kormium.inList
@@ -407,6 +408,43 @@ class SqliteIntegrationTest {
             Authors.deleteWhere(Query(Authors.id inList listOf(withBook, withoutBook)))
         }
     }
+
+    /** A three-table join reads every side as a whole entity via select() + row.entity(table). */
+    @Test
+    fun testThreeTableJoinHydratesEntities() {
+        val authorId = Uuid.random()
+        val bookId = Uuid.random()
+        val reviewId = Uuid.random()
+        db.transaction {
+            Authors.execSql(authorsDdl)
+            Books.execSql(booksDdl)
+            Reviews.execSql(reviewsDdl)
+            Authors.insert(Author().apply { id = authorId; name = "Ada" })
+            Books.insert(Book().apply { id = bookId; this.authorId = authorId; title = "Notes" })
+            Reviews.insert(Review().apply { id = reviewId; this.bookId = bookId; stars = 5 })
+        }
+
+        val triples: List<Triple<Author, Book, Review>> = db.autocommit {
+            (Authors innerJoin Books on (Authors.id eq Books.authorId)
+                     innerJoin Reviews on (Books.id eq Reviews.bookId))
+                .select()
+                .map { Triple(it.entity(Authors), it.entity(Books), it.entity(Reviews)) }
+        }
+
+        assertEquals(1, triples.size)
+        val (author, book, review) = triples.single()
+        assertEquals("Ada", author.name)
+        assertEquals("Notes", book.title)
+        assertEquals(authorId, book.authorId)
+        assertEquals(5, review.stars)
+        assertEquals(bookId, review.bookId)
+
+        db.transaction {
+            Reviews.deleteWhere(Query(Reviews.id eq reviewId))
+            Books.deleteWhere(Query(Books.id eq bookId))
+            Authors.deleteWhere(Query(Authors.id eq authorId))
+        }
+    }
 }
 
 object SqCatalog : Catalog
@@ -457,6 +495,20 @@ object Books : Table<SqCatalog, Book>("books", ::Book) {
     init { id; authorId; title }
 }
 
+class Review : Entity() {
+    var id by Reviews.id
+    var bookId by Reviews.bookId
+    var stars by Reviews.stars
+}
+
+object Reviews : Table<SqCatalog, Review>("reviews", ::Review) {
+    val id by Column.UUID().primaryKey()
+    val bookId by Column.UUID()
+    val stars by Column.Int()
+
+    init { id; bookId; stars }
+}
+
 class AllTypesEntity : Entity() {
     var id by AllTypes.id
     var anInt by AllTypes.anInt
@@ -501,4 +553,5 @@ object AllTypes : Table<SqCatalog, AllTypesEntity>("all_types", ::AllTypesEntity
 internal val productsDdl = """CREATE TABLE IF NOT EXISTS "products" ("id" TEXT NOT NULL, "price" TEXT NOT NULL, "qty" INTEGER NOT NULL, "displayName" TEXT NOT NULL, "note" TEXT, "rank" INTEGER, PRIMARY KEY ("id"))"""
 internal val authorsDdl = """CREATE TABLE IF NOT EXISTS "authors" ("id" TEXT NOT NULL, "name" TEXT NOT NULL, PRIMARY KEY ("id"))"""
 internal val booksDdl = """CREATE TABLE IF NOT EXISTS "books" ("id" TEXT NOT NULL, "authorId" TEXT NOT NULL, "title" TEXT NOT NULL, PRIMARY KEY ("id"))"""
+internal val reviewsDdl = """CREATE TABLE IF NOT EXISTS "reviews" ("id" TEXT NOT NULL, "bookId" TEXT NOT NULL, "stars" INTEGER NOT NULL, PRIMARY KEY ("id"))"""
 internal val allTypesDdl = """CREATE TABLE IF NOT EXISTS "all_types" ("id" TEXT NOT NULL, "anInt" INTEGER NOT NULL, "aDouble" REAL NOT NULL, "aBool" INTEGER NOT NULL, "aText" TEXT NOT NULL, "aDecimal" TEXT NOT NULL, "anInstant" TEXT NOT NULL, "aJson" TEXT NOT NULL, "aLong" INTEGER NOT NULL, "aFloat" REAL NOT NULL, "aShort" INTEGER NOT NULL, "aDate" TEXT NOT NULL, "aTime" TEXT NOT NULL, "aDateTime" TEXT NOT NULL, PRIMARY KEY ("id"))"""


### PR DESCRIPTION
## Why

Two-table joins read as entity `Pair`s via `find()`, but three-or-more-table joins dropped to column-by-column `select(...)` projections — you couldn't get whole entities back. Reconstructing them by hand is exactly the boilerplate the ORM should remove (and exactly what a coding agent gets wrong).

## What

Adds a public `fun <T : Entity> ResultRow.entity(table: Table<*, T>): T` that rebuilds any joined table's entity from a row:

```kotlin
val triples: List<Triple<User, Order, Item>> = db.autocommit {
    (Users innerJoin Orders on (Users.id eq Orders.userId)
           innerJoin Items  on (Orders.id eq Items.orderId))
        .select()
        .map { Triple(it.entity(Users), it.entity(Orders), it.entity(Items)) }
}
```

It delegates to the existing per-table `hydrateFrom`, so absent-column handling and type mapping are identical to the two-table `find()` — which remains the two-table convenience over the same mechanism.

**LEFT joins:** `entity()` always returns a non-null `T`; for an unmatched right side it hydrates NULL columns, so detect that yourself with `row.getOrNull(Right.id) == null`. `find()` keeps doing this for you and returns `Pair<A, B?>`. Documented.

## Changes

- `ResultRow.entity(table)` in `Join.kt` (purely additive — no signature changed).
- SQLite integration test joining `Authors → Books → Reviews`, reading all three as entities (adds a small `Reviews` test table).
- `docs/queries.md` + `AGENTS.md` show the 3+-table form and the LEFT-join caveat.

## Tests

`:kormium-sqlite:jvmTest` (incl. new `testThreeTableJoinHydratesEntities`) and `:kormium-core:jvmTest` green locally.

Second of two PRs from the #52 code ideas (first was structural result keys, #90). With both merged, #52 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)