### PR TITLE
feat: COALESCE — null fallback as a typed, readable expression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,10 @@ Plain string comparison (`eq` / `like` / `<`) follows the **engine collation** �
 accent-sensitivity differ across PostgreSQL/MySQL/SQLite. Kormium does not inject a collation;
 for deterministic case-insensitive matching, lower **both sides**: `name.lower() eq "ada"`.
 
+Null fallback: `column.coalesce(default)` → `COALESCE("column", default)` — the value or the
+fallback when NULL. Readable in `select(...)` and comparable to a literal (`Users.rank.coalesce(0)
+gt 5`), or to another column (`a.coalesce(b)`). A non-null fallback makes the result non-null.
+
 For a reusable query, build a `Query` value instead of a block:
 `Users.find(Query(Users.age gtEq 18))`. Every `find` / `count` / `update` / `deleteWhere`
 accepts either form.
@@ -231,6 +235,6 @@ the `;` splitter can't handle, pass statements explicitly: `Migration("002", lis
 - Predicate names are `less` / `lessEq` (not `lt` / `ltEq`) and `neq` (not `ne`).
 - Read nullable join columns with `getOrNull`; `row[col]` throws on NULL/absent.
 - Not modeled by the typed DSL: subqueries, `UNION`, CTEs, window functions, `RIGHT`/`FULL`/
-  `CROSS`/self-joins, `ILIKE` operator (use `lower()`), regex, `CASE`/`COALESCE`, scalar functions
+  `CROSS`/self-joins, `ILIKE` operator (use `lower()`), regex, `CASE` (use `coalesce` for null fallback), scalar functions
   beyond `lower`/`upper`/`trim`/`ltrim`/`rtrim`, arithmetic in `SELECT` projections, `RETURNING` on
   `UPDATE`/`DELETE`, `FOR UPDATE`. Drop to `RawExpression` or `execute(...)` for those.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -83,6 +83,30 @@ val lowered: List<String> = db.autocommit {
 `LOWER(col)` cannot use a plain index on `col` — add a functional index on `LOWER(col)` if you
 match on it often.
 
+## Null Fallback (`COALESCE`)
+
+`column.coalesce(default)` renders `COALESCE("column", default)` — the column's value, or the
+fallback when it is `NULL`. It reads back from a `select(...)` projection and composes with the
+predicates, comparing a literal through the column's converter:
+
+```kotlin
+// Read a nullable column with a fallback (non-null, so row[...] is safe):
+val names: List<String> = db.autocommit {
+    val name = Users.nickname.coalesce("anonymous")
+    Users.query().select(name).map { it[name] }
+}
+
+// Treat a NULL as the fallback in a predicate:
+Users.find { where { Users.rank.coalesce(0) gt 5 } }   // COALESCE("rank", 0) > 5
+
+// First non-null of two columns:
+Users.find { where { Users.nickname.coalesce(Users.name) eq "Ada" } }
+```
+
+The default binds through the column's converter, so an enum/`Instant`/`BigDecimal` fallback maps
+the same way a comparison literal does. When the fallback is non-null the result is non-null —
+read it with `row[...]`; for a `coalesce` of two nullable columns, use `getOrNull`.
+
 ## Ordering, Limit and Offset
 
 ```kotlin
@@ -318,7 +342,7 @@ Not modeled by the typed DSL today:
 - **Pattern-match variants.** `like` only; no `ILIKE` operator (lower both sides for a
   case-insensitive match — see [String Functions](#string-functions)), `SIMILAR TO`, or regex.
 - **Computed expressions.** No arithmetic (`+`, `-`, `*`, `/`), string concatenation, `CASE`,
-  `COALESCE`, casts, or scalar functions other than the string functions `lower` / `upper` /
+  casts, or scalar functions other than the string functions `lower` / `upper` /
   `trim` / `ltrim` / `rtrim` (see [String Functions](#string-functions)) in `SELECT`/`WHERE`/`HAVING`.
 - **Expression / aggregate ordering and null placement.** `ORDER BY` takes plain columns with
   `ASC` / `DESC` only — no ordering by an aggregate or expression, and no `NULLS FIRST` /

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -311,6 +311,38 @@ infix fun StringExpr.lessEq(value: String): Expression = LessEqOp(this, Value(va
 infix fun StringExpr.gt(value: String): Expression = GreaterOp(this, Value(value))
 infix fun StringExpr.gtEq(value: String): Expression = GreaterEqOp(this, Value(value))
 
+/**
+ * `COALESCE(a, b, ...)` — the first non-null argument. It is a [Selectable] (readable from a
+ * `select(...)` projection) and carries the [columnType] of its source column, both to read the
+ * result back and to bind a compared literal through the right converter. Compare it with a typed
+ * literal via the operators below, or with another expression through the generic operators. The
+ * value is non-null when the last argument is (e.g. a literal default), so `row[...]` is safe then;
+ * otherwise read it with `getOrNull`.
+ */
+class CoalesceOp<Z> internal constructor(
+    private val args: List<Expression>,
+    internal val columnType: ColumnType<Z>,
+) : Selectable<Z> {
+    override fun toSql(builder: ParamBuilder): String = "COALESCE(${args.joinToString(", ") { it.toSql(builder) }})"
+    override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z? = columnType.read(rs, index)
+    override fun resultKey(): Any = "COALESCE(${args.joinToString(", ") { ((it as? Selectable<*>)?.resultKey() ?: it).toString() }})"
+}
+
+/** `COALESCE("col", default)` — read a nullable column with a fallback; the default binds through the column's converter. */
+fun <Z> Column<Z, *, *>.coalesce(default: Z): CoalesceOp<Z> = CoalesceOp(listOf(this, Value(bindParam(default))), columnType)
+
+/** `COALESCE("col", "other")` — the first non-null of two same-typed columns. */
+fun <Z> Column<Z, *, *>.coalesce(other: Column<Z, *, *>): CoalesceOp<Z> = CoalesceOp(listOf(this, other), columnType)
+
+// Comparing a COALESCE to a typed literal binds it through the source column's converter.
+// (COALESCE-to-expression comparison already works through the generic operators above.)
+infix fun <Z> CoalesceOp<Z>.eq(value: Z): Expression = EqOp(this, columnType.lit(value))
+infix fun <Z> CoalesceOp<Z>.neq(value: Z): Expression = NeqOp(this, columnType.lit(value))
+infix fun <Z> CoalesceOp<Z>.less(value: Z): Expression = LessOp(this, columnType.lit(value))
+infix fun <Z> CoalesceOp<Z>.lessEq(value: Z): Expression = LessEqOp(this, columnType.lit(value))
+infix fun <Z> CoalesceOp<Z>.gt(value: Z): Expression = GreaterOp(this, columnType.lit(value))
+infix fun <Z> CoalesceOp<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, columnType.lit(value))
+
 /** Groups an expression in parentheses so it composes safely with surrounding `AND`/`OR`. */
 class ParenExpression(private val expr: Expression) : Expression {
     override fun toSql(builder: ParamBuilder): String = "(${expr.toSql(builder)})"

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -9,11 +9,13 @@ import io.github.kormium.UniqueViolationException
 import io.github.kormium.and
 import io.github.kormium.autocommit
 import io.github.kormium.between
+import io.github.kormium.coalesce
 import io.github.kormium.count
 import io.github.kormium.createSqliteDatabase
 import io.github.kormium.database.Database
 import io.github.kormium.entity
 import io.github.kormium.eq
+import io.github.kormium.gt
 import io.github.kormium.gtEq
 import io.github.kormium.inList
 import io.github.kormium.innerJoin
@@ -545,6 +547,35 @@ class SqliteIntegrationTest {
         assertEquals("ada", lowered)
 
         db.transaction { Labels.deleteWhere(Query(Labels.id inList listOf(l1, l2, l3, l4))) }
+    }
+
+    /**
+     * `coalesce` fills a null column with a fallback — read back from a projection (the default
+     * makes it non-null) and used in a predicate (a null is treated as the fallback).
+     */
+    @Test
+    fun testCoalesce() {
+        val tag = "coalesce-${Uuid.random()}"
+        db.transaction {
+            Products.execSql(productsDdl)
+            Products.insert(Product().apply { id = Uuid.random(); price = BigDecimal.fromInt(1); qty = 1; displayName = tag; note = null; rank = null })
+            Products.insert(Product().apply { id = Uuid.random(); price = BigDecimal.fromInt(1); qty = 1; displayName = tag; note = "set"; rank = 7 })
+        }
+
+        // SELECT: the null note reads back as the fallback.
+        val notes = db.autocommit {
+            val n = Products.note.coalesce("none")
+            Products.query().where(Products.displayName eq tag).select(n).map { it[n] }.sorted()
+        }
+        assertEquals(listOf("none", "set"), notes)
+
+        // WHERE: a null rank coalesces to 0, so only the rank=7 row passes `> 5`.
+        val highRank = db.autocommit {
+            Products.find { where { (Products.displayName eq tag) and (Products.rank.coalesce(0) gt 5) } }
+        }
+        assertEquals(listOf(7), highRank.map { it.rank })
+
+        db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
     }
 
     /**


### PR DESCRIPTION
## Why

Filling a `NULL` with a fallback (`COALESCE`) was a DSL wall — you dropped to raw SQL. It's a high-frequency need (display defaults, treating a null as a value in a predicate), and the natural thing an agent writes. Part of the DSL-coverage track (A3); CASE is deferred to its own step.

## What

```kotlin
// SELECT: read a nullable column with a fallback (non-null → row[...] is safe)
val name = Users.nickname.coalesce("anonymous")
Users.query().select(name).map { it[name] }

// WHERE: a NULL is treated as the fallback
Users.find { where { Users.rank.coalesce(0) gt 5 } }     // COALESCE("rank", 0) > 5

// First non-null of two columns
Users.find { where { Users.nickname.coalesce(Users.name) eq "Ada" } }
```

- `Column<Z>.coalesce(default: Z)` and `Column<Z>.coalesce(other: Column<Z>)` → `CoalesceOp<Z>`.
- `CoalesceOp<Z>` is a `Selectable<Z>` carrying the **source column's `ColumnType`**, so it reads back through the right reader, and a compared literal binds through the column's converter (enum/`Instant`/`BigDecimal` map the same as a comparison literal). Structural result key, so a projection reads back with a fresh instance.
- Typed predicate overloads on `CoalesceOp`: `eq`/`neq`/`gt`/`gtEq`/`less`/`lessEq` against a literal; comparison to another expression already works via the generic operators.
- Standard SQL — renders identically on PostgreSQL/MySQL/SQLite, **no dialect hook**.

Nullability: a non-null fallback makes the result non-null (`row[...]`); a `coalesce` of two nullable columns stays nullable (`getOrNull`).

## Why not CASE in this PR

`CASE` with literal results gives no `ColumnType` to read the result by (and `Z` is erased), so `CASE` in `select(...)` can't pick a reader — that typing deserves its own design round (anchor-by-operand vs explicit type). Tracked separately. COALESCE always has a column operand, so it types cleanly.

## Tests

`SqliteIntegrationTest.testCoalesce` — read-back with fallback + a predicate treating `NULL` as the fallback. `:kormium-sqlite:jvmTest` + `:kormium-core:jvmTest` green locally. Docs: `docs/queries.md` (new section, removed from "Unsupported") + `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)