### PR TITLE
feat: N-ary COALESCE (vararg columns + chainable literal fallback)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,8 @@ for deterministic case-insensitive matching, lower **both sides**: `name.lower()
 
 Null fallback: `column.coalesce(default)` → `COALESCE("column", default)` — the value or the
 fallback when NULL. Readable in `select(...)` and comparable to a literal (`Users.rank.coalesce(0)
-gt 5`), or to another column (`a.coalesce(b)`). A non-null fallback makes the result non-null.
+gt 5`). N-ary: `a.coalesce(b, c)` (more columns), `a.coalesce(b).coalesce("default")` (trailing
+literal). A non-null fallback makes the result non-null.
 
 Conditional value: `case { whenever(cond) then v; …; otherwise(d) }` → searched `CASE`. A `Selectable`
 (readable in `select(...)`) — **hold it in a `val`** to read it back. The result type is inferred for

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -99,8 +99,9 @@ val names: List<String> = db.autocommit {
 // Treat a NULL as the fallback in a predicate:
 Users.find { where { Users.rank.coalesce(0) gt 5 } }   // COALESCE("rank", 0) > 5
 
-// First non-null of two columns:
-Users.find { where { Users.nickname.coalesce(Users.name) eq "Ada" } }
+// First non-null of several columns, then a literal fallback:
+Users.find { where { Users.nickname.coalesce(Users.handle, Users.name) eq "Ada" } }
+select(Users.nickname.coalesce(Users.handle, Users.name).coalesce("anonymous")) // COALESCE(nick, handle, name, 'anonymous')
 ```
 
 The default binds through the column's converter, so an enum/`Instant`/`BigDecimal` fallback maps

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -359,7 +359,7 @@ infix fun StringExpr.gtEq(value: String): Expression = GreaterEqOp(this, Value(v
  * otherwise read it with `getOrNull`.
  */
 class CoalesceOp<Z> internal constructor(
-    private val args: List<Expression>,
+    internal val args: List<Expression>,
     internal val columnType: ColumnType<Z>,
 ) : Selectable<Z> {
     override fun toSql(builder: ParamBuilder): String = "COALESCE(${args.joinToString(", ") { it.toSql(builder) }})"
@@ -370,8 +370,17 @@ class CoalesceOp<Z> internal constructor(
 /** `COALESCE("col", default)` — read a nullable column with a fallback; the default binds through the column's converter. */
 fun <Z> Column<Z, *, *>.coalesce(default: Z): CoalesceOp<Z> = CoalesceOp(listOf(this, Value(bindParam(default))), columnType)
 
-/** `COALESCE("col", "other")` — the first non-null of two same-typed columns. */
-fun <Z> Column<Z, *, *>.coalesce(other: Column<Z, *, *>): CoalesceOp<Z> = CoalesceOp(listOf(this, other), columnType)
+/** `COALESCE("col", "c2", "c3", ...)` — the first non-null of this column and the [others], in order. */
+fun <Z> Column<Z, *, *>.coalesce(vararg others: Column<Z, *, *>): CoalesceOp<Z> =
+    CoalesceOp(listOf(this, *others), columnType)
+
+/** Extends a `COALESCE` with more columns: `a.coalesce(b).coalesce(c, d)` → `COALESCE(a, b, c, d)`. */
+fun <Z> CoalesceOp<Z>.coalesce(vararg others: Column<Z, *, *>): CoalesceOp<Z> =
+    CoalesceOp(args + others, columnType)
+
+/** Appends a literal fallback to a `COALESCE`, typically last: `a.coalesce(b).coalesce("default")`. */
+fun <Z> CoalesceOp<Z>.coalesce(default: Z): CoalesceOp<Z> =
+    CoalesceOp(args + columnType.lit(default), columnType)
 
 // Comparing a COALESCE to a typed literal binds it through the source column's converter.
 // (COALESCE-to-expression comparison already works through the generic operators above.)

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -746,6 +746,27 @@ class SqliteIntegrationTest {
 
         db.transaction { Authors.deleteWhere(Query(Authors.id inList scope)) }
     }
+
+    /** N-ary `coalesce`: more columns via vararg, plus a trailing literal fallback. */
+    @Test
+    fun testCoalesceVararg() {
+        val idA = Uuid.random()
+        val idB = Uuid.random()
+        db.transaction {
+            Products.execSql(productsDdl)
+            Products.insert(Product().apply { id = idA; price = BigDecimal.fromInt(1); qty = 1; displayName = "A"; note = null; rank = null })
+            Products.insert(Product().apply { id = idB; price = BigDecimal.fromInt(1); qty = 1; displayName = "x"; note = "B"; rank = null })
+        }
+
+        // COALESCE("note", "displayName", 'Z'): A's note is NULL -> "A"; B's note -> "B".
+        val values = db.autocommit {
+            val c = Products.note.coalesce(Products.displayName).coalesce("Z")
+            Products.query().where(Products.id inList listOf(idA, idB)).select(c).map { it[c] }.sorted()
+        }
+        assertEquals(listOf("A", "B"), values)
+
+        db.transaction { Products.deleteWhere(Query(Products.id inList listOf(idA, idB))) }
+    }
 }
 
 object SqCatalog : Catalog


### PR DESCRIPTION
## Why

`coalesce` only took two operands (`col + default`, `col + col`). Real fallback chains often span several columns ending in a literal — `COALESCE(nickname, handle, name, 'anonymous')`. Completeness/maturity.

## What

```kotlin
Users.nickname.coalesce(Users.handle, Users.name)                 // COALESCE(nick, handle, name)
Users.nickname.coalesce(Users.handle).coalesce("anonymous")       // COALESCE(nick, handle, 'anonymous')
Users.rank.coalesce(0)                                            // unchanged — col + literal
```

- `Column<Z>.coalesce(vararg others: Column<Z>)` — first non-null of several columns (subsumes the old single-column overload; source-compatible).
- `CoalesceOp<Z>.coalesce(vararg others: Column<Z>)` / `CoalesceOp<Z>.coalesce(default: Z)` — extend a COALESCE with more columns or a trailing literal. All render one flat `COALESCE(...)`.
- `CoalesceOp.args` becomes `internal` so the chaining extensions can append; the result still keys structurally (literals included), so it reads back from a projection with a fresh instance.

## Tests

`SqliteIntegrationTest.testCoalesceVararg` — `COALESCE(note, displayName, 'Z')` read back across two rows. `:kormium-sqlite:jvmTest` + `:kormium-core:jvmTest` green locally. Docs: `docs/queries.md` + `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)