### PR TITLE
feat: order by a computed expression (e.g. lower(name)), not just a column

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,9 @@ Predicates: `eq`, `neq`, `gt`, `gtEq`, `less`, `lessEq`, `between (lo..hi)`, `li
 as parameters. `between` takes an inclusive Kotlin range (`Users.age between 18..65`); an empty
 range and an empty `inList` both render to `FALSE` (match no rows), never invalid SQL.
 
+`orderBy` takes a column or a computed expression: `orderBy ASC Users.name.lower()` (case-insensitive),
+`orderBy DESC (Users.qty * Users.price)`.
+
 String functions: a `String` column has `lower()`, `upper()`, `trim()`, `ltrim()`, `rtrim()`,
 each returning a `StringExpr` that chains (`name.trim().lower()`), composes with the predicates
 above (`name.lower() eq "ada"`, `a.lower() eq b.lower()`), and is readable in `select(...)`.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -197,6 +197,11 @@ Users.find {
 }
 ```
 
+`orderBy` takes a column or a **computed expression** — `orderBy ASC Users.name.lower()` for a
+case-insensitive sort, or `orderBy DESC (Users.qty * Users.price)`. Multiple `orderBy` calls keep
+their order. (Ordering by an aggregate belongs to the grouped `Table.query()` path, and
+`NULLS FIRST` / `LAST` is not modeled.)
+
 ## Reusable Queries with `Query`
 
 The `find { ... }` / `count { ... }` block is a thin ergonomic layer over `Query`, the value
@@ -427,9 +432,9 @@ Not modeled by the typed DSL today:
   (see [String Functions](#string-functions)) in `SELECT`/`WHERE`/`HAVING`. Arithmetic
   (`+` `-` `*` `/` `%`) over numeric columns *is* supported — see [Arithmetic](#arithmetic);
   conditional values via searched `case { }` — see [Conditional Values](#conditional-values-case).
-- **Expression / aggregate ordering and null placement.** `ORDER BY` takes plain columns with
-  `ASC` / `DESC` only — no ordering by an aggregate or expression, and no `NULLS FIRST` /
-  `NULLS LAST`.
+- **Aggregate ordering and null placement.** `ORDER BY` takes a column or a computed expression
+  (`lower(name)`, arithmetic) with `ASC` / `DESC`, but not an aggregate (that is the grouped
+  `Table.query()` path), and no `NULLS FIRST` / `NULLS LAST`.
 - **Grouping in the `find { }` block.** `groupBy` / `having` / `distinct` live on the join /
   `Table.query()` path, not the entity-returning `find { }` builder.
 - **Statement-level extras.** No `ORDER BY` / `LIMIT` on `UPDATE` / `DELETE`, no `RETURNING`

--- a/kormium-core/src/commonMain/kotlin/Query.kt
+++ b/kormium-core/src/commonMain/kotlin/Query.kt
@@ -5,7 +5,7 @@ data class Query(
     val whereExpression: Expression? = null,
     val limit: UInt = UInt.MAX_VALUE,
     val offset: UInt = 0u,
-    val orderBy: Map<Column<*, *, *>, AscDescOrder>? = null
+    val orderBy: Map<Selectable<*>, AscDescOrder>? = null
 ) {
     /**
      * Renders this query's clauses to SQL, registering any compared values as
@@ -31,8 +31,8 @@ data class Query(
     // Debug-friendly rendering; placeholders are emitted in place of values.
     override fun toString(): String = toSql(ParamBuilder(StandardDialect, StandardTypeMapper))
 
-    private fun prepareOrderBy(orderBy: Map<Column<*, *, *>, AscDescOrder>, builder: ParamBuilder): String =
-        orderBy.entries.joinToString(",") { (key, value) -> "${builder.dialect.quoteIdentifier(key.name)} ${value.name}" }
+    private fun prepareOrderBy(orderBy: Map<Selectable<*>, AscDescOrder>, builder: ParamBuilder): String =
+        orderBy.entries.joinToString(",") { (key, value) -> "${key.toSql(builder)} ${value.name}" }
 }
 
 enum class AscDescOrder{

--- a/kormium-core/src/commonMain/kotlin/QueryBuilder.kt
+++ b/kormium-core/src/commonMain/kotlin/QueryBuilder.kt
@@ -20,7 +20,7 @@ package io.github.kormium
 @KormiumDsl
 class QueryBuilder {
     private val conditions = mutableListOf<Expression>()
-    private val orderings = LinkedHashMap<Column<*, *, *>, AscDescOrder>()
+    private val orderings = LinkedHashMap<Selectable<*>, AscDescOrder>()
 
     /** `orderBy DESC Users.age`, `orderBy ASC Users.name`. Multiple calls keep their order. */
     val orderBy: OrderByDsl = OrderByDsl(orderings)
@@ -60,13 +60,17 @@ class QueryBuilder {
     }
 }
 
-/** Infix ordering for [QueryBuilder.orderBy]: `orderBy DESC column`, `orderBy ASC column`. */
-class OrderByDsl internal constructor(private val orderings: MutableMap<Column<*, *, *>, AscDescOrder>) {
-    infix fun ASC(column: Column<*, *, *>) {
-        orderings[column] = AscDescOrder.ASC
+/**
+ * Infix ordering for [QueryBuilder.orderBy]: `orderBy DESC column`, `orderBy ASC column`. The
+ * operand is any [Selectable] — a column, or a computed value like `Users.name.lower()` or
+ * `Users.qty * 2` (for case-insensitive or computed ordering).
+ */
+class OrderByDsl internal constructor(private val orderings: MutableMap<Selectable<*>, AscDescOrder>) {
+    infix fun ASC(expression: Selectable<*>) {
+        orderings[expression] = AscDescOrder.ASC
     }
 
-    infix fun DESC(column: Column<*, *, *>) {
-        orderings[column] = AscDescOrder.DESC
+    infix fun DESC(expression: Selectable<*>) {
+        orderings[expression] = AscDescOrder.DESC
     }
 }

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -724,6 +724,28 @@ class SqliteIntegrationTest {
             Authors.deleteWhere(Query(Authors.id inList scope))
         }
     }
+
+    /** `orderBy` accepts a computed expression — case-insensitive sort via `lower(name)`. */
+    @Test
+    fun testOrderByExpression() {
+        val rows = listOf("Zara", "alice", "bob").map { Uuid.random() to it }
+        db.transaction {
+            Authors.execSql(authorsDdl)
+            rows.forEach { (id, n) -> Authors.insert(Author().apply { this.id = id; name = n }) }
+        }
+        val scope = rows.map { it.first }
+
+        // Binary order would put "Zara" first (uppercase Z < lowercase a); lower(name) sorts properly.
+        val byLower = db.autocommit {
+            Authors.find {
+                where { Authors.id inList scope }
+                orderBy ASC Authors.name.lower()
+            }
+        }
+        assertEquals(listOf("alice", "bob", "Zara"), byLower.map { it.name })
+
+        db.transaction { Authors.deleteWhere(Query(Authors.id inList scope)) }
+    }
 }
 
 object SqCatalog : Catalog


### PR DESCRIPTION
## Why

`orderBy` only took a plain column, so a case-insensitive sort (`ORDER BY lower(name)`) or computed ordering wasn't expressible — and that blocked case-insensitive keyset pagination (the `WHERE lower(name) > …` half worked, the matching `ORDER BY lower(name)` didn't). A maturity gap.

## What

`orderBy` now accepts any `Selectable`:

```kotlin
Users.find {
    where { Users.id inList scope }
    orderBy ASC Users.name.lower()          // case-insensitive
    orderBy DESC (Users.qty * Users.price)  // computed
}
```

- `OrderByDsl.ASC`/`DESC` and `Query.orderBy` widen from `Column` to `Selectable<*>`; `prepareOrderBy` renders each key via `toSql`.
- **Fully backward-compatible:** a `Column` is a `Selectable`, so existing `orderBy DESC col` and `Query(orderBy = mapOf(col to DESC))` compile unchanged, and a column renders to the same identifier as before.

## Tests

`SqliteIntegrationTest.testOrderByExpression` — `lower(name)` yields a case-insensitive order (`alice, bob, Zara`) where SQLite's binary default would put `Zara` first. `:kormium-sqlite:jvmTest` + `:kormium-core:jvmTest` green locally. Docs: `docs/queries.md` (Ordering section, removed from "Unsupported") + `AGENTS.md`.

Note: the widened type also accepts an aggregate, which only makes sense on the grouped `Table.query()` path — using one in `find { }` `orderBy` renders `ORDER BY COUNT(*)` and errors at the DB. Documented; not worth a narrower type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)