### PR TITLE
feat: arithmetic in SELECT projections, with structural result keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,9 @@ Conditional value: `case { whenever(cond) then v; …; otherwise(d) }` → searc
 (readable in `select(...)`) — **hold it in a `val`** to read it back. The result type is inferred for
 built-in types; for an enum/custom type pass the ColumnType: `case(MyColumnType) { … }`.
 
+Arithmetic: numeric columns support `+ - * / %` (`Posts.likes - Posts.dislikes`, `Posts.views + 1`)
+— in `where { }`, in an `update { }` `set`, and as a `select(...)` projection that reads back.
+
 For a reusable query, build a `Query` value instead of a block:
 `Users.find(Query(Users.age gtEq 18))`. Every `find` / `count` / `update` / `deleteWhere`
 accepts either form.
@@ -239,6 +242,6 @@ the `;` splitter can't handle, pass statements explicitly: `Migration("002", lis
 - Predicate names are `less` / `lessEq` (not `lt` / `ltEq`) and `neq` (not `ne`).
 - Read nullable join columns with `getOrNull`; `row[col]` throws on NULL/absent.
 - Not modeled by the typed DSL: subqueries, `UNION`, CTEs, window functions, `RIGHT`/`FULL`/
-  `CROSS`/self-joins, `ILIKE` operator (use `lower()`), regex, simple `CASE expr WHEN` (searched `case { }` is supported), scalar functions
-  beyond `lower`/`upper`/`trim`/`ltrim`/`rtrim`, arithmetic in `SELECT` projections, `RETURNING` on
-  `UPDATE`/`DELETE`, `FOR UPDATE`. Drop to `RawExpression` or `execute(...)` for those.
+  `CROSS`/self-joins, `ILIKE` operator (use `lower()`), regex, simple `CASE expr WHEN` (searched
+  `case { }` is supported), scalar functions beyond `lower`/`upper`/`trim`/`ltrim`/`rtrim`,
+  `RETURNING` on `UPDATE`/`DELETE`, `FOR UPDATE`. Drop to `RawExpression` or `execute(...)` for those.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -141,6 +141,29 @@ val status = case(StatusColumnType) {
 A `CASE`'s identity is the expression you built, so **hold it in a `val`** to read it back from a row
 (`val tier = case { }; row[tier]`). Only searched `CASE` is modeled (no `CASE expr WHEN value`).
 
+## Arithmetic
+
+Numeric columns support `+`, `-`, `*`, `/`, `%`. The operands are a same-typed column, another
+arithmetic expression, or a literal (bound through the column's converter); the result is the same
+type and nests, so it chains. It works in a `where { }`, in an `update { }` `set`, and as a
+`select(...)` projection that reads back:
+
+```kotlin
+// In a predicate:
+Posts.find { where { (Posts.likes - Posts.dislikes) gtEq 100 } }
+
+// Atomic self-referential update:
+Posts.update { Posts.views set (Posts.views + 1); where { Posts.id eq id } }
+
+// As a projection, read back (a literal is part of the key, so no `val` is needed):
+val lineTotals: List<Int> = db.autocommit {
+    Orders.query().select(Orders.qty * Orders.unitPrice).map { it[Orders.qty * Orders.unitPrice] }
+}
+```
+
+The result reads through the column's type and is `NULL` when any operand is — use `getOrNull`
+for an expression that can be null.
+
 ## Ordering, Limit and Offset
 
 ```kotlin
@@ -375,9 +398,11 @@ Not modeled by the typed DSL today:
 - **`EXISTS` / `NOT EXISTS`.**
 - **Pattern-match variants.** `like` only; no `ILIKE` operator (lower both sides for a
   case-insensitive match — see [String Functions](#string-functions)), `SIMILAR TO`, or regex.
-- **Computed expressions.** No arithmetic (`+`, `-`, `*`, `/`), string concatenation,
-  casts, or scalar functions other than the string functions `lower` / `upper` /
-  `trim` / `ltrim` / `rtrim` (see [String Functions](#string-functions)) in `SELECT`/`WHERE`/`HAVING`.
+- **Computed expressions.** No string concatenation, casts, or scalar functions other than
+  the string functions `lower` / `upper` / `trim` / `ltrim` / `rtrim`
+  (see [String Functions](#string-functions)) in `SELECT`/`WHERE`/`HAVING`. Arithmetic
+  (`+` `-` `*` `/` `%`) over numeric columns *is* supported — see [Arithmetic](#arithmetic);
+  conditional values via searched `case { }` — see [Conditional Values](#conditional-values-case).
 - **Expression / aggregate ordering and null placement.** `ORDER BY` takes plain columns with
   `ASC` / `DESC` only — no ordering by an aggregate or expression, and no `NULLS FIRST` /
   `NULLS LAST`.

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -40,8 +40,18 @@ interface Expression {
     fun toSql(builder: ParamBuilder): String
 }
 
-class Value(private val value: Any?) : Expression {
+class Value(internal val value: Any?) : Expression {
     override fun toSql(builder: ParamBuilder): String = builder.bind(value)
+}
+
+// A stable, structural key for an operand of a computed [Selectable] (COALESCE, arithmetic): a
+// nested selectable contributes its own key, a literal its (bound) value — so two computed
+// expressions differ by their literals, not only their shape, and a projection reads back with a
+// fresh instance. A non-selectable, non-literal operand falls back to identity (rare).
+internal fun structuralKey(expr: Expression): Any = when (expr) {
+    is Selectable<*> -> expr.resultKey()
+    is Value -> "lit(${expr.value})"
+    else -> expr
 }
 
 /**
@@ -194,14 +204,15 @@ infix fun Column<*, *, *>.neq(value: Nothing?): Expression = IsNullOp(this, true
  * staying type-checked (`(base + bonus) * 2`). Carrying [columnType] lets a literal on either side
  * bind through the originating column's converter rather than a guessed mapping.
  */
-interface NumericExpr<Z> : Expression {
+interface NumericExpr<Z> : Selectable<Z> {
     val columnType: ColumnType<Z>
 }
 
 /**
  * Arithmetic node: renders `left op right`, binding any literal as a parameter. A nested
  * [ArithmeticOp] operand is parenthesized so SQL precedence matches the Kotlin expression that
- * built it (`(a + b) * c`, not `a + b * c`).
+ * built it (`(a + b) * c`, not `a + b * c`). As a [Selectable] it can be read from a `select(...)`
+ * projection; the result is read through [columnType] and is null when any operand is.
  */
 class ArithmeticOp<Z>(
     private val left: Expression,
@@ -210,6 +221,10 @@ class ArithmeticOp<Z>(
     override val columnType: ColumnType<Z>,
 ) : NumericExpr<Z> {
     override fun toSql(builder: ParamBuilder): String = "${render(left, builder)} $opSign ${render(right, builder)}"
+
+    override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z? = columnType.read(rs, index)
+
+    override fun resultKey(): Any = "(${structuralKey(left)} $opSign ${structuralKey(right)})"
 
     private fun render(expr: Expression, builder: ParamBuilder): String {
         val sql = expr.toSql(builder)
@@ -287,7 +302,7 @@ class StringFunction(private val fn: String, private val args: List<Expression>)
     override fun toSql(builder: ParamBuilder): String = "$fn(${args.joinToString(", ") { it.toSql(builder) }})"
     override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): String? = rs.getString(index)
     override fun resultKey(): Any =
-        "$fn(${args.joinToString(", ") { ((it as? Selectable<*>)?.resultKey() ?: it).toString() }})"
+        "$fn(${args.joinToString(", ") { structuralKey(it).toString() }})"
 }
 
 // Scalar string functions, defined on both Column<String> and StringExpr so they chain like the
@@ -331,7 +346,7 @@ class CoalesceOp<Z> internal constructor(
 ) : Selectable<Z> {
     override fun toSql(builder: ParamBuilder): String = "COALESCE(${args.joinToString(", ") { it.toSql(builder) }})"
     override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z? = columnType.read(rs, index)
-    override fun resultKey(): Any = "COALESCE(${args.joinToString(", ") { ((it as? Selectable<*>)?.resultKey() ?: it).toString() }})"
+    override fun resultKey(): Any = "COALESCE(${args.joinToString(", ") { structuralKey(it).toString() }})"
 }
 
 /** `COALESCE("col", default)` — read a nullable column with a fallback; the default binds through the column's converter. */

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -30,6 +30,7 @@ import io.github.kormium.upper
 import io.github.kormium.query
 import io.github.kormium.renderSql
 import io.github.kormium.sum
+import io.github.kormium.times
 import io.github.kormium.transaction
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -611,6 +612,41 @@ class SqliteIntegrationTest {
             Products.find { where { (Products.displayName eq tag) and (b eq "mid") } }
         }
         assertEquals(listOf(30), mids.map { it.qty })
+
+        db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
+    }
+
+    /**
+     * Arithmetic reads back from a `select(...)` projection — with a *fresh* expression instance,
+     * proving the structural result key (the literal is part of the key, so different literals in
+     * one query don't collide). COALESCE with a literal now reads back fresh too.
+     */
+    @Test
+    fun testArithmeticInProjection() {
+        val tag = "arith-${Uuid.random()}"
+        db.transaction {
+            Products.execSql(productsDdl)
+            Products.insert(Product().apply { id = Uuid.random(); price = BigDecimal.fromInt(1); qty = 10; displayName = tag; note = null; rank = 5 })
+        }
+
+        // Selected and read back with brand-new `* 2` instances — no val needed.
+        val doubled = db.autocommit {
+            Products.query().where(Products.displayName eq tag).select(Products.qty * 2).single()[Products.qty * 2]
+        }
+        assertEquals(20, doubled)
+
+        // Two different literals in one projection don't share a key.
+        val pair = db.autocommit {
+            val row = Products.query().where(Products.displayName eq tag).select(Products.qty * 2, Products.qty * 3).single()
+            row[Products.qty * 2] to row[Products.qty * 3]
+        }
+        assertEquals(20 to 30, pair)
+
+        // COALESCE(rank, 0) with a literal default also reads back with a fresh instance.
+        val coalesced = db.autocommit {
+            Products.query().where(Products.displayName eq tag).select(Products.rank.coalesce(0)).single()[Products.rank.coalesce(0)]
+        }
+        assertEquals(5, coalesced)
 
         db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
     }


### PR DESCRIPTION
## Why

Column arithmetic (`+ - * / %`) already worked in `WHERE` and `update { set }`, but **not** in a `SELECT` projection (`NumericExpr` wasn't `Selectable`) — and the docs wrongly listed arithmetic as unsupported. This makes computed numeric values projectable and read-back-able (line totals, deltas, …), and removes a `val`-only footgun for reading computed expressions.

## What

- `NumericExpr<Z>` is now a `Selectable<Z>`; `ArithmeticOp` reads through its `columnType`. So `select(Orders.qty * Orders.unitPrice)` works and reads back.
- **Structural result keys including literals.** A computed expression's key now incorporates its operands' structure *and* its literals — `Value` exposes its bound value through a shared `structuralKey(expr)` helper. So a projection reads back with a **fresh instance** (no `val`), and `qty * 2` / `qty * 3` in one query don't collide. `CoalesceOp` and `StringFunction` adopt the same helper, so `coalesce(col, default)` and the string functions also read back fresh.

```kotlin
val lineTotals = db.autocommit {
    Orders.query().select(Orders.qty * Orders.unitPrice).map { it[Orders.qty * Orders.unitPrice] }
}
```

- Result reads through the column's type and is `NULL` when any operand is (`getOrNull`). Standard SQL, no dialect hook.

## CASE note

`CASE` still keys by **instance** (needs a `val` to read back): its key also depends on the branch *conditions* (arbitrary predicates that have no structural key). Removing the `val` there needs a "structural key for every expression" pass — tracked separately.

## Tests

`SqliteIntegrationTest.testArithmeticInProjection` — read arithmetic back with a fresh instance, two non-colliding literals, and a fresh COALESCE-with-literal read. `:kormium-sqlite:jvmTest` + `:kormium-core:jvmTest` green locally. Docs: `docs/queries.md` (new Arithmetic section, removed from "Unsupported") + `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)