### PR TITLE
feat: correlated EXISTS via Table.any { } / Table.none { }

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,11 @@ built-in types; for an enum/custom type pass the ColumnType: `case(MyColumnType)
 Arithmetic: numeric columns support `+ - * / %` (`Posts.likes - Posts.dislikes`, `Posts.views + 1`)
 — in `where { }`, in an `update { }` `set`, and as a `select(...)` projection that reads back.
 
+Existence (correlated EXISTS): `Table.any { predicate }` → `EXISTS (SELECT 1 FROM table WHERE …)`,
+`Table.none { }` → `NOT EXISTS`. The predicate references the outer column to correlate:
+`Users.find { where { Orders.any { Orders.userId eq Users.id } } }`. This also covers `IN (SELECT)`.
+A scalar subquery isn't modeled — compare against a `RawExpression("(SELECT …)")`.
+
 For a reusable query, build a `Query` value instead of a block:
 `Users.find(Query(Users.age gtEq 18))`. Every `find` / `count` / `update` / `deleteWhere`
 accepts either form.
@@ -241,7 +246,8 @@ the `;` splitter can't handle, pass statements explicitly: `Migration("002", lis
 - `findById` targets the primary key and throws on a composite key — use `find(Query(col eq v))`.
 - Predicate names are `less` / `lessEq` (not `lt` / `ltEq`) and `neq` (not `ne`).
 - Read nullable join columns with `getOrNull`; `row[col]` throws on NULL/absent.
-- Not modeled by the typed DSL: subqueries, `UNION`, CTEs, window functions, `RIGHT`/`FULL`/
+- Not modeled by the typed DSL: subqueries other than correlated `EXISTS` (use `any`/`none`; scalar →
+  compare against a `RawExpression`), `UNION`, CTEs, window functions, `RIGHT`/`FULL`/
   `CROSS`/self-joins, `ILIKE` operator (use `lower()`), regex, simple `CASE expr WHEN` (searched
   `case { }` is supported), scalar functions beyond `lower`/`upper`/`trim`/`ltrim`/`rtrim`,
   `RETURNING` on `UPDATE`/`DELETE`, `FOR UPDATE`. Drop to `RawExpression` or `execute(...)` for those.

--- a/docs/adr/0004-correlated-exists-any-none.md
+++ b/docs/adr/0004-correlated-exists-any-none.md
@@ -1,0 +1,81 @@
+# ADR 0004 — Subqueries: correlated `EXISTS` via `any` / `none`, not a subquery-as-value
+
+- Status: Accepted
+- Date: 2026-06-30
+
+## Context
+
+Users need subqueries — most often "is there a related row?" (`EXISTS`), sometimes `IN (SELECT …)`
+or a scalar comparison (`price > (SELECT AVG(price))`).
+
+The obvious typed-DSL design is a **subquery value**: build a `SELECT` you can embed, e.g.
+`col inSubquery select(Orders.userId) { where { … } }`. Every spelling of this was awkward:
+
+- it nests a whole `SELECT … FROM … WHERE …` as a value inside a predicate, breaking the DSL's
+  flat `find { where { } }` shape;
+- it forces a wrapper type and a name; `col inSubquery subquery(...)` even stutters;
+- the table gets named twice (`Orders.subquery(Orders.userId)`).
+
+This is structural, not a naming problem: representing a nested query as an embeddable value never
+reads cleanly in a flat DSL.
+
+## Decision
+
+Do **not** model a subquery-as-value. Model the common case — a correlated existence check — as a
+**Kotlin-idiomatic quantifier on the table**:
+
+```kotlin
+Table.any { predicate }   // EXISTS (SELECT 1 FROM table WHERE predicate)
+Table.none { predicate }  // NOT EXISTS (...)
+```
+
+The predicate is an ordinary boolean expression that references the outer query's columns to
+correlate:
+
+```kotlin
+Users.find { where { Orders.any { (Orders.userId eq Users.id) and (Orders.total gt 100) } } }
+Users.find { where { Orders.none { Orders.userId eq Users.id } } }
+```
+
+- This also covers **`IN (SELECT …)`**: `id IN (SELECT userId FROM orders WHERE …)` is the same as
+  `Orders.any { (Orders.userId eq Users.id) and … }`, and reads clearer (the correlation is visible).
+- A **scalar** subquery is written as a typed comparison against a `RawExpression`, which already
+  works through the generic `Expression`-to-`Expression` operators:
+  `Products.price gt RawExpression("(SELECT AVG(\"price\") FROM \"products\")")`.
+
+Correlation requires both sides qualified (`orders.userId = users.id`). `ParamBuilder.qualifyColumns`
+becomes flippable, and the `EXISTS` predicate renders inside `builder.qualified { }` (then restores),
+so outer and inner columns don't collide while parameters keep flowing into the one builder in order.
+
+## Consequences
+
+Positive:
+
+- The DSL stays flat and reads like Kotlin (`any` / `none` are everyday idioms); no nested
+  query-as-value, no wrapper type, no stutter.
+- Covers existence **and** the common `IN (SELECT)` case with one clean construct.
+- Correlation is explicit and visible (`Orders.userId eq Users.id`), so the SQL is obvious.
+
+Negative / costs:
+
+- Scalar subqueries are not first-class — they go through `RawExpression`, which is verbatim and
+  cannot bind parameters (fine for static aggregate subqueries, on the author for anything with input).
+- Subqueries in `SELECT` / `FROM`, `UNION`, CTEs, etc. remain out of scope (raw SQL).
+- `qualifyColumns` is now mutable on `ParamBuilder` (a small, internal, save/restore concession).
+
+## Alternatives considered
+
+- **Subquery-as-value** (`col inSubquery select(col) { where }`, scalar `col gt select(...)`).
+  Rejected: it never reads cleanly in a flat DSL, names the table twice, and the operator/value
+  naming stutters. This was the first direction and it was abandoned after several syntax attempts.
+- **Drop subqueries entirely**, leaving everything to `RawExpression`. Seriously considered — it fits
+  the project's "deliberate slice + escape hatch" stance — but correlated `EXISTS` is high-value and
+  common, and `any` / `none` express it cleanly enough to be worth modeling.
+- **A typed scalar-subquery value.** Deferred: scalar subqueries are rarer, and the typed-comparison
+  against `RawExpression` covers them without an ugly value type.
+
+## Notes
+
+The `any` / `none` reframe came directly from rejecting the subquery-as-value approach: once the goal
+is "is there a related row?" rather than "embed a SELECT", the Kotlin `any`/`none` quantifier is the
+natural fit. A first-class scalar subquery can be revisited later if a real need appears.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,3 +7,4 @@ rewrite.
 - [0001 — Concrete dialects live in standalone modules](0001-standalone-dialect-modules.md)
 - [0002 — No `ilike`; case-insensitive matching is explicit via `lower()`](0002-no-ilike-explicit-lower.md)
 - [0003 — `dialect` is a public member of `Database` / `SuspendDatabase`](0003-public-dialect-on-database.md)
+- [0004 — Subqueries: correlated `EXISTS` via `any` / `none`, not a subquery-as-value](0004-correlated-exists-any-none.md)

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -164,6 +164,28 @@ val lineTotals: List<Int> = db.autocommit {
 The result reads through the column's type and is `NULL` when any operand is — use `getOrNull`
 for an expression that can be null.
 
+## Existence (`any` / `none`)
+
+`Table.any { predicate }` renders a correlated `EXISTS (SELECT 1 FROM table WHERE predicate)`;
+`Table.none { }` renders `NOT EXISTS`. Read like Kotlin's `any`/`none`. The predicate is an ordinary
+boolean expression and references the outer query's columns to correlate — columns on both sides
+render qualified (`orders.userId = users.id`) so they don't collide:
+
+```kotlin
+// Users who have at least one order over 100:
+Users.find { where { Orders.any { (Orders.userId eq Users.id) and (Orders.total gt 100) } } }
+
+// Users with no orders at all:
+Users.find { where { Orders.none { Orders.userId eq Users.id } } }
+```
+
+This is also how to write an `IN (SELECT ...)`: `id IN (SELECT userId FROM orders WHERE …)` is the
+same as `Orders.any { (Orders.userId eq Users.id) and … }`. A **scalar** subquery (comparing to a
+single value) is not modeled — write it as a typed comparison against a `RawExpression`:
+`Products.find { where { Products.price gt RawExpression("""(SELECT AVG("price") FROM "products")""") } }`.
+For why subqueries are modeled this way (and not as an embeddable value), see
+[ADR 0004](adr/0004-correlated-exists-any-none.md).
+
 ## Ordering, Limit and Offset
 
 ```kotlin
@@ -386,8 +408,11 @@ slice runs through raw SQL — either a `RawExpression` inside the DSL or `execu
 
 Not modeled by the typed DSL today:
 
-- **Subqueries.** No subqueries in any position (`SELECT`, `FROM`, `WHERE`, `IN (SELECT ...)`,
-  scalar or correlated). `inList` takes an in-memory `List`, not a query.
+- **Subqueries** other than `EXISTS`. Correlated `EXISTS` / `NOT EXISTS` is modeled by `any` / `none`
+  (see [Existence](#existence-any--none)); subqueries in `SELECT` / `FROM`, `IN (SELECT ...)` and
+  scalar subqueries are not — express a scalar one as a typed comparison against a `RawExpression`
+  (`Products.price gt RawExpression("(SELECT AVG(\"price\") FROM \"products\")")`). `inList` takes an
+  in-memory `List`, not a query.
 - **`UNION` / `INTERSECT` / `EXCEPT`.** No set-operation combinators.
 - **CTEs and recursive queries.** No `WITH` / `WITH RECURSIVE`.
 - **Window functions.** No `OVER (...)`, `PARTITION BY`, or ranking functions. Aggregates are
@@ -395,7 +420,6 @@ Not modeled by the typed DSL today:
 - **`RIGHT` / `FULL OUTER` / `CROSS` joins and self-joins.** Only `innerJoin` and `leftJoin`
   are available, and a table cannot be aliased to join it to itself.
 - **`DISTINCT ON`.** Only plain `DISTINCT` is supported.
-- **`EXISTS` / `NOT EXISTS`.**
 - **Pattern-match variants.** `like` only; no `ILIKE` operator (lower both sides for a
   case-insensitive match — see [String Functions](#string-functions)), `SIMILAR TO`, or regex.
 - **Computed expressions.** No string concatenation, casts, or scalar functions other than

--- a/kormium-core/src/commonMain/kotlin/Exists.kt
+++ b/kormium-core/src/commonMain/kotlin/Exists.kt
@@ -1,0 +1,39 @@
+package io.github.kormium
+
+/**
+ * `[NOT ]EXISTS (SELECT 1 FROM table WHERE predicate)`. The predicate is rendered with columns
+ * qualified by their table, so a reference to an outer column (`users.id`) correlates correctly
+ * against an inner one (`orders.userId`). Built by [any] / [none].
+ */
+class ExistsOp internal constructor(
+    private val table: Table<*, *>,
+    private val predicate: Expression,
+    private val negated: Boolean,
+) : Expression {
+    override fun toSql(builder: ParamBuilder): String {
+        val condition = builder.qualified { predicate.toSql(builder) }
+        val prefix = if (negated) "NOT " else ""
+        return "${prefix}EXISTS (SELECT 1 FROM ${table.qualifiedName(builder.dialect)} WHERE $condition)"
+    }
+}
+
+/**
+ * `EXISTS (SELECT 1 FROM this WHERE …)` — true when at least one row of this table matches the
+ * [predicate]. Read like Kotlin's `any { }`. The predicate is an ordinary boolean expression and
+ * may reference the outer query's columns to correlate:
+ *
+ * ```kotlin
+ * Users.find { where { Orders.any { (Orders.userId eq Users.id) and (Orders.total gt 100) } } }
+ * ```
+ */
+fun <T : Entity> Table<*, T>.any(predicate: () -> Expression): Expression = ExistsOp(this, predicate(), negated = false)
+
+/**
+ * `NOT EXISTS (SELECT 1 FROM this WHERE …)` — true when no row of this table matches the
+ * [predicate]. Read like Kotlin's `none { }`:
+ *
+ * ```kotlin
+ * Users.find { where { Orders.none { Orders.userId eq Users.id } } }   // users with no orders
+ * ```
+ */
+fun <T : Entity> Table<*, T>.none(predicate: () -> Expression): Expression = ExistsOp(this, predicate(), negated = true)

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -19,9 +19,12 @@ import kotlin.uuid.Uuid
 class ParamBuilder(
     val dialect: Dialect,
     private val typeMapper: TypeMapper,
-    /** When true, a [Column] renders as `"table"."col"` (needed to disambiguate joins). */
-    val qualifyColumns: Boolean = false,
+    qualifyColumns: Boolean = false,
 ) {
+    /** When true, a [Column] renders as `"table"."col"` (needed to disambiguate joins / subqueries). */
+    var qualifyColumns: Boolean = qualifyColumns
+        private set
+
     private var counter = 0
     private val collected = LinkedHashMap<String, Any?>()
 
@@ -33,6 +36,21 @@ class ParamBuilder(
         val name = "p${counter++}"
         collected[name] = typeMapper.toParameter(value)
         return dialect.renderBind(name, value)
+    }
+
+    /**
+     * Renders [block] with columns qualified by their table, then restores the previous setting —
+     * used inside a correlated subquery so an outer column (`users.id`) and an inner one
+     * (`orders.userId`) don't collide. Parameters keep flowing into this same builder, in order.
+     */
+    internal fun <R> qualified(block: () -> R): R {
+        val previous = qualifyColumns
+        qualifyColumns = true
+        try {
+            return block()
+        } finally {
+            qualifyColumns = previous
+        }
     }
 }
 

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -7,6 +7,7 @@ import io.github.kormium.Query
 import io.github.kormium.Table
 import io.github.kormium.UniqueViolationException
 import io.github.kormium.and
+import io.github.kormium.any
 import io.github.kormium.autocommit
 import io.github.kormium.between
 import io.github.kormium.case
@@ -23,6 +24,7 @@ import io.github.kormium.innerJoin
 import io.github.kormium.leftJoin
 import io.github.kormium.lower
 import io.github.kormium.ltrim
+import io.github.kormium.none
 import io.github.kormium.not
 import io.github.kormium.rtrim
 import io.github.kormium.trim
@@ -679,6 +681,48 @@ class SqliteIntegrationTest {
         val viaDb = db.renderSql { Products.find { where { Products.qty gtEq 10 } } }
         assertEquals(find.sql, viaDb.sql)
         assertEquals(find.params, viaDb.params)
+    }
+
+    /**
+     * `any` / `none` render correlated `EXISTS` / `NOT EXISTS`: the inner predicate references the
+     * outer table's column (`Books.authorId eq Authors.id`), and both sides render qualified.
+     */
+    @Test
+    fun testExistsViaAnyNone() {
+        val withBook = Uuid.random()
+        val withoutBook = Uuid.random()
+        val bookId = Uuid.random()
+        db.transaction {
+            Authors.execSql(authorsDdl)
+            Books.execSql(booksDdl)
+            Authors.insert(Author().apply { id = withBook; name = "Ada" })
+            Authors.insert(Author().apply { id = withoutBook; name = "Grace" })
+            Books.insert(Book().apply { id = bookId; authorId = withBook; title = "Notes" })
+        }
+        val scope = listOf(withBook, withoutBook)
+
+        // any → authors who have at least one book.
+        val haveBooks = db.autocommit {
+            Authors.find { where { (Authors.id inList scope) and Books.any { Books.authorId eq Authors.id } } }
+        }
+        assertEquals(listOf(withBook), haveBooks.map { it.id })
+
+        // none → authors with no books.
+        val noBooks = db.autocommit {
+            Authors.find { where { (Authors.id inList scope) and Books.none { Books.authorId eq Authors.id } } }
+        }
+        assertEquals(listOf(withoutBook), noBooks.map { it.id })
+
+        // Correlation plus an inner condition.
+        val withNotes = db.autocommit {
+            Authors.find { where { (Authors.id inList scope) and Books.any { (Books.authorId eq Authors.id) and (Books.title eq "Notes") } } }
+        }
+        assertEquals(listOf(withBook), withNotes.map { it.id })
+
+        db.transaction {
+            Books.deleteWhere(Query(Books.id eq bookId))
+            Authors.deleteWhere(Query(Authors.id inList scope))
+        }
     }
 }
 


### PR DESCRIPTION
## Why

Subqueries are the last big DSL-coverage gap. The obvious "subquery as an embeddable value" design read badly in a flat DSL (named the table twice, `inSubquery subquery(...)` stuttered). So instead: model the **common** subquery — "is there a related row?" — as a Kotlin-idiomatic quantifier.

## What

```kotlin
// EXISTS — users who have at least one order over 100
Users.find { where { Orders.any { (Orders.userId eq Users.id) and (Orders.total gt 100) } } }

// NOT EXISTS — users with no orders
Users.find { where { Orders.none { Orders.userId eq Users.id } } }
```

- `Table.any { predicate }` → `EXISTS (SELECT 1 FROM table WHERE predicate)`; `Table.none { }` → `NOT EXISTS`. The predicate is an ordinary boolean expression that references the outer column to correlate — read like Kotlin's `any`/`none`.
- **Covers `IN (SELECT …)`** too: `id IN (SELECT userId FROM orders WHERE …)` is `Orders.any { (Orders.userId eq Users.id) and … }`, and the correlation is visible.
- **Scalar** subqueries stay a typed comparison against a `RawExpression` (already works via the generic operators) — no ugly subquery-as-value type.

Correlation needs both sides qualified (`orders.userId = users.id`), so `ParamBuilder.qualifyColumns` is now flippable and `ExistsOp` renders its predicate via `builder.qualified { }` then restores — params keep flowing into the one builder, the outer query is otherwise unchanged.

## Decision recorded

The deliberate choice (model only correlated `EXISTS` via `any`/`none`, not a subquery-as-value; scalar via `RawExpression`) is **[ADR 0004](docs/adr/0004-correlated-exists-any-none.md)**.

## Tests

`SqliteIntegrationTest.testExistsViaAnyNone` — `any`, `none`, and correlation with an inner condition. `:kormium-sqlite:jvmTest` + `:kormium-core:jvmTest` green locally. Docs: `docs/queries.md` (new Existence section, `EXISTS` removed from "Unsupported") + `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)