### PR TITLE
feat: searched CASE — conditional values, type inferred for built-ins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,10 @@ Null fallback: `column.coalesce(default)` → `COALESCE("column", default)` — 
 fallback when NULL. Readable in `select(...)` and comparable to a literal (`Users.rank.coalesce(0)
 gt 5`), or to another column (`a.coalesce(b)`). A non-null fallback makes the result non-null.
 
+Conditional value: `case { whenever(cond) then v; …; otherwise(d) }` → searched `CASE`. A `Selectable`
+(readable in `select(...)`) — **hold it in a `val`** to read it back. The result type is inferred for
+built-in types; for an enum/custom type pass the ColumnType: `case(MyColumnType) { … }`.
+
 For a reusable query, build a `Query` value instead of a block:
 `Users.find(Query(Users.age gtEq 18))`. Every `find` / `count` / `update` / `deleteWhere`
 accepts either form.
@@ -235,6 +239,6 @@ the `;` splitter can't handle, pass statements explicitly: `Migration("002", lis
 - Predicate names are `less` / `lessEq` (not `lt` / `ltEq`) and `neq` (not `ne`).
 - Read nullable join columns with `getOrNull`; `row[col]` throws on NULL/absent.
 - Not modeled by the typed DSL: subqueries, `UNION`, CTEs, window functions, `RIGHT`/`FULL`/
-  `CROSS`/self-joins, `ILIKE` operator (use `lower()`), regex, `CASE` (use `coalesce` for null fallback), scalar functions
+  `CROSS`/self-joins, `ILIKE` operator (use `lower()`), regex, simple `CASE expr WHEN` (searched `case { }` is supported), scalar functions
   beyond `lower`/`upper`/`trim`/`ltrim`/`rtrim`, arithmetic in `SELECT` projections, `RETURNING` on
   `UPDATE`/`DELETE`, `FOR UPDATE`. Drop to `RawExpression` or `execute(...)` for those.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -107,6 +107,40 @@ The default binds through the column's converter, so an enum/`Instant`/`BigDecim
 the same way a comparison literal does. When the fallback is non-null the result is non-null —
 read it with `row[...]`; for a `coalesce` of two nullable columns, use `getOrNull`.
 
+## Conditional Values (`CASE`)
+
+`case { }` builds a searched `CASE WHEN ... THEN ... ELSE ... END`: `whenever(condition) then value`
+adds a branch, `otherwise(value)` sets the fallback. It is a `Selectable`, so it reads back from a
+`select(...)` projection, and it composes with the predicates:
+
+```kotlin
+val tier = case {
+    whenever(Users.age gtEq 65) then "senior"
+    whenever(Users.age gtEq 18) then "adult"
+    otherwise("minor")
+}
+
+val labels = db.autocommit {
+    Users.query().select(tier).map { it[tier] }     // "senior" / "adult" / "minor"
+}
+
+Users.find { where { case { whenever(Users.age gtEq 18) then true; otherwise(false) } eq true } }
+```
+
+The result type is inferred from the branch values for the built-in types (String, the integer and
+floating types, Boolean, `BigDecimal`, `Instant`, the date/time types, `Uuid`). For an enum or other
+custom-mapped result, pass the `ColumnType` so the value can be read and bound:
+
+```kotlin
+val status = case(StatusColumnType) {
+    whenever(Users.active eq true) then Status.ACTIVE
+    otherwise(Status.INACTIVE)
+}
+```
+
+A `CASE`'s identity is the expression you built, so **hold it in a `val`** to read it back from a row
+(`val tier = case { }; row[tier]`). Only searched `CASE` is modeled (no `CASE expr WHEN value`).
+
 ## Ordering, Limit and Offset
 
 ```kotlin
@@ -341,7 +375,7 @@ Not modeled by the typed DSL today:
 - **`EXISTS` / `NOT EXISTS`.**
 - **Pattern-match variants.** `like` only; no `ILIKE` operator (lower both sides for a
   case-insensitive match — see [String Functions](#string-functions)), `SIMILAR TO`, or regex.
-- **Computed expressions.** No arithmetic (`+`, `-`, `*`, `/`), string concatenation, `CASE`,
+- **Computed expressions.** No arithmetic (`+`, `-`, `*`, `/`), string concatenation,
   casts, or scalar functions other than the string functions `lower` / `upper` /
   `trim` / `ltrim` / `rtrim` (see [String Functions](#string-functions)) in `SELECT`/`WHERE`/`HAVING`.
 - **Expression / aggregate ordering and null placement.** `ORDER BY` takes plain columns with

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -1,6 +1,12 @@
 package io.github.kormium
 
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import io.github.kormium.resultset.ResultSet
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlin.uuid.Uuid
 
 /**
  * Collects bind values while an [Expression] or [Query] is rendered to SQL.
@@ -342,6 +348,105 @@ infix fun <Z> CoalesceOp<Z>.less(value: Z): Expression = LessOp(this, columnType
 infix fun <Z> CoalesceOp<Z>.lessEq(value: Z): Expression = LessEqOp(this, columnType.lit(value))
 infix fun <Z> CoalesceOp<Z>.gt(value: Z): Expression = GreaterOp(this, columnType.lit(value))
 infix fun <Z> CoalesceOp<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, columnType.lit(value))
+
+/**
+ * A searched `CASE WHEN cond THEN value ... ELSE default END`. It is a [Selectable] (readable from
+ * a `select(...)` projection) carrying the [columnType] that reads the result back and binds each
+ * branch value. Because its identity is the built expression, hold it in a `val` to read it back
+ * from a row (`val tier = case { … }; row[tier]`). Compare it to a typed literal with the operators
+ * below, or to another expression through the generic operators.
+ */
+class CaseOp<Z> internal constructor(
+    private val branches: List<Pair<Expression, Expression>>,
+    private val elseValue: Expression?,
+    internal val columnType: ColumnType<Z>,
+) : Selectable<Z> {
+    override fun toSql(builder: ParamBuilder): String {
+        val whens = branches.joinToString(" ") { (cond, value) -> "WHEN ${cond.toSql(builder)} THEN ${value.toSql(builder)}" }
+        val elseSql = elseValue?.let { " ELSE ${it.toSql(builder)}" }.orEmpty()
+        return "CASE $whens$elseSql END"
+    }
+
+    override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z? = columnType.read(rs, index)
+
+    // A CASE's value depends on its branch literals, which render as placeholders — so two CASEs
+    // can share a rendered SQL string. Key by instance instead; hold the CASE in a val to read it.
+    override fun resultKey(): Any = this
+}
+
+/** Builds the branches of a [case]. `whenever(cond) then value` adds a branch; `otherwise(value)` sets the ELSE. */
+class CaseBuilder<Z> internal constructor(private val columnType: ColumnType<Z>) {
+    internal val branches = mutableListOf<Pair<Expression, Expression>>()
+    internal var elseValue: Expression? = null
+
+    fun whenever(condition: Expression): WhenStep = WhenStep(condition)
+
+    inner class WhenStep internal constructor(private val condition: Expression) {
+        infix fun then(value: Z) {
+            branches += condition to columnType.lit(value)
+        }
+    }
+
+    fun otherwise(value: Z) {
+        elseValue = columnType.lit(value)
+    }
+}
+
+/**
+ * A searched `CASE` whose result type is given explicitly — use this for enum / custom column
+ * types, where the reader cannot be inferred from [Z]:
+ * `case(StatusColumnType) { whenever(...) then Status.ACTIVE; otherwise Status.INACTIVE }`.
+ */
+fun <Z> case(columnType: ColumnType<Z>, block: CaseBuilder<Z>.() -> Unit): CaseOp<Z> {
+    val builder = CaseBuilder(columnType).apply(block)
+    require(builder.branches.isNotEmpty()) { "case { } needs at least one `whenever(...) then ...`" }
+    return CaseOp(builder.branches, builder.elseValue, columnType)
+}
+
+/**
+ * A searched `CASE` whose result type is inferred from the branch values for the built-in types
+ * (String, the integer and floating types, Boolean, BigDecimal, Instant, the date/time types, Uuid):
+ *
+ * ```kotlin
+ * val tier = case {
+ *     whenever(Users.age gtEq 65) then "senior"
+ *     whenever(Users.age gtEq 18) then "adult"
+ *     otherwise "minor"
+ * }
+ * ```
+ *
+ * For an enum or other custom-mapped result, use the [case] overload that takes a `ColumnType`.
+ */
+inline fun <reified Z> case(noinline block: CaseBuilder<Z>.() -> Unit): CaseOp<Z> {
+    @Suppress("UNCHECKED_CAST")
+    val columnType = when (Z::class) {
+        String::class -> TextColumnType
+        Int::class -> IntColumnType
+        Long::class -> LongColumnType
+        Short::class -> ShortColumnType
+        Boolean::class -> BooleanColumnType
+        Double::class -> DoubleColumnType
+        Float::class -> FloatColumnType
+        BigDecimal::class -> BigDecimalColumnType
+        Instant::class -> InstantColumnType
+        LocalDate::class -> LocalDateColumnType
+        LocalTime::class -> LocalTimeColumnType
+        LocalDateTime::class -> LocalDateTimeColumnType
+        Uuid::class -> UuidColumnType
+        else -> error(
+            "case<${Z::class.simpleName}> can't infer how to read the result; " +
+                "use case(columnType) { ... } with the column's ColumnType",
+        )
+    } as ColumnType<Z>
+    return case(columnType, block)
+}
+
+infix fun <Z> CaseOp<Z>.eq(value: Z): Expression = EqOp(this, columnType.lit(value))
+infix fun <Z> CaseOp<Z>.neq(value: Z): Expression = NeqOp(this, columnType.lit(value))
+infix fun <Z> CaseOp<Z>.less(value: Z): Expression = LessOp(this, columnType.lit(value))
+infix fun <Z> CaseOp<Z>.lessEq(value: Z): Expression = LessEqOp(this, columnType.lit(value))
+infix fun <Z> CaseOp<Z>.gt(value: Z): Expression = GreaterOp(this, columnType.lit(value))
+infix fun <Z> CaseOp<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, columnType.lit(value))
 
 /** Groups an expression in parentheses so it composes safely with surrounding `AND`/`OR`. */
 class ParenExpression(private val expr: Expression) : Expression {

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -9,6 +9,7 @@ import io.github.kormium.UniqueViolationException
 import io.github.kormium.and
 import io.github.kormium.autocommit
 import io.github.kormium.between
+import io.github.kormium.case
 import io.github.kormium.coalesce
 import io.github.kormium.count
 import io.github.kormium.createSqliteDatabase
@@ -574,6 +575,42 @@ class SqliteIntegrationTest {
             Products.find { where { (Products.displayName eq tag) and (Products.rank.coalesce(0) gt 5) } }
         }
         assertEquals(listOf(7), highRank.map { it.rank })
+
+        db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
+    }
+
+    /** `case` buckets a value into a label, read back from a projection and filtered on in a predicate. */
+    @Test
+    fun testCase() {
+        val tag = "case-${Uuid.random()}"
+        db.transaction {
+            Products.execSql(productsDdl)
+            listOf(5, 30, 100).forEach { q ->
+                Products.insert(Product().apply { id = Uuid.random(); price = BigDecimal.fromInt(1); qty = q; displayName = tag; note = null; rank = null })
+            }
+        }
+
+        // SELECT: bucket qty into a label and read it back (held in a val).
+        val bucket = case {
+            whenever(Products.qty gtEq 100) then "big"
+            whenever(Products.qty gtEq 10) then "mid"
+            otherwise("small")
+        }
+        val labels = db.autocommit {
+            Products.query().where(Products.displayName eq tag).select(bucket).map { it[bucket] }.sorted()
+        }
+        assertEquals(listOf("big", "mid", "small"), labels)
+
+        // WHERE: filter by the computed bucket.
+        val mids = db.autocommit {
+            val b = case {
+                whenever(Products.qty gtEq 100) then "big"
+                whenever(Products.qty gtEq 10) then "mid"
+                otherwise("small")
+            }
+            Products.find { where { (Products.displayName eq tag) and (b eq "mid") } }
+        }
+        assertEquals(listOf(30), mids.map { it.qty })
 
         db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
     }


### PR DESCRIPTION
Completes A3 (after COALESCE, #95). Replaces the auto-closed #96 (its base `feat/coalesce` was deleted on merge); diff here is CASE-only.

## What

```kotlin
val tier = case {
    whenever(Users.age gtEq 65) then "senior"
    whenever(Users.age gtEq 18) then "adult"
    otherwise("minor")
}
db.autocommit { Users.query().select(tier).map { it[tier] } }   // read back
Users.find { where { tier eq "adult" } }                         // filter on it
```

- `case { whenever(cond) then value; …; otherwise(default) }` → searched `CASE WHEN … THEN … ELSE … END`.
- Result is a `Selectable<Z>` carrying a `ColumnType`, so it reads back from `select(...)` and a compared literal binds through it (`eq`/`neq`/`gt`/`gtEq`/`less`/`lessEq` on `CaseOp`).
- **Type inference (variant R):** result type inferred from the branch values for built-in types (reified `Z` → matching `ColumnType`); for an enum/custom type, the explicit overload takes it: `case(StatusColumnType) { … }`.
- Standard SQL — no dialect hook. Searched CASE only (no simple `CASE expr WHEN value`).

## Design note

A computed `Selectable` needs a `ColumnType<Z>` to read its result; `CASE` literal results give none and `Z` is erased. Resolved by inferring the `ColumnType` from reified `Z` for built-ins, with an explicit-`ColumnType` escape. A `CASE` keys by **instance** (its branch literals render as placeholders, so two CASEs can share a rendered string) — hold it in a `val` to read it back (documented).

## Tests

`SqliteIntegrationTest.testCase` — bucket-label read-back + predicate filter. `:kormium-sqlite:jvmTest` + `:kormium-core:jvmTest` green locally. Docs: `docs/queries.md` + `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)