### PR TITLE
feat: renderSql — render a query's SQL without a connection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,19 @@ val db: Database<App> = createDatabase(
 // Async MySQL (kormium-r2dbc):       createMySqlR2dbcDatabase(...)
 ```
 
+## Inspect the SQL without running it
+
+`renderSql { }` returns the SQL a query would run (string + bound params) with no connection — the
+block reads like a `transaction { }` body but each operation returns a `RenderedSql`. Use it to
+self-check a query before executing.
+
+```kotlin
+val r = renderSql(App, PostgresDialect) { Users.find { where { Users.age gtEq 18 } } }
+r.sql     // SELECT "id", ... FROM "users" WHERE "age" >= :p0 ...
+r.params  // {p0=18}
+db.renderSql { Users.count { where { Users.age gtEq 18 } } }   // uses the db's own dialect
+```
+
 ## Read — the canonical single-table form
 
 ```kotlin

--- a/docs/adr/0003-public-dialect-on-database.md
+++ b/docs/adr/0003-public-dialect-on-database.md
@@ -1,0 +1,81 @@
+# ADR 0003 — `dialect` is a public member of `Database` / `SuspendDatabase`
+
+- Status: Accepted
+- Date: 2026-06-30
+
+## Context
+
+The SQL [Dialect] (placeholder style, identifier quoting, LIMIT/OFFSET, upsert tail, …) was a
+private detail of each backend driver: drivers held it as `private val dialect` and wired it into
+the executor that renders SQL. It was private for three reasons, all correct at the time:
+
+1. **Minimal SPI surface.** `Database` is the extension point backends implement; it exposed only
+   what a *consumer* needs (`config`, `writeListeners`, `usePinned`, `close`). The fewer required
+   members, the easier a new driver is to write.
+2. **No consumer use case.** A user never renders SQL themselves — the DSL + scope + executor do it
+   internally. There was nothing the dialect needed to be exposed *for*.
+3. **Consistency with [ADR 0001].** Concrete dialects are pluggable internals wired into drivers;
+   core knows only the `Dialect` abstraction.
+
+[renderSql] (rendering a query to its SQL without a connection) is the first feature that needs the
+dialect from the outside — both the offline `renderSql(catalog, dialect) { }` and the convenience
+`Database.renderSql { }`, which should preview SQL for *that* backend.
+
+## Decision
+
+Make `val dialect: Dialect` a public member of both `Database` and `SuspendDatabase`, with a neutral
+`StandardDialect` default (mirroring how `config` / `writeListeners` are defaulted members), and
+override it in the shipped drivers with their concrete dialect. The driver *interfaces*
+(`SqliteDriver` / `PostgresDriver` / `MySqlDriver`), which extend both `Database` and
+`SuspendDatabase`, re-declare `override val dialect` to resolve the inherited-default diamond — as
+they already do for `config` / `writeListeners` / `isClosed`.
+
+Only the **dialect** is exposed. The rendered SQL string depends on the dialect (and the value
+types), not on the `TypeMapper` — in `ParamBuilder.bind`, the type mapper only converts the stored
+parameter value, while `renderBind` sees the original value. So `typeMapper` stays internal, and
+`renderSql` uses `StandardTypeMapper` for the displayed parameter values.
+
+Being pre-1.0 is what makes this the right time: there are no released consumers, and the only
+out-of-tree implementor (the `kormium/pglite` engine) is also pre-release and in the same org.
+
+## Consequences
+
+Positive:
+
+- Enables `renderSql` / `db.renderSql`, and gives future tooling (query `explain`, an MCP server,
+  debugging) a first-class way to ask "what dialect does this database speak".
+- Formalizes something every SQL backend already has; it is a stable, static, cheap property.
+- Per-table `*Sql` builders and `buildSelect` became `internal` (from `private`) so the render scope
+  reuses the **exact** statement builders execution uses — the preview cannot drift from reality.
+
+Negative / costs:
+
+- It widens the `Database` / `SuspendDatabase` SPI: a custom implementation that already had a
+  member named `dialect` must now `override` it, and one that implements both interfaces must
+  resolve the diamond. For shipped drivers this is a one-line change; the out-of-tree pglite engine
+  adapts on its next update.
+- `db.renderSql` is offered only on `Database<G>` (not `SuspendDatabase<G>`) to avoid an overload
+  ambiguity on drivers that implement both. A suspend-only backend (r2dbc) renders with the offline
+  form, passing `db.dialect`: `renderSql(App, db.dialect) { ... }`.
+
+## Alternatives considered
+
+- **Keep `dialect` private; open a connection in `db.renderSql` to read it off the executor.**
+  Rejected: opening a real (network) connection just to *render* SQL contradicts the feature, and
+  fails when the database is unreachable.
+- **A `HasDialect` marker interface drivers opt into.** Rejected: a dialect is universal to every
+  SQL backend, so it belongs on the base interface, not an optional capability — and pre-1.0 makes
+  the direct member clean rather than a compatibility workaround.
+- **Ship only the offline `renderSql(dialect) { }`, no `db.renderSql`.** Considered while the change
+  looked like a broad SPI break; reconsidered once pre-1.0 and the dialect-only scope made exposing
+  it clean.
+
+## Notes
+
+The web engines' database classes (`SqliteWasmDatabase`, `PgDatabase`, `MySqlDatabase`) implement
+only `SuspendDatabase`, so they compile unchanged on the `StandardDialect` default; overriding them
+with their real dialect (so `db.dialect` is exact on the web stack) is a small follow-up.
+
+[Dialect]: ../design.md
+[ADR 0001]: 0001-standalone-dialect-modules.md
+[renderSql]: ../api-cookbook.md

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,3 +6,4 @@ rewrite.
 
 - [0001 — Concrete dialects live in standalone modules](0001-standalone-dialect-modules.md)
 - [0002 — No `ilike`; case-insensitive matching is explicit via `lower()`](0002-no-ilike-explicit-lower.md)
+- [0003 — `dialect` is a public member of `Database` / `SuspendDatabase`](0003-public-dialect-on-database.md)

--- a/docs/api-cookbook.md
+++ b/docs/api-cookbook.md
@@ -197,6 +197,31 @@ db.transaction {
 `lower()` settles only the case dimension; locale ordering and accents still follow the collation.
 See [ADR 0002](adr/0002-no-ilike-explicit-lower.md) for the full rationale.
 
+## Render a Query's SQL Without Running It
+
+`renderSql { }` produces the SQL a query *would* run — as a string plus its bound parameters —
+without a connection. The block reads exactly like a `transaction { }` / `autocommit { }` body,
+but each operation returns its `RenderedSql` instead of executing. Useful to inspect, log, or
+have a coding agent self-check a query before it runs.
+
+```kotlin
+import io.github.kormium.renderSql
+
+// Offline: pass the Catalog (for the type tag) and a dialect.
+val r = renderSql(App, PostgresDialect) {
+    Users.find { where { Users.age gtEq 18 } }
+}
+println(r.sql)     //  SELECT "id", "name", "age" FROM "users" WHERE "age" >= :p0 ...
+println(r.params)  //  {p0=18}
+
+// Against a live database, using its own dialect:
+val r2 = db.renderSql { Users.deleteWhere { where { Users.deletedAt neq null } } }
+```
+
+Reads, writes and joins all render. A batch `insertAll` may split into several statements, so it
+returns a `List<RenderedSql>`. For a suspend-only backend (r2dbc), pass its dialect to the offline
+form: `renderSql(App, db.dialect) { ... }`.
+
 ## Count Rows
 
 ```kotlin

--- a/kormium-core/src/commonMain/kotlin/Join.kt
+++ b/kormium-core/src/commonMain/kotlin/Join.kt
@@ -204,7 +204,7 @@ internal fun Join<*>.allColumns(): List<Column<*, *, *>> =
 
 // Builds the SELECT SQL + params (columns are emitted qualified, e.g. "users"."id",
 // so colliding names don't clash). Pure — no I/O; the runners below execute it.
-private fun buildSelect(
+internal fun buildSelect(
     join: Join<*>,
     fields: List<Selectable<*>>,
     dialect: Dialect,

--- a/kormium-core/src/commonMain/kotlin/RenderSql.kt
+++ b/kormium-core/src/commonMain/kotlin/RenderSql.kt
@@ -1,0 +1,102 @@
+package io.github.kormium
+
+import io.github.kormium.database.Database
+
+/**
+ * The SQL a query would run, as a string plus its bound parameters — produced by [renderSql]
+ * without touching a database. The parameter values are neutral representations (the SQL string
+ * is faithful to the dialect; only the displayed values go through [StandardTypeMapper]).
+ */
+class RenderedSql(val sql: String, val params: Map<String, Any?>) {
+    internal constructor(rendered: Pair<String, Map<String, Any?>>) : this(rendered.first, rendered.second)
+
+    override fun toString(): String = if (params.isEmpty()) sql else "$sql\nparams: $params"
+}
+
+/**
+ * Renders queries to their [RenderedSql] without a connection. It mirrors [Scope]'s operation
+ * surface, but every operation returns the SQL it *would* run instead of executing it — the same
+ * call-site syntax (`Users.find { where { } }`), a different return type. Obtain one via the
+ * top-level [renderSql] (offline, explicit dialect) or [Database.renderSql] (the backend's dialect).
+ */
+class RenderScope<G : Catalog> internal constructor(val dialect: Dialect, val typeMapper: TypeMapper) {
+
+    // ---- reads ----
+    fun <T : Entity> Table<G, T>.find(query: Query): RenderedSql = RenderedSql(selectSql(query, dialect, typeMapper))
+    fun <T : Entity> Table<G, T>.find(block: QueryBuilder.() -> Unit): RenderedSql = find(QueryBuilder().apply(block).build())
+    fun <T : Entity> Table<G, T>.findById(id: Any): RenderedSql = RenderedSql(selectByIdSql(id, dialect, typeMapper))
+    fun <T : Entity> Table<G, T>.all(): RenderedSql = RenderedSql(selectAllSql(dialect) to emptyMap())
+    fun <T : Entity> Table<G, T>.count(query: Query = Query()): RenderedSql = RenderedSql(countSql(query, dialect, typeMapper))
+    fun <T : Entity> Table<G, T>.count(block: QueryBuilder.() -> Unit): RenderedSql = count(QueryBuilder().apply(block).build())
+
+    // ---- writes ----
+    fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): RenderedSql =
+        RenderedSql(insertSql(entity, dialect, typeMapper, returning))
+
+    /** A batch insert may split into several statements (per [BatchInsertMode]), so this returns one [RenderedSql] each. */
+    fun <T : Entity> Table<G, T>.insertAll(
+        entities: List<T>,
+        returning: Boolean = false,
+        batchInsertMode: BatchInsertMode = BatchInsertMode.GroupByAssignedFields,
+    ): List<RenderedSql> =
+        buildBatchStatements(entities, batchInsertMode, dialect, typeMapper, returning).map { RenderedSql(it.sql, it.params) }
+
+    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, T>, update: T, returning: Boolean = false): RenderedSql =
+        upsert(entity, listOf(onConflict), update, returning)
+
+    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, T>>, update: T, returning: Boolean = false): RenderedSql =
+        RenderedSql(upsertSql(entity, onConflict, update, dialect, typeMapper, returning))
+
+    fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: Column<*, *, T>): RenderedSql =
+        insertOrIgnore(entity, listOf(onConflict))
+
+    fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: List<Column<*, *, T>>): RenderedSql =
+        RenderedSql(insertOrIgnoreSql(entity, onConflict, dialect, typeMapper))
+
+    fun <T : Entity> Table<G, T>.update(query: Query, entity: T): RenderedSql =
+        RenderedSql(updateSql(query, entity, dialect, typeMapper))
+
+    fun <T : Entity> Table<G, T>.update(entity: T, block: QueryBuilder.() -> Unit): RenderedSql =
+        update(QueryBuilder().apply(block).build(), entity)
+
+    fun <T : Entity> Table<G, T>.update(block: UpdateBuilder.() -> Unit): RenderedSql {
+        val builder = UpdateBuilder().apply(block)
+        return RenderedSql(updateSql(builder.buildWhere(), builder.buildAssignments(), dialect, typeMapper))
+    }
+
+    fun <T : Entity> Table<G, T>.deleteWhere(query: Query): RenderedSql = RenderedSql(deleteSql(query, dialect, typeMapper))
+    fun <T : Entity> Table<G, T>.deleteWhere(block: QueryBuilder.() -> Unit): RenderedSql =
+        deleteWhere(QueryBuilder().apply(block).build())
+
+    // ---- joins (SQL-producing form only; result-mapping variants render the same SQL) ----
+    fun Join<G>.select(vararg fields: Selectable<*>): RenderedSql =
+        RenderedSql(buildSelect(this, if (fields.isEmpty()) allColumns() else fields.toList(), dialect, typeMapper))
+
+    fun <A : Entity, B : Entity> JoinPair<G, A, B>.select(vararg fields: Selectable<*>): RenderedSql = asJoin().select(*fields)
+    fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>): RenderedSql = asJoin().select(*fields)
+}
+
+/**
+ * Renders queries to their SQL without a connection, for the given [dialect]. The [block] reads
+ * exactly like a `transaction { }` / `autocommit { }` body, but each operation returns its
+ * [RenderedSql] instead of running:
+ *
+ * ```kotlin
+ * val r = renderSql(App, PostgresDialect) { Users.find { where { Users.age gtEq 18 } } }
+ * println(r.sql)     // SELECT ... FROM "users" WHERE "age" >= :p0 ...
+ * println(r.params)  // {p0=18}
+ * ```
+ *
+ * [catalog] is the [Catalog] object (`App`) — passed so the catalog tag [G] is inferred, the same
+ * tag a `Database<App>` pins; it is not otherwise used.
+ */
+fun <G : Catalog, R> renderSql(
+    catalog: G,
+    dialect: Dialect = StandardDialect,
+    typeMapper: TypeMapper = StandardTypeMapper,
+    block: RenderScope<G>.() -> R,
+): R = RenderScope<G>(dialect, typeMapper).block()
+
+/** Renders queries using this database's own [Dialect], so the preview matches the real backend. */
+fun <G : Catalog, R> Database<G>.renderSql(block: RenderScope<G>.() -> R): R =
+    RenderScope<G>(dialect, StandardTypeMapper).block()

--- a/kormium-core/src/commonMain/kotlin/Table.kt
+++ b/kormium-core/src/commonMain/kotlin/Table.kt
@@ -114,7 +114,7 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
 
     // ---- pure SQL builders (no I/O) — shared by the blocking and suspend runners ----
 
-    private fun selectByIdSql(id: Any, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
+    internal fun selectByIdSql(id: Any, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
         val pk = primaryKey.singleOrNull()
             ?: throw IllegalStateException(
                 "findById requires a single-column primary key on $tableName; " +
@@ -146,17 +146,17 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         return sql.trimIndent() to builder.params
     }
 
-    private fun selectSql(query: Query, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
+    internal fun selectSql(query: Query, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
         val builder = paramBuilder(dialect, typeMapper)
         val queryStr = query.toSql(builder)
         val sql = "SELECT ${getColumnNames(dialect).joinToString(", ")} FROM ${qualifiedTableName(dialect)} $queryStr"
         return sql.trimIndent() to builder.params
     }
 
-    private fun selectAllSql(dialect: Dialect): String =
+    internal fun selectAllSql(dialect: Dialect): String =
         "SELECT ${getColumnNames(dialect).joinToString(", ")} FROM ${qualifiedTableName(dialect)}".trimIndent()
 
-    private fun insertSql(entity: T, dialect: Dialect, typeMapper: TypeMapper, returning: Boolean): Pair<String, Map<String, Any?>> {
+    internal fun insertSql(entity: T, dialect: Dialect, typeMapper: TypeMapper, returning: Boolean): Pair<String, Map<String, Any?>> {
         val builder = paramBuilder(dialect, typeMapper)
         // Only the present fields go into the INSERT: an absent field is omitted (so the
         // database can apply its default / generated value), an explicit null is bound as NULL.
@@ -204,9 +204,9 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
 
     // One executable statement of a batch: SQL, its params, and the original input indices it
     // covers (so RETURNING results can be scattered back into input order).
-    private class BatchStatement(val sql: String, val params: Map<String, Any?>, val indices: List<Int>)
+    internal class BatchStatement(val sql: String, val params: Map<String, Any?>, val indices: List<Int>)
 
-    private fun buildBatchStatements(
+    internal fun buildBatchStatements(
         entities: List<T>,
         mode: BatchInsertMode,
         dialect: Dialect,
@@ -256,7 +256,7 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         }
     }
 
-    private fun upsertSql(
+    internal fun upsertSql(
         entity: T,
         conflict: List<Column<*, *, *>>,
         update: T,
@@ -280,7 +280,7 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         return sql to builder.params
     }
 
-    private fun insertOrIgnoreSql(
+    internal fun insertOrIgnoreSql(
         entity: T,
         conflict: List<Column<*, *, *>>,
         dialect: Dialect,
@@ -297,7 +297,7 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
             dialect.renderInsertOrIgnoreSuffix(conflictCols) to builder.params
     }
 
-    private fun countSql(query: Query, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
+    internal fun countSql(query: Query, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
         val builder = paramBuilder(dialect, typeMapper)
         // Count the rows matching the predicate only: ORDER BY / LIMIT / OFFSET must not apply
         // to an aggregate (an OFFSET would skip the single COUNT row and read as 0).
@@ -306,7 +306,7 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         return sql.trimIndent() to builder.params
     }
 
-    private fun updateSql(query: Query, entity: T, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
+    internal fun updateSql(query: Query, entity: T, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
         val builder = paramBuilder(dialect, typeMapper)
         val updateFields = generatePresentFields(entity)
         require(updateFields.isNotEmpty()) {
@@ -324,7 +324,7 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         return sql.trimIndent() to builder.params
     }
 
-    private fun updateSql(query: Query, assignments: Map<Column<*, *, *>, Expression>, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
+    internal fun updateSql(query: Query, assignments: Map<Column<*, *, *>, Expression>, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
         val builder = paramBuilder(dialect, typeMapper)
         // Order matters: render SET (collecting binds) before WHERE so placeholders are numbered
         // left-to-right as they appear in the statement.
@@ -341,7 +341,7 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         return sql.trimIndent() to builder.params
     }
 
-    private fun deleteSql(query: Query, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
+    internal fun deleteSql(query: Query, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
         val builder = paramBuilder(dialect, typeMapper)
         // WHERE only: a plain DELETE doesn't take ORDER BY / LIMIT / OFFSET (invalid in Postgres).
         val queryStr = query.toWhereSql(builder)

--- a/kormium-core/src/commonMain/kotlin/database/Database.kt
+++ b/kormium-core/src/commonMain/kotlin/database/Database.kt
@@ -1,8 +1,10 @@
 package io.github.kormium.database
 
 import io.github.kormium.Catalog
+import io.github.kormium.Dialect
 import io.github.kormium.KormiumConfig
 import io.github.kormium.SqlExecutor
+import io.github.kormium.StandardDialect
 import io.github.kormium.TransactionIsolation
 import io.github.kormium.WriteListeners
 
@@ -21,6 +23,14 @@ import io.github.kormium.WriteListeners
 interface Database<out G : Catalog> : AutoCloseable {
     /** Per-database configuration; defaults to [KormiumConfig] defaults unless a backend overrides it. */
     val config: KormiumConfig get() = KormiumConfig()
+
+    /**
+     * The SQL dialect this database renders to (placeholder style, identifier quoting, LIMIT/OFFSET,
+     * upsert tail, …). Backends override it with their concrete dialect; the neutral
+     * [StandardDialect] default keeps custom/test implementations compiling. Exposed so a query can
+     * be rendered to its SQL without a connection — see [io.github.kormium.renderSql].
+     */
+    val dialect: Dialect get() = StandardDialect
 
     /**
      * The write-notification registry for this database. The default [WriteListeners.Disabled]

--- a/kormium-core/src/commonMain/kotlin/database/SuspendDatabase.kt
+++ b/kormium-core/src/commonMain/kotlin/database/SuspendDatabase.kt
@@ -1,7 +1,9 @@
 package io.github.kormium.database
 
 import io.github.kormium.Catalog
+import io.github.kormium.Dialect
 import io.github.kormium.KormiumConfig
+import io.github.kormium.StandardDialect
 import io.github.kormium.SuspendSqlExecutor
 import io.github.kormium.TransactionIsolation
 import io.github.kormium.WriteListeners
@@ -17,6 +19,13 @@ import io.github.kormium.WriteListeners
 interface SuspendDatabase<out G : Catalog> : AutoCloseable {
     /** Per-database configuration; defaults to [KormiumConfig] defaults unless a backend overrides it. */
     val config: KormiumConfig get() = KormiumConfig()
+
+    /**
+     * The SQL dialect this database renders to. Backends override it with their concrete dialect;
+     * the neutral [StandardDialect] default keeps custom implementations compiling. Read it to render
+     * a query for this backend offline: `renderSql(App, db.dialect) { ... }`.
+     */
+    val dialect: Dialect get() = StandardDialect
 
     /**
      * The write-notification registry for this database. The default [WriteListeners.Disabled]

--- a/kormium-core/src/commonTest/kotlin/DatabaseMock.kt
+++ b/kormium-core/src/commonTest/kotlin/DatabaseMock.kt
@@ -15,6 +15,7 @@ class DatabaseMock: Database<Nothing>, SuspendDatabase<Nothing> {
     override var config = KormiumConfig()
     override val writeListeners = WriteListeners()
     override val isClosed: Boolean = false
+    override val dialect = StandardDialect
 
     var result: Any? = null
     var internalSql: String = ""

--- a/kormium-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/JdbcDatabase.kt
+++ b/kormium-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/JdbcDatabase.kt
@@ -52,7 +52,7 @@ open class JdbcDatabase(
     username: String? = null,
     password: String? = null,
     poolSize: Int,
-    private val dialect: Dialect,
+    override val dialect: Dialect,
     private val typeMapper: TypeMapper,
     private val wrap: ResultSetWrapper,
     private val translate: SqlExceptionTranslator = StandardSqlExceptionTranslator,

--- a/kormium-mysql/src/commonMain/kotlin/MySqlDriver.kt
+++ b/kormium-mysql/src/commonMain/kotlin/MySqlDriver.kt
@@ -20,4 +20,7 @@ interface MySqlDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoCloseab
 
     // Resolves the isClosed default inherited from both interfaces; concrete drivers track it.
     override val isClosed: Boolean
+
+    // Resolves the dialect default inherited from both interfaces; concrete drivers supply MySqlDialect.
+    override val dialect: Dialect
 }

--- a/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/MySqlNativeDriver.kt
+++ b/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/MySqlNativeDriver.kt
@@ -96,6 +96,7 @@ internal class MySqlNativeDriver(
     }
 
     override val writeListeners: WriteListeners = WriteListeners()
+    override val dialect = MySqlDialect
 
     // A MySQL connection handle is single-threaded: one command at a time. We keep a fixed pool and
     // hand each connection to exactly one caller at a time through a Channel that doubles as the

--- a/kormium-postgres/src/commonMain/kotlin/PostgresDriver.kt
+++ b/kormium-postgres/src/commonMain/kotlin/PostgresDriver.kt
@@ -21,4 +21,7 @@ interface PostgresDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoClos
 
     // Resolves the isClosed default inherited from both interfaces; concrete drivers track it.
     override val isClosed: Boolean
+
+    // Resolves the dialect default inherited from both interfaces; concrete drivers supply PostgresDialect.
+    override val dialect: Dialect
 }

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/PostgresDriver.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/PostgresDriver.kt
@@ -83,7 +83,7 @@ private class PostgresDriverImpl(
         require(poolSize >= 1) { "poolSize must be >= 1, was $poolSize" }
     }
 
-    private val dialect: Dialect = PostgresDialect
+    override val dialect: Dialect = PostgresDialect
     private val typeMapper: TypeMapper = StandardTypeMapper
     override val writeListeners: WriteListeners = WriteListeners()
 

--- a/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/R2dbcDatabase.kt
+++ b/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/R2dbcDatabase.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.withContext
  */
 class R2dbcDatabase internal constructor(
     private val pool: ConnectionPool,
-    private val dialect: Dialect,
+    override val dialect: Dialect,
     private val typeMapper: TypeMapper,
     // The driver's positional bind marker ($N for postgres, ? for mysql). Defaults to postgres so
     // existing call sites are unchanged.

--- a/kormium-sqlite/src/androidMain/kotlin/CreateSqliteDatabase.android.kt
+++ b/kormium-sqlite/src/androidMain/kotlin/CreateSqliteDatabase.android.kt
@@ -37,7 +37,7 @@ private class SqliteAndroidDriver(path: String, private val poolSize: Int, overr
         }
     }
 
-    private val dialect: Dialect = SqliteDialect
+    override val dialect: Dialect = SqliteDialect
     private val typeMapper: TypeMapper = StandardTypeMapper
     override val writeListeners: WriteListeners = WriteListeners()
 

--- a/kormium-sqlite/src/commonMain/kotlin/SqliteDriver.kt
+++ b/kormium-sqlite/src/commonMain/kotlin/SqliteDriver.kt
@@ -21,4 +21,7 @@ interface SqliteDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoClosea
 
     // Resolves the isClosed default inherited from both interfaces; concrete drivers track it.
     override val isClosed: Boolean
+
+    // Resolves the dialect default inherited from both interfaces; concrete drivers supply SqliteDialect.
+    override val dialect: Dialect
 }

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -25,12 +25,14 @@ import io.github.kormium.rtrim
 import io.github.kormium.trim
 import io.github.kormium.upper
 import io.github.kormium.query
+import io.github.kormium.renderSql
 import io.github.kormium.sum
 import io.github.kormium.transaction
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
 /**
@@ -543,6 +545,36 @@ class SqliteIntegrationTest {
         assertEquals("ada", lowered)
 
         db.transaction { Labels.deleteWhere(Query(Labels.id inList listOf(l1, l2, l3, l4))) }
+    }
+
+    /**
+     * `renderSql` produces the SQL a query would run, with its bound params, without a connection —
+     * for reads, writes and joins — and `db.renderSql` does the same using the database's dialect.
+     */
+    @Test
+    fun testRenderSqlWithoutExecuting() {
+        val id = Uuid.random()
+
+        // Offline render (no connection): the predicate value is bound, not inlined.
+        val find = renderSql(SqCatalog) { Products.find { where { Products.qty gtEq 10 } } }
+        assertTrue(find.sql.startsWith("SELECT"), find.sql)
+        assertTrue(find.sql.contains("WHERE"), find.sql)
+        assertEquals(listOf<Any?>(10), find.params.values.toList())
+
+        // Reads, writes and joins all render.
+        assertTrue(renderSql(SqCatalog) { Products.count { where { Products.qty gtEq 10 } } }.sql.trim().startsWith("SELECT COUNT(*)"))
+        assertTrue(renderSql(SqCatalog) { Products.update(Product().apply { qty = 1 }) { where { Products.id eq id } } }.sql.trim().startsWith("UPDATE"))
+        assertTrue(renderSql(SqCatalog) { Products.deleteWhere { where { Products.id eq id } } }.sql.trim().startsWith("DELETE"))
+        assertTrue(
+            renderSql(SqCatalog) {
+                (Authors innerJoin Books on (Authors.id eq Books.authorId)).select(Authors.name, Books.title)
+            }.sql.contains("INNER JOIN"),
+        )
+
+        // db.renderSql renders with the database's own dialect; same query → same SQL here.
+        val viaDb = db.renderSql { Products.find { where { Products.qty gtEq 10 } } }
+        assertEquals(find.sql, viaDb.sql)
+        assertEquals(find.params, viaDb.params)
     }
 }
 

--- a/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
+++ b/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
@@ -40,7 +40,7 @@ private class SqliteNativeDriver(path: String, private val poolSize: Int, overri
         require(poolSize >= 1) { "poolSize must be >= 1, was $poolSize" }
     }
 
-    private val dialect: Dialect = SqliteDialect
+    override val dialect: Dialect = SqliteDialect
     private val typeMapper: TypeMapper = StandardTypeMapper
     override val writeListeners: WriteListeners = WriteListeners()
 


### PR DESCRIPTION
## Why

Give an explicit way to see the SQL a query *would* run — to inspect, log, or have a coding agent self-check a query before executing it. First of the AI-tooling items, and a foundation for future `explain` / MCP tooling.

## What

A **render-scope** whose operations return the SQL they would run instead of executing — same call-site syntax as a `transaction { }` body, a different return type (the `Scope` vs `SuspendScope` pattern, a third sibling). No connection involved.

```kotlin
// Offline: the Catalog object drives the type tag, plus a dialect.
val r = renderSql(App, PostgresDialect) { Users.find { where { Users.age gtEq 18 } } }
r.sql     // SELECT "id", ... FROM "users" WHERE "age" >= :p0 ...
r.params  // {p0=18}

// Or against a live database, using its own dialect:
db.renderSql { Users.deleteWhere { where { Users.deletedAt neq null } } }
```

- Full coverage: `find`/`count`/`findById`/`all`, `insert`/`insertAll` (a batch may split → `List<RenderedSql>`)/`upsert`/`insertOrIgnore`, `update` (×3)/`deleteWhere`, join `select`.
- The render scope reuses the **exact** per-table `*Sql` builders and `buildSelect` execution uses (made `internal`), so the preview can't drift from what runs.

## SPI change — `dialect` is now public on `Database` / `SuspendDatabase`

To support `db.renderSql`, `val dialect` becomes a public member (neutral `StandardDialect` default, overridden by the shipped drivers). It was private because nothing consumed it before; `renderSql` is the first use case, and pre-1.0 is the right time. Only the dialect is exposed — the rendered SQL doesn't depend on the `TypeMapper`, so that stays internal. Recorded as **[ADR 0003](docs/adr/0003-public-dialect-on-database.md)**.

`db.renderSql` is offered on `Database<G>` only (avoids an overload ambiguity on drivers that implement both interfaces); suspend-only backends (r2dbc) use `renderSql(App, db.dialect) { }`.

## Verification

- **JVM green locally:** `:kormium-core:jvmTest` + `:kormium-sqlite:jvmTest` (incl. new `testRenderSqlWithoutExecuting`: reads, writes, join, offline + `db.renderSql`). All five `Database`+`SuspendDatabase` diamond implementors updated (drivers + `DatabaseMock`).
- **Native / wasm:** the driver overrides there are mechanical (`private val dialect` → `override`); verified by CI (not locally compilable here).
- **Follow-up:** the web-engine database classes (`SqliteWasmDatabase`, `PgDatabase`, `MySqlDatabase`) keep the `StandardDialect` default for now — overriding them with their real dialect (so `db.dialect` is exact on web) is a small follow-up, noted in ADR 0003.

Docs: cookbook recipe + `AGENTS.md` note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)