### PR TITLE
feat(core): key CASE structurally (no val needed to read it back)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,8 +111,9 @@ fallback when NULL. Readable in `select(...)` and comparable to a literal (`User
 gt 5`), or to another column (`a.coalesce(b)`). A non-null fallback makes the result non-null.
 
 Conditional value: `case { whenever(cond) then v; …; otherwise(d) }` → searched `CASE`. A `Selectable`
-(readable in `select(...)`) — **hold it in a `val`** to read it back. The result type is inferred for
-built-in types; for an enum/custom type pass the ColumnType: `case(MyColumnType) { … }`.
+(readable in `select(...)`) keyed structurally, so a freshly built identical `case { }` reads back —
+a `val` is handy for reuse, not required. The result type is inferred for built-in types; for an
+enum/custom type pass the ColumnType: `case(MyColumnType) { … }`.
 
 Arithmetic: numeric columns support `+ - * / %` (`Posts.likes - Posts.dislikes`, `Posts.views + 1`)
 — in `where { }`, in an `update { }` `set`, and as a `select(...)` projection that reads back.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -138,8 +138,9 @@ val status = case(StatusColumnType) {
 }
 ```
 
-A `CASE`'s identity is the expression you built, so **hold it in a `val`** to read it back from a row
-(`val tier = case { }; row[tier]`). Only searched `CASE` is modeled (no `CASE expr WHEN value`).
+A `CASE` is keyed structurally (by its conditions and branch values), like the other computed
+expressions — a freshly built, identical `case { }` reads back from a row, so a `val` is for reuse,
+not required. Only searched `CASE` is modeled (no `CASE expr WHEN value`).
 
 ## Arithmetic
 

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -16,11 +16,16 @@ import kotlin.uuid.Uuid
  * quoting and placeholder rendering are delegated to [dialect]; value conversion
  * to [typeMapper].
  */
-class ParamBuilder(
+class ParamBuilder private constructor(
     val dialect: Dialect,
-    private val typeMapper: TypeMapper,
-    qualifyColumns: Boolean = false,
+    private val typeMapper: TypeMapper?,
+    private val keyMode: Boolean,
+    qualifyColumns: Boolean,
 ) {
+    /** The normal builder: binds values as real parameters through [typeMapper]. */
+    constructor(dialect: Dialect, typeMapper: TypeMapper, qualifyColumns: Boolean = false) :
+        this(dialect, typeMapper, keyMode = false, qualifyColumns = qualifyColumns)
+
     /** When true, a [Column] renders as `"table"."col"` (needed to disambiguate joins / subqueries). */
     var qualifyColumns: Boolean = qualifyColumns
         private set
@@ -33,8 +38,11 @@ class ParamBuilder(
 
     /** Registers [value] as a bind parameter and returns the placeholder to embed in the SQL. */
     fun bind(value: Any?): String {
+        // Key mode inlines the literal instead of binding it (and never touches the type mapper),
+        // so an expression can render a stable structural key that distinguishes its literals.
+        if (keyMode) return "lit($value)"
         val name = "p${counter++}"
-        collected[name] = typeMapper.toParameter(value)
+        collected[name] = typeMapper!!.toParameter(value)
         return dialect.renderBind(name, value)
     }
 
@@ -51,6 +59,14 @@ class ParamBuilder(
         } finally {
             qualifyColumns = previous
         }
+    }
+
+    companion object {
+        // A builder that inlines literals instead of binding them, used to derive an expression's
+        // structural result key (see CaseOp) — never executed, so the dialect only needs to be
+        // deterministic (any fixed one), and no type mapper is required.
+        internal fun forKey(): ParamBuilder =
+            ParamBuilder(StandardDialect, typeMapper = null, keyMode = true, qualifyColumns = false)
     }
 }
 
@@ -385,9 +401,9 @@ infix fun <Z> CoalesceOp<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, colum
 /**
  * A searched `CASE WHEN cond THEN value ... ELSE default END`. It is a [Selectable] (readable from
  * a `select(...)` projection) carrying the [columnType] that reads the result back and binds each
- * branch value. Because its identity is the built expression, hold it in a `val` to read it back
- * from a row (`val tier = case { … }; row[tier]`). Compare it to a typed literal with the operators
- * below, or to another expression through the generic operators.
+ * branch value. Like the other computed expressions it is keyed structurally, so a freshly built,
+ * identical `case { … }` reads back from a row — a `val` is handy for reuse, not required. Compare
+ * it to a typed literal with the operators below, or to another expression through the generic ones.
  */
 class CaseOp<Z> internal constructor(
     private val branches: List<Pair<Expression, Expression>>,
@@ -402,9 +418,10 @@ class CaseOp<Z> internal constructor(
 
     override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z? = columnType.read(rs, index)
 
-    // A CASE's value depends on its branch literals, which render as placeholders — so two CASEs
-    // can share a rendered SQL string. Key by instance instead; hold the CASE in a val to read it.
-    override fun resultKey(): Any = this
+    // Key off the CASE rendered with its branch literals inlined (key-mode builder): that captures
+    // the conditions and values — including literals that normally render as placeholders — so two
+    // CASEs differ by content, and a freshly built identical one reads back from a row.
+    override fun resultKey(): Any = toSql(ParamBuilder.forKey())
 }
 
 /** Builds the branches of a [case]. `whenever(cond) then value` adds a branch; `otherwise(value)` sets the ELSE. */

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -593,14 +593,16 @@ class SqliteIntegrationTest {
             }
         }
 
-        // SELECT: bucket qty into a label and read it back (held in a val).
-        val bucket = case {
+        // SELECT: bucket qty into a label. Selected and read back with *separate, freshly built*
+        // case { } instances — no val — proving CASE is keyed structurally like the other computed
+        // expressions (the conditions and branch literals are part of the key).
+        fun bucket() = case {
             whenever(Products.qty gtEq 100) then "big"
             whenever(Products.qty gtEq 10) then "mid"
             otherwise("small")
         }
         val labels = db.autocommit {
-            Products.query().where(Products.displayName eq tag).select(bucket).map { it[bucket] }.sorted()
+            Products.query().where(Products.displayName eq tag).select(bucket()).map { it[bucket()] }.sorted()
         }
         assertEquals(listOf("big", "mid", "small"), labels)
 


### PR DESCRIPTION
## What

`CASE` was the **last** computed expression keyed by instance identity, so reading it back from a row required holding it in a `val`:

```kotlin
val tier = case { ... }
select(tier); row[tier]      // row[case { ... }] did NOT work
```

Now it's keyed structurally — like `COALESCE`, arithmetic and aggregates — so a freshly built, identical `case { }` reads back:

```kotlin
fun bucket() = case { whenever(Products.qty gtEq 100) then "big"; ...; otherwise("small") }
select(bucket()); row[bucket()]   // ✅
```

## How

The key is the CASE rendered with its **branch literals inlined** instead of bound as `:p0`. A new key-mode `ParamBuilder` (`ParamBuilder.forKey()`) makes `bind(value)` return the value in place of a placeholder; `CaseOp.resultKey()` is then `toSql(ParamBuilder.forKey())`. Reusing `toSql` means the key captures the whole structure — conditions, branch values, nested expressions — with no per-condition-type handling to maintain.

`forKey()` always uses `StandardDialect` and `qualifyColumns = false`: the key is never executed, only needs to be deterministic, and both the select-time and read-time calls go through it, so they agree.

## Public API

Unchanged. `ParamBuilder`'s public constructor `(dialect, typeMapper, qualifyColumns = false)` keeps the same signature; the primary constructor is now private and the public one delegates to it.

## Test

`testCase` now selects with `bucket()` and reads back with a **separate, freshly built** `bucket()` — no `val` — proving the structural key. JVM SQLite suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)