### PR TITLE
feat: string scalar functions (lower/upper/trim/ltrim/rtrim)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,13 @@ Predicates: `eq`, `neq`, `gt`, `gtEq`, `less`, `lessEq`, `between (lo..hi)`, `li
 as parameters. `between` takes an inclusive Kotlin range (`Users.age between 18..65`); an empty
 range and an empty `inList` both render to `FALSE` (match no rows), never invalid SQL.
 
+String functions: a `String` column has `lower()`, `upper()`, `trim()`, `ltrim()`, `rtrim()`,
+each returning a `StringExpr` that chains (`name.trim().lower()`), composes with the predicates
+above (`name.lower() eq "ada"`, `a.lower() eq b.lower()`), and is readable in `select(...)`.
+Plain string comparison (`eq` / `like` / `<`) follows the **engine collation** — case- and
+accent-sensitivity differ across PostgreSQL/MySQL/SQLite. Kormium does not inject a collation;
+for deterministic case-insensitive matching, lower **both sides**: `name.lower() eq "ada"`.
+
 For a reusable query, build a `Query` value instead of a block:
 `Users.find(Query(Users.age gtEq 18))`. Every `find` / `count` / `update` / `deleteWhere`
 accepts either form.
@@ -211,5 +218,6 @@ the `;` splitter can't handle, pass statements explicitly: `Migration("002", lis
 - Predicate names are `less` / `lessEq` (not `lt` / `ltEq`) and `neq` (not `ne`).
 - Read nullable join columns with `getOrNull`; `row[col]` throws on NULL/absent.
 - Not modeled by the typed DSL: subqueries, `UNION`, CTEs, window functions, `RIGHT`/`FULL`/
-  `CROSS`/self-joins, `ILIKE`/regex, `CASE`/`COALESCE`, arithmetic in `SELECT` projections,
-  `RETURNING` on `UPDATE`/`DELETE`, `FOR UPDATE`. Drop to `RawExpression` or `execute(...)` for those.
+  `CROSS`/self-joins, `ILIKE` operator (use `lower()`), regex, `CASE`/`COALESCE`, scalar functions
+  beyond `lower`/`upper`/`trim`/`ltrim`/`rtrim`, arithmetic in `SELECT` projections, `RETURNING` on
+  `UPDATE`/`DELETE`, `FOR UPDATE`. Drop to `RawExpression` or `execute(...)` for those.

--- a/docs/adr/0002-no-ilike-explicit-lower.md
+++ b/docs/adr/0002-no-ilike-explicit-lower.md
@@ -1,0 +1,82 @@
+# ADR 0002 — No `ilike`; case-insensitive matching is explicit via `lower()`
+
+- Status: Accepted
+- Date: 2026-06-30
+
+## Context
+
+Users need case-insensitive string matching. The obvious SQL spelling is PostgreSQL's `ILIKE`
+operator — but it does not exist in MySQL or SQLite, and case-insensitivity is not a uniform
+concept across the engines Kormium supports:
+
+- **PostgreSQL** — `LIKE`/`=`/`<` are case-sensitive; `ILIKE` is a Postgres-only operator.
+- **MySQL / MariaDB** — no `ILIKE`; the case behavior of `LIKE`/`=` depends on the column
+  **collation**, and the default collations (`utf8mb4_..._ci`) are case-insensitive.
+- **SQLite** — no `ILIKE`; `LIKE` is case-insensitive for ASCII by default, case-sensitive
+  beyond it.
+
+So the *same* typed query — `Users.name eq "Ada"` — already returns different rows on different
+engines (matches `"ada"` under a MySQL `_ci` collation, not under PostgreSQL/SQLite). String
+comparison semantics are delegated to the engine's collation, which Kormium does not model.
+
+Before this change the typed DSL had no scalar functions at all, so a user could not even write
+`LOWER(col)` — case-insensitive matching meant dropping to `RawExpression`, losing parameter
+binding and type-safety.
+
+## Decision
+
+Do **not** add an `ilike` predicate. Instead:
+
+1. Expose `lower()` (and `upper()`/`trim()`/`ltrim()`/`rtrim()`) as **explicit, composable
+   scalar functions** returning a typed `StringExpr`.
+2. Keep `like` rendering native `LIKE` — its case behavior follows the engine collation, by
+   design, and is documented as such.
+3. Case-insensitive matching is written explicitly, lowering **both sides** where the reader can
+   see it: `Users.name.lower() eq "ada"`, `a.lower() like b.lower()`.
+
+`LOWER`/`UPPER`/`TRIM`/`LTRIM`/`RTRIM` are standard SQL and render identically on
+PostgreSQL/MySQL/SQLite, so this needs no dialect hook.
+
+## Consequences
+
+Positive:
+
+- **No hidden magic.** What runs is what the code says. There is no operator that silently
+  normalizes case, and — importantly — none that silently changes which index the query can use
+  (an `ILIKE` or an injected `LOWER` defeats a plain b-tree index; making that explicit keeps the
+  index trade-off visible to the author).
+- **Deterministic across engines.** `lower()` on both sides settles the case dimension uniformly,
+  independent of the engine's default collation.
+- **A general primitive, not a one-off.** `lower()` composes (`name.trim().lower()`), works in
+  `select(...)` projections, and is reusable in `eq`/comparison — far more than a single `ilike`
+  predicate would be. It is the first of the DSL's scalar functions.
+
+Negative / costs:
+
+- More verbose at the call site than `name ilike "a%"`, and the author must remember to lower
+  **both** sides (a one-sided `lower(name) like "A%"` simply matches nothing — visibly).
+- No terse `ILIKE`-shaped spelling that an LLM or a Postgres user reaches for by reflex; the
+  collation note and `AGENTS.md` steer them to `lower()`.
+
+## Alternatives considered
+
+- **Native `ILIKE` on PostgreSQL via a dialect hook, `LOWER(...) LIKE LOWER(...)` elsewhere.**
+  Rejected: it reintroduces cross-engine divergence (ILIKE's case-folding and `LOWER()` can
+  differ on non-ASCII), and `LOWER(col)` actually indexes *better* for prefix search (a plain
+  expression b-tree index, which `ILIKE` cannot use without a trigram GIN index). The supposed
+  performance win for native `ILIKE` exists only on unindexed sequential scans.
+- **An `ilike` predicate that desugars to `LOWER(lhs) LIKE LOWER(rhs)` everywhere.** Rejected
+  once `lower()` exists: it would be a black box hiding the same SQL the user could write
+  explicitly, and would hide the index implication — the opposite of the project's
+  explicit-over-magic stance.
+- **Make plain `like`/`eq` deterministically case-sensitive on every engine.** Deferred, not
+  rejected outright: there is no clean per-query way on SQLite (only a connection-global
+  `PRAGMA case_sensitive_like`, which would also affect users' raw SQL), and MySQL's `LIKE BINARY`
+  over-reaches into accent/byte sensitivity and hurts index usage. A separate decision.
+
+## Notes
+
+`length()` was also deferred from the first scalar-function batch: it returns `Int` (a different
+type lane) and is non-portable without a dialect hook (MySQL `LENGTH` counts bytes; character
+length needs `CHAR_LENGTH`, absent in SQLite). Ordering by an expression (`ORDER BY lower(name)`)
+remains unsupported, so case-insensitive keyset pagination is not yet fully expressible.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,3 +5,4 @@ and its consequences. One file per decision, numbered and append-only — supers
 rewrite.
 
 - [0001 — Concrete dialects live in standalone modules](0001-standalone-dialect-modules.md)
+- [0002 — No `ilike`; case-insensitive matching is explicit via `lower()`](0002-no-ilike-explicit-lower.md)

--- a/docs/api-cookbook.md
+++ b/docs/api-cookbook.md
@@ -160,6 +160,43 @@ fun usersAfter(cursor: User?): List<User> = db.autocommit {
 
 Each `where { }` is ANDed with the others; multiple `orderBy` calls keep their order.
 
+## Case-Insensitive Match (instead of `ILIKE`)
+
+Kormium has no `ilike` operator. Plain `like` / `eq` follow the engine's **collation**, so their
+case behavior differs across PostgreSQL, MySQL and SQLite. For a result that is identical on every
+backend, lower **both sides** explicitly with the `lower()` scalar function:
+
+```kotlin
+// Case-insensitive equality — matches "Ada", "ADA", "ada" on every engine.
+val ada = db.autocommit {
+    Users.find { where { Users.name.lower() eq "ada" } }            // LOWER("name") = 'ada'
+}
+
+// Case-insensitive LIKE — the pattern is already lowercase, since the left side is lowered.
+val examples = db.autocommit {
+    Users.find { where { Users.email.lower() like "%@example.com" } }
+}
+```
+
+`lower()` chains, and the right side can be another lowered column:
+
+```kotlin
+Users.find { where { Users.name.trim().lower() eq "ada" } }
+Users.find { where { Users.name.lower() eq Users.email.lower() } }
+```
+
+`LOWER("name")` cannot use a plain index on `name`. If you match on it often, add a functional
+index so the lookup stays fast:
+
+```kotlin
+db.transaction {
+    executeUpdate("""CREATE INDEX IF NOT EXISTS users_name_lower_idx ON "users" (LOWER("name"))""")
+}
+```
+
+`lower()` settles only the case dimension; locale ordering and accents still follow the collation.
+See [ADR 0002](adr/0002-no-ilike-explicit-lower.md) for the full rationale.
+
 ## Count Rows
 
 ```kotlin

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -77,7 +77,8 @@ val lowered: List<String> = db.autocommit {
 > not inject a collation for you (that would be hidden, and would change which index the query
 > can use). For deterministic, case-insensitive matching, lower **both sides** explicitly:
 > `Users.name.lower() eq "ada"`. `lower()` settles the case dimension; locale ordering and
-> accents still follow the collation.
+> accents still follow the collation. For why Kormium has no `ilike` operator, see
+> [ADR 0002](adr/0002-no-ilike-explicit-lower.md).
 
 `LOWER(col)` cannot use a plain index on `col` — add a functional index on `LOWER(col)` if you
 match on it often.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -53,6 +53,35 @@ Users.find {
 An empty `inList` renders to `FALSE`, so it matches no rows instead of generating invalid
 SQL.
 
+## String Functions
+
+A `String` column exposes the scalar functions `lower()`, `upper()`, `trim()`, `ltrim()` and
+`rtrim()`. Each returns a `StringExpr` that chains and composes with the string predicates, and
+can also be read back from a `select(...)` projection:
+
+```kotlin
+Users.find { where { Users.name.lower() eq "ada" } }              // LOWER("name") = 'ada'
+Users.find { where { Users.name.trim().lower() eq "ada" } }       // chained
+Users.find { where { Users.name.lower() eq Users.handle.lower() } } // column-to-column
+Users.find { where { Users.sku.upper() gtEq "M000" } }            // lexicographic range
+
+val lowered: List<String> = db.autocommit {
+    val name = Users.name.lower()
+    Users.query().select(name).map { it[name] }
+}
+```
+
+> **Collation note.** A plain string comparison (`eq`, `like`, `<`, …) follows the **engine's
+> collation**, so its case- and accent-sensitivity differ across PostgreSQL, MySQL and SQLite —
+> the same `Users.name eq "Ada"` can match `"ada"` on one engine and not another. Kormium does
+> not inject a collation for you (that would be hidden, and would change which index the query
+> can use). For deterministic, case-insensitive matching, lower **both sides** explicitly:
+> `Users.name.lower() eq "ada"`. `lower()` settles the case dimension; locale ordering and
+> accents still follow the collation.
+
+`LOWER(col)` cannot use a plain index on `col` — add a functional index on `LOWER(col)` if you
+match on it often.
+
 ## Ordering, Limit and Offset
 
 ```kotlin
@@ -285,9 +314,11 @@ Not modeled by the typed DSL today:
   are available, and a table cannot be aliased to join it to itself.
 - **`DISTINCT ON`.** Only plain `DISTINCT` is supported.
 - **`EXISTS` / `NOT EXISTS`.**
-- **Pattern-match variants.** `like` only; no `ILIKE`, `SIMILAR TO`, or regex operators.
+- **Pattern-match variants.** `like` only; no `ILIKE` operator (lower both sides for a
+  case-insensitive match — see [String Functions](#string-functions)), `SIMILAR TO`, or regex.
 - **Computed expressions.** No arithmetic (`+`, `-`, `*`, `/`), string concatenation, `CASE`,
-  `COALESCE`, casts, or scalar functions in `SELECT`/`WHERE`/`HAVING`.
+  `COALESCE`, casts, or scalar functions other than the string functions `lower` / `upper` /
+  `trim` / `ltrim` / `rtrim` (see [String Functions](#string-functions)) in `SELECT`/`WHERE`/`HAVING`.
 - **Expression / aggregate ordering and null placement.** `ORDER BY` takes plain columns with
   `ASC` / `DESC` only — no ordering by an aggregate or expression, and no `NULLS FIRST` /
   `NULLS LAST`.

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -1,5 +1,7 @@
 package io.github.kormium
 
+import io.github.kormium.resultset.ResultSet
+
 /**
  * Collects bind values while an [Expression] or [Query] is rendered to SQL.
  * Instead of inlining values into the SQL string (which is open to SQL
@@ -259,6 +261,55 @@ infix fun <Z> NumericExpr<Z>.less(value: Z): Expression = LessOp(this, columnTyp
 infix fun <Z> NumericExpr<Z>.lessEq(value: Z): Expression = LessEqOp(this, columnType.lit(value))
 infix fun <Z> NumericExpr<Z>.gt(value: Z): Expression = GreaterOp(this, columnType.lit(value))
 infix fun <Z> NumericExpr<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, columnType.lit(value))
+
+/**
+ * A typed string-valued SQL expression. A string [Column] yields one via the scalar functions
+ * below (`lower()`, `upper()`, `trim()`, `ltrim()`, `rtrim()`), and each returns another
+ * [StringExpr], so they chain (`name.trim().lower()`). Being a [Selectable] it can also be read
+ * back from a row in `select(...)`. Compare it with `eq` / `neq` / `like` / `gt` / `gtEq` /
+ * `less` / `lessEq` against a `String` literal, or — through the generic expression operators —
+ * against another [StringExpr] (`a.lower() eq b.lower()`).
+ */
+interface StringExpr : Selectable<String>
+
+/**
+ * A scalar SQL function rendered as `FN(arg, ...)`. The string-returning ones are [StringExpr],
+ * so they compose with the string predicates and chain. The result key is structural (the
+ * function over its arguments' keys), so a projected function reads back with a fresh instance.
+ */
+class StringFunction(private val fn: String, private val args: List<Expression>) : StringExpr {
+    override fun toSql(builder: ParamBuilder): String = "$fn(${args.joinToString(", ") { it.toSql(builder) }})"
+    override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): String? = rs.getString(index)
+    override fun resultKey(): Any =
+        "$fn(${args.joinToString(", ") { ((it as? Selectable<*>)?.resultKey() ?: it).toString() }})"
+}
+
+// Scalar string functions, defined on both Column<String> and StringExpr so they chain like the
+// arithmetic operators do. LOWER/UPPER/TRIM/LTRIM/RTRIM are standard and render identically on
+// PostgreSQL, MySQL and SQLite, so no dialect hook is needed.
+fun Column<String, *, *>.lower(): StringExpr = StringFunction("LOWER", listOf(this))
+fun StringExpr.lower(): StringExpr = StringFunction("LOWER", listOf(this))
+fun Column<String, *, *>.upper(): StringExpr = StringFunction("UPPER", listOf(this))
+fun StringExpr.upper(): StringExpr = StringFunction("UPPER", listOf(this))
+fun Column<String, *, *>.trim(): StringExpr = StringFunction("TRIM", listOf(this))
+fun StringExpr.trim(): StringExpr = StringFunction("TRIM", listOf(this))
+fun Column<String, *, *>.ltrim(): StringExpr = StringFunction("LTRIM", listOf(this))
+fun StringExpr.ltrim(): StringExpr = StringFunction("LTRIM", listOf(this))
+fun Column<String, *, *>.rtrim(): StringExpr = StringFunction("RTRIM", listOf(this))
+fun StringExpr.rtrim(): StringExpr = StringFunction("RTRIM", listOf(this))
+
+// Comparing a StringExpr to a String literal. (StringExpr-to-StringExpr comparison already works
+// through the generic `Expression` operators above.) `like` has no generic form, so both its
+// literal and StringExpr forms are provided here. Note: a bare string comparison follows the
+// engine's collation (see docs) — wrap both sides in `lower()` for deterministic case folding.
+infix fun StringExpr.like(pattern: String): Expression = LikeOp(this, Value(pattern))
+infix fun StringExpr.like(other: StringExpr): Expression = LikeOp(this, other)
+infix fun StringExpr.eq(value: String): Expression = EqOp(this, Value(value))
+infix fun StringExpr.neq(value: String): Expression = NeqOp(this, Value(value))
+infix fun StringExpr.less(value: String): Expression = LessOp(this, Value(value))
+infix fun StringExpr.lessEq(value: String): Expression = LessEqOp(this, Value(value))
+infix fun StringExpr.gt(value: String): Expression = GreaterOp(this, Value(value))
+infix fun StringExpr.gtEq(value: String): Expression = GreaterEqOp(this, Value(value))
 
 /** Groups an expression in parentheses so it composes safely with surrounding `AND`/`OR`. */
 class ParenExpression(private val expr: Expression) : Expression {

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -18,7 +18,12 @@ import io.github.kormium.gtEq
 import io.github.kormium.inList
 import io.github.kormium.innerJoin
 import io.github.kormium.leftJoin
+import io.github.kormium.lower
+import io.github.kormium.ltrim
 import io.github.kormium.not
+import io.github.kormium.rtrim
+import io.github.kormium.trim
+import io.github.kormium.upper
 import io.github.kormium.query
 import io.github.kormium.sum
 import io.github.kormium.transaction
@@ -494,6 +499,51 @@ class SqliteIntegrationTest {
             Authors.deleteWhere(Query(Authors.id eq authorId))
         }
     }
+
+    /**
+     * String scalar functions: `lower`/`upper`/`trim`/`ltrim`/`rtrim` compose and chain, match a
+     * literal or another column (case-insensitively when both sides are lowered), order with the
+     * comparison operators, and read back from a projection with a fresh instance.
+     */
+    @Test
+    fun testStringScalarFunctions() {
+        val l1 = Uuid.random(); val l2 = Uuid.random(); val l3 = Uuid.random(); val l4 = Uuid.random()
+        db.transaction {
+            Labels.execSql(labelsDdl)
+            Labels.insertAll(listOf(
+                Label().apply { id = l1; a = "Ada"; b = "ada" },
+                Label().apply { id = l2; a = "BOB"; b = "bob" },
+                Label().apply { id = l3; a = "  cara  "; b = "cara" },
+                Label().apply { id = l4; a = "Zoe"; b = "different" },
+            ))
+        }
+
+        // Column-to-column, both lowered: Ada/ada and BOB/bob match; "  cara  " != "cara".
+        val ci = db.autocommit { Labels.find { where { Labels.a.lower() eq Labels.b.lower() } } }
+        assertEquals(listOf(l1, l2).sorted(), ci.map { it.id }.sorted())
+
+        // trim() makes "  cara  " line up with "cara".
+        val trimmed = db.autocommit { Labels.find { where { Labels.a.trim().lower() eq Labels.b.lower() } } }
+        assertEquals(listOf(l1, l2, l3).sorted(), trimmed.map { it.id }.sorted())
+
+        // lower()/upper() vs a literal.
+        assertEquals(l1, db.autocommit { Labels.find { where { Labels.a.lower() eq "ada" } } }.single().id)
+        assertEquals(l2, db.autocommit { Labels.find { where { Labels.a.upper() eq "BOB" } } }.single().id)
+
+        // ltrim()+rtrim() chained strip both ends.
+        assertEquals(l3, db.autocommit { Labels.find { where { Labels.a.ltrim().rtrim().lower() eq "cara" } } }.single().id)
+
+        // Lexicographic comparison: only "ZOE" >= "M".
+        assertEquals(l4, db.autocommit { Labels.find { where { Labels.a.upper() gtEq "M" } } }.single().id)
+
+        // Read a function projection back — with a freshly built instance (structural result key).
+        val lowered = db.autocommit {
+            Labels.query().where(Labels.id eq l1).select(Labels.a.lower()).single()[Labels.a.lower()]
+        }
+        assertEquals("ada", lowered)
+
+        db.transaction { Labels.deleteWhere(Query(Labels.id inList listOf(l1, l2, l3, l4))) }
+    }
 }
 
 object SqCatalog : Catalog
@@ -558,6 +608,20 @@ object Reviews : Table<SqCatalog, Review>("reviews", ::Review) {
     init { id; bookId; stars }
 }
 
+class Label : Entity() {
+    var id by Labels.id
+    var a by Labels.a
+    var b by Labels.b
+}
+
+object Labels : Table<SqCatalog, Label>("labels", ::Label) {
+    val id by Column.UUID().primaryKey()
+    val a by Column.Text()
+    val b by Column.Text()
+
+    init { id; a; b }
+}
+
 class AllTypesEntity : Entity() {
     var id by AllTypes.id
     var anInt by AllTypes.anInt
@@ -603,4 +667,5 @@ internal val productsDdl = """CREATE TABLE IF NOT EXISTS "products" ("id" TEXT N
 internal val authorsDdl = """CREATE TABLE IF NOT EXISTS "authors" ("id" TEXT NOT NULL, "name" TEXT NOT NULL, PRIMARY KEY ("id"))"""
 internal val booksDdl = """CREATE TABLE IF NOT EXISTS "books" ("id" TEXT NOT NULL, "authorId" TEXT NOT NULL, "title" TEXT NOT NULL, PRIMARY KEY ("id"))"""
 internal val reviewsDdl = """CREATE TABLE IF NOT EXISTS "reviews" ("id" TEXT NOT NULL, "bookId" TEXT NOT NULL, "stars" INTEGER NOT NULL, PRIMARY KEY ("id"))"""
+internal val labelsDdl = """CREATE TABLE IF NOT EXISTS "labels" ("id" TEXT NOT NULL, "a" TEXT NOT NULL, "b" TEXT NOT NULL, PRIMARY KEY ("id"))"""
 internal val allTypesDdl = """CREATE TABLE IF NOT EXISTS "all_types" ("id" TEXT NOT NULL, "anInt" INTEGER NOT NULL, "aDouble" REAL NOT NULL, "aBool" INTEGER NOT NULL, "aText" TEXT NOT NULL, "aDecimal" TEXT NOT NULL, "anInstant" TEXT NOT NULL, "aJson" TEXT NOT NULL, "aLong" INTEGER NOT NULL, "aFloat" REAL NOT NULL, "aShort" INTEGER NOT NULL, "aDate" TEXT NOT NULL, "aTime" TEXT NOT NULL, "aDateTime" TEXT NOT NULL, PRIMARY KEY ("id"))"""


### PR DESCRIPTION
## Why

Case-insensitive matching was a DSL wall — you couldn't even write `LOWER(col)` in the typed DSL, only drop to `RawExpression` (losing parameterization and type-safety). And plain string comparison is silently **non-portable**: `Users.name eq "Ada"` matches `"ada"` under MySQL's default `_ci` collation but not under PostgreSQL/SQLite. This gives an explicit, visible tool instead of magic.

## What

- New `StringExpr : Selectable<String>` (mirrors `NumericExpr<Z>`), plus scalar functions on **both** `Column<String>` and `StringExpr` so they chain: `lower()`, `upper()`, `trim()`, `ltrim()`, `rtrim()`.
- A general `StringFunction(fn, args)` node — renders `FN(args)`, structural result key (so a projected function reads back with a fresh instance).
- `StringExpr` composes with the predicates: `like` (literal **and** `StringExpr`), `eq`/`neq`/`gt`/`gtEq`/`less`/`lessEq` (literal). `StringExpr`-to-`StringExpr` comparison already works via the generic expression operators.

```kotlin
where { Users.name.lower() eq "ada" }                 // LOWER("name") = 'ada'
where { Users.name.trim().lower() eq "ada" }          // chained
where { Users.name.lower() eq Users.handle.lower() }  // column-to-column, case-insensitive
where { Users.sku.upper() gtEq "M000" }               // lexicographic range
select(Users.name.lower())                            // read back
```

`LOWER/UPPER/TRIM/LTRIM/RTRIM` are standard SQL and render identically on PostgreSQL/MySQL/SQLite — **no dialect hook**.

## Deliberately no `ilike`

Plain string comparison follows the engine **collation** (case/accent-sensitivity differs per backend). Rather than hide that behind a magic `ilike` (which would also silently change which index the query can use), Kormium keeps `like` native and lets you settle the case dimension explicitly and visibly with `lower()` on both sides. Documented as a collation note in `docs/queries.md` and `AGENTS.md`. `like` is unchanged.

## Tests

`SqliteIntegrationTest.testStringScalarFunctions`: chaining, column-to-column case-insensitive match, `trim`, literal compare, lexicographic ordering, and reading a function projection back with a fresh instance. `:kormium-sqlite:jvmTest` + `:kormium-core:jvmTest` green locally.

Purely additive — no existing signature changes. Part of the DSL-coverage track (after `between`, #92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)