### PR TITLE
feat: BETWEEN predicate via an inclusive Kotlin range

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,10 +77,11 @@ val all: List<User> = db.autocommit { Users.all() }
 val n: Long       = db.autocommit { Users.count { where { Users.age gtEq 18 } } }
 ```
 
-Predicates: `eq`, `neq`, `gt`, `gtEq`, `less`, `lessEq`, `like`, `inList(...)`,
-`eq null` / `neq null` (render as `IS [NOT] NULL`), combined with `and` / `or` / `not(...)`.
-Values are typed (`Users.age eq 18`, not `"18"`) and always bound as parameters. An empty
-`inList` renders to `FALSE` (matches no rows), never invalid SQL.
+Predicates: `eq`, `neq`, `gt`, `gtEq`, `less`, `lessEq`, `between (lo..hi)`, `like`,
+`inList(...)`, `eq null` / `neq null` (render as `IS [NOT] NULL`), combined with
+`and` / `or` / `not(...)`. Values are typed (`Users.age eq 18`, not `"18"`) and always bound
+as parameters. `between` takes an inclusive Kotlin range (`Users.age between 18..65`); an empty
+range and an empty `inList` both render to `FALSE` (match no rows), never invalid SQL.
 
 For a reusable query, build a `Query` value instead of a block:
 `Users.find(Query(Users.age gtEq 18))`. Every `find` / `count` / `update` / `deleteWhere`
@@ -210,5 +211,5 @@ the `;` splitter can't handle, pass statements explicitly: `Migration("002", lis
 - Predicate names are `less` / `lessEq` (not `lt` / `ltEq`) and `neq` (not `ne`).
 - Read nullable join columns with `getOrNull`; `row[col]` throws on NULL/absent.
 - Not modeled by the typed DSL: subqueries, `UNION`, CTEs, window functions, `RIGHT`/`FULL`/
-  `CROSS`/self-joins, `BETWEEN`, `ILIKE`/regex, arithmetic/`CASE`/`COALESCE`, `RETURNING` on
-  `UPDATE`/`DELETE`, `FOR UPDATE`. Drop to `RawExpression` or `execute(...)` for those.
+  `CROSS`/self-joins, `ILIKE`/regex, `CASE`/`COALESCE`, arithmetic in `SELECT` projections,
+  `RETURNING` on `UPDATE`/`DELETE`, `FOR UPDATE`. Drop to `RawExpression` or `execute(...)` for those.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -27,6 +27,7 @@ val adults: List<User> = db.autocommit {
 Users.find { where { Users.id eq id } }
 Users.find { where { Users.age gt 18 } }
 Users.find { where { Users.age lessEq 65 } }
+Users.find { where { Users.age between 18..65 } }     // inclusive both ends
 Users.find { where { Users.name like "A%" } }
 Users.find { where { Users.id inList listOf(id1, id2) } }
 Users.find { where { Users.note eq null } }
@@ -284,7 +285,6 @@ Not modeled by the typed DSL today:
   are available, and a table cannot be aliased to join it to itself.
 - **`DISTINCT ON`.** Only plain `DISTINCT` is supported.
 - **`EXISTS` / `NOT EXISTS`.**
-- **`BETWEEN`.** Express it as two comparisons (`col gtEq lo` and `col lessEq hi`).
 - **Pattern-match variants.** `like` only; no `ILIKE`, `SIMILAR TO`, or regex operators.
 - **Computed expressions.** No arithmetic (`+`, `-`, `*`, `/`), string concatenation, `CASE`,
   `COALESCE`, casts, or scalar functions in `SELECT`/`WHERE`/`HAVING`.
@@ -298,8 +298,9 @@ Not modeled by the typed DSL today:
   (`INSERT ... ON CONFLICT` *is* available — see `upsert` and `insertOrIgnore`.)
 
 The supported `WHERE` / `HAVING` predicates are exactly: `eq`, `neq`, `less`, `lessEq`, `gt`,
-`gtEq`, `like`, `inList`, `eq null` / `neq null` (rendered as `IS [NOT] NULL`), and the
-`and` / `or` / `not(...)` combinators.
+`gtEq`, `between` (an inclusive `lo..hi` range; an empty range matches nothing), `like`,
+`inList`, `eq null` / `neq null` (rendered as `IS [NOT] NULL`), and the `and` / `or` / `not(...)`
+combinators.
 
 ## Observing Changes
 

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -130,11 +130,35 @@ infix fun <Z> Column<Z, *, *>.gtEq(value: Z): Expression = GreaterEqOp(this, Val
 /** `column IN (v1, v2, ...)`. An empty list renders to `FALSE` (matches nothing). */
 class InListOp(private val column: Expression, private val values: List<*>) : Expression {
     override fun toSql(builder: ParamBuilder): String =
-        if (values.isEmpty()) "FALSE"
+        if (values.isEmpty()) FalseExpression.toSql(builder)
         else "${column.toSql(builder)} IN (${values.joinToString(", ") { builder.bind(it) }})"
 }
 
 infix fun <Z> Column<Z, *, *>.inList(values: List<Z>): Expression = InListOp(this, values.map { bindParam(it) })
+
+/** The SQL `FALSE` literal — what a predicate over an empty set (`inList`, `between`) renders to. */
+internal object FalseExpression : Expression {
+    override fun toSql(builder: ParamBuilder): String = "FALSE"
+}
+
+/** `expr BETWEEN lo AND hi` — both bounds inclusive, matching SQL and Kotlin's `lo..hi`. */
+class BetweenOp(private val expr: Expression, private val low: Expression, private val high: Expression) : Expression {
+    override fun toSql(builder: ParamBuilder): String =
+        "${expr.toSql(builder)} BETWEEN ${low.toSql(builder)} AND ${high.toSql(builder)}"
+}
+
+// `column between lo..hi` — inclusive both ends (SQL BETWEEN == Kotlin `..`). The Comparable bound
+// admits exactly the orderable column types (numbers, dates, text) and rejects Json/Bytes/Uuid at
+// compile time, where BETWEEN is meaningless. A reversed/empty range (lo > hi) renders to FALSE,
+// like an empty `inList`. Bounds bind through the column's converter, as in `eq` / `gtEq`.
+infix fun <Z : Comparable<Z>> Column<Z, *, *>.between(range: ClosedRange<Z>): Expression =
+    if (range.isEmpty()) FalseExpression
+    else BetweenOp(this, Value(bindParam(range.start)), Value(bindParam(range.endInclusive)))
+
+/** `(a + b) between lo..hi` — `between` over an arithmetic operand. */
+infix fun <Z : Comparable<Z>> NumericExpr<Z>.between(range: ClosedRange<Z>): Expression =
+    if (range.isEmpty()) FalseExpression
+    else BetweenOp(this, columnType.lit(range.start), columnType.lit(range.endInclusive))
 
 /** `column LIKE pattern` (text columns only). */
 class LikeOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "LIKE")

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -6,7 +6,9 @@ import io.github.kormium.ForeignKeyViolationException
 import io.github.kormium.Query
 import io.github.kormium.Table
 import io.github.kormium.UniqueViolationException
+import io.github.kormium.and
 import io.github.kormium.autocommit
+import io.github.kormium.between
 import io.github.kormium.count
 import io.github.kormium.createSqliteDatabase
 import io.github.kormium.database.Database
@@ -16,6 +18,7 @@ import io.github.kormium.gtEq
 import io.github.kormium.inList
 import io.github.kormium.innerJoin
 import io.github.kormium.leftJoin
+import io.github.kormium.not
 import io.github.kormium.query
 import io.github.kormium.sum
 import io.github.kormium.transaction
@@ -250,6 +253,52 @@ class SqliteIntegrationTest {
             Products.query().where(Products.displayName eq tag).select(total).single()[total]
         }
         assertEquals(4_000_000_000L, sum)
+        db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
+    }
+
+    /**
+     * `between` is inclusive on both ends, composes with `not`, and an empty/reversed range
+     * (lo > hi) matches nothing — over an Int column and a BigDecimal column.
+     */
+    @Test
+    fun testBetweenInclusiveAndEmptyRange() {
+        val tag = "between-${Uuid.random()}"
+        db.transaction {
+            Products.execSql(productsDdl)
+            listOf(5, 10, 20, 25).forEach { q ->
+                Products.insert(Product().apply {
+                    id = Uuid.random(); price = BigDecimal.fromInt(q); qty = q
+                    displayName = tag; note = null; rank = null
+                })
+            }
+        }
+
+        // Inclusive both ends: 10 and 20 are in, 5 and 25 are out.
+        val inRange = db.autocommit {
+            Products.find { where { (Products.displayName eq tag) and (Products.qty between 10..20) } }
+        }
+        assertEquals(listOf(10, 20), inRange.map { it.qty }.sorted())
+
+        // Same over a BigDecimal column.
+        val byPrice = db.autocommit {
+            Products.find {
+                where { (Products.displayName eq tag) and (Products.price between BigDecimal.fromInt(10)..BigDecimal.fromInt(20)) }
+            }
+        }
+        assertEquals(2, byPrice.size)
+
+        // not(between): everything outside 10..20 -> 5 and 25.
+        val outside = db.autocommit {
+            Products.find { where { (Products.displayName eq tag) and not(Products.qty between 10..20) } }
+        }
+        assertEquals(listOf(5, 25), outside.map { it.qty }.sorted())
+
+        // Reversed/empty range renders FALSE -> no rows.
+        val empty = db.autocommit {
+            Products.find { where { (Products.displayName eq tag) and (Products.qty between 20..10) } }
+        }
+        assertEquals(emptyList(), empty)
+
         db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
     }
 


### PR DESCRIPTION
## Why

`BETWEEN` was a DSL wall: writing a bounded range meant either two comparisons (`col gtEq lo` + `col lessEq hi`) or dropping to raw SQL. It's a high-frequency predicate, and the natural thing a coding agent writes. First of the DSL-coverage items in the AI-friendliness backlog.

## What

```kotlin
where { Users.age between 18..65 }                 // inclusive both ends
where { Orders.total between min..max }            // BigDecimal
where { Orders.createdAt between weekAgo..now }    // Instant
where { not(Users.age between 18..65) }            // NOT BETWEEN
```

- `infix fun <Z : Comparable<Z>> Column<Z, *, *>.between(range: ClosedRange<Z>)` + the same over `NumericExpr<Z>`.
- Renders native `expr BETWEEN ? AND ?`; **inclusive** both ends (SQL `BETWEEN` == Kotlin `..`).
- The `Comparable` bound admits exactly the orderable column types (numbers, dates, text) and **rejects Json/Bytes/Uuid at compile time**, where BETWEEN is meaningless — the constraint does the filtering.
- A reversed/empty range (`lo > hi`) renders to `FALSE`, like an empty `inList`; both now share a small `FalseExpression`.
- Bounds bind through the column's converter, as in `eq` / `gtEq`.
- `NOT BETWEEN` is `not(... between ...)`; column-to-column bounds are out of scope for v1.

Purely additive — no existing signature changes.

## Tests

`SqliteIntegrationTest.testBetweenInclusiveAndEmptyRange`: inclusive ends over an Int column, a BigDecimal range, `not(between)`, and the empty-range → `FALSE` (no rows) case. `:kormium-sqlite:jvmTest` + `:kormium-core:jvmTest` green locally.

Docs: `docs/queries.md` (added to the predicate list/summary, removed from "Unsupported") and `AGENTS.md` (predicate vocabulary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)