### PR TITLE
fix: override dialect in the web-engine databases (db.dialect exact on web)

### DIFF
--- a/kormium-mysql-node/src/wasmJsMain/kotlin/io/github/kormium/mysql/node/MySqlDatabase.kt
+++ b/kormium-mysql-node/src/wasmJsMain/kotlin/io/github/kormium/mysql/node/MySqlDatabase.kt
@@ -23,6 +23,7 @@ class MySqlDatabase internal constructor(
 ) : SuspendDatabase<Nothing> {
 
     override val writeListeners: WriteListeners = WriteListeners()
+    override val dialect = MySqlDialect
 
     private val lifecycle = DatabaseLifecycle { pool.end() }
 

--- a/kormium-postgres-node/src/wasmJsMain/kotlin/io/github/kormium/postgres/node/PgDatabase.kt
+++ b/kormium-postgres-node/src/wasmJsMain/kotlin/io/github/kormium/postgres/node/PgDatabase.kt
@@ -24,6 +24,7 @@ class PgDatabase internal constructor(
 ) : SuspendDatabase<Nothing> {
 
     override val writeListeners: WriteListeners = WriteListeners()
+    override val dialect = PostgresDialect
 
     private val lifecycle = DatabaseLifecycle { pool.end() }
 

--- a/kormium-sqlite-node/src/wasmJsMain/kotlin/io/github/kormium/sqlite/node/NodeSqliteDatabase.kt
+++ b/kormium-sqlite-node/src/wasmJsMain/kotlin/io/github/kormium/sqlite/node/NodeSqliteDatabase.kt
@@ -26,6 +26,7 @@ class NodeSqliteDatabase internal constructor(
 ) : SuspendDatabase<Nothing> {
 
     override val writeListeners: WriteListeners = WriteListeners()
+    override val dialect = SqliteDialect
 
     private val lifecycle = DatabaseLifecycle { db.close() }
     private val connectionLock = Mutex()

--- a/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/SqliteWasmDatabase.kt
+++ b/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/SqliteWasmDatabase.kt
@@ -30,6 +30,7 @@ class SqliteWasmDatabase internal constructor(
 ) : SuspendDatabase<Nothing> {
 
     override val writeListeners: WriteListeners = WriteListeners()
+    override val dialect = SqliteDialect
 
     private val lifecycle = DatabaseLifecycle { api.close(db) }
     private val connectionLock = Mutex()


### PR DESCRIPTION
## Why

`db.dialect` (and therefore `db.renderSql`) should reflect the real backend. The web-engine databases — `SqliteWasmDatabase`, `PgDatabase`, `MySqlDatabase`, `NodeSqliteDatabase` — implement `SuspendDatabase` only, so they were compiling on the `StandardDialect` default and rendering neutral SQL instead of SQLite/Postgres/MySQL. Resolves the follow-up noted in [ADR 0003](docs/adr/0003-public-dialect-on-database.md).

## What

Each web database now `override val dialect = <X>Dialect` (the dialect object is already imported for the executor) — mirroring how they already override `config` / `writeListeners` / `isClosed`. One line each, no behavior change beyond `db.dialect` being exact.

Verified by CI (wasmJs targets aren't compiled in the local JVM run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)