### PR TITLE
feat(core)!: typed findOne replaces untyped findById; eq null restricted to nullable columns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ val adults: List<User> = db.autocommit {
     }
 }
 
-val ada: User? = db.autocommit { Users.findById(uuid) }   // targets the primary key
+val ada: User? = db.autocommit { Users.findOne { where { Users.id eq uuid } } }   // one row or null
 val all: List<User> = db.autocommit { Users.all() }
 val n: Long       = db.autocommit { Users.count { where { Users.age gtEq 18 } } }
 ```
@@ -237,7 +237,7 @@ the `;` splitter can't handle, pass statements explicitly: `Migration("002", lis
 | Task | Use |
 |------|-----|
 | Filtered read, one table | `Table.find { where { } orderBy limit }` |
-| By primary key | `Table.findById(id)` |
+| One row by id / unique column | `Table.findOne { where { col eq v } }` (→ `T?`) |
 | Reusable / prebuilt query | `Table.find(Query(...))` |
 | Two-table join as entities | `(A innerJoin B on ...).find()` |
 | Columns / aggregates from a join | `.select(...)` + `row[col]` / `row[agg]` |
@@ -248,9 +248,18 @@ the `;` splitter can't handle, pass statements explicitly: `Migration("002", lis
 ## Gotchas
 
 - Operations are scope extensions — they don't compile outside `db.transaction { }` /
-  `db.autocommit { }` (or the `suspend*` variants).
-- A `Table<G, _>` can only be used in a `Database<G>` scope; mixing catalogs is a compile error.
-- `findById` targets the primary key and throws on a composite key — use `find(Query(col eq v))`.
+  `db.autocommit { }` (or the `suspend*` variants). Symptom of being outside one: `find` / `insert`
+  resolve to a Kotlin stdlib function (`kotlin.collections.find`) or `where` is "unresolved".
+- A `Table<G, _>` can only be used in a `Database<G>` scope; mixing catalogs is a compile error
+  ("receiver type mismatch" naming `Table<ThatCatalog, _>`).
+- One row by primary key (or any unique column): `findOne { where { col eq v } }` → `T?` (`LIMIT 1`).
+  There is no `findById` — naming the column keeps the id **type-checked**.
+- Value comparisons are typed: `Users.age eq "18"` won't compile (pass `18`; the error names the
+  expected type). Column-to-column comparisons are NOT cross-checked — `intCol eq uuidCol` compiles,
+  so match the types yourself.
+- `eq null` / `neq null` (→ `IS [NOT] NULL`) work only on **nullable** columns; on a non-null column
+  they don't compile (it can never be NULL).
+- `orderBy` needs a direction — `orderBy ASC col` / `orderBy DESC col`; bare `orderBy col` is a syntax error.
 - Predicate names are `less` / `lessEq` (not `lt` / `ltEq`) and `neq` (not `ne`).
 - Read nullable join columns with `getOrNull`; `row[col]` throws on NULL/absent.
 - Not modeled by the typed DSL: subqueries other than correlated `EXISTS` (use `any`/`none`; scalar →

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ All notable changes to Kormium are documented here. The format is based on
 - `Table.primaryKey` is now `List<Column<*, *, T>>` (was `List<Column<*, *, *>>`) and the table's
   columns carry their entity type. Source-compatible for normal use; code that passed columns held
   as a bare `Column<*, *, *>` to `onConflict` must use the table's own columns.
+- **`findById(id: Any)` removed in favour of typed `findOne`.** The single untyped read in the API
+  silently accepted a wrong-typed id (e.g. a `String` for a `Uuid` key) and bypassed the column's
+  converter. Replaced by `findOne { where { Users.id eq id } }` / `findOne(Query(...))` → `T?`
+  (`LIMIT 1`): the id is type-checked against the column, binds through its converter, and the same
+  form reads by any unique column, not only the primary key. See
+  [ADR 0005](docs/adr/0005-no-untyped-findbyid.md).
+- **`eq null` / `neq null` are restricted to nullable columns.** They render `IS [NOT] NULL`; on a
+  non-null column the comparison is meaningless (it can never be NULL) and now fails to compile.
+  This also makes a wrong-typed value comparison (`age eq "x"`) report against the real
+  `eq(value)` candidate ("Int expected") instead of the null overload ("Nothing? expected").
 
 ## [0.8.0] — Cross-instance notifications, Windows async, expression UPDATE
 

--- a/benchmarks/src/jmh/kotlin/ComparisonBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/ComparisonBenchmark.kt
@@ -200,7 +200,7 @@ open class ComparisonBenchmark {
 
     // --- kormium ---
     @Benchmark
-    fun kormiumFindById(): Any? = kormiumDb.autocommit { CmpTable.findById(seededKormiumId) }
+    fun kormiumFindById(): Any? = kormiumDb.autocommit { CmpTable.findOne { where { CmpTable.id eq seededKormiumId } } }
 
     @Benchmark
     fun kormiumSelectWhere(): Any? = kormiumDb.autocommit { CmpTable.find(Query(CmpTable.name eq "seed")) }

--- a/benchmarks/src/jmh/kotlin/KormiumBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/KormiumBenchmark.kt
@@ -105,7 +105,7 @@ open class KormiumBenchmark {
     }
 
     @Benchmark
-    fun findById(): Any? = db.autocommit { BenchTable.findById(seededId) }
+    fun findById(): Any? = db.autocommit { BenchTable.findOne { where { BenchTable.id eq seededId } } }
 
     @Benchmark
     fun selectWhere(): Any? = db.autocommit { BenchTable.find(Query(BenchTable.name eq "seed")) }

--- a/docs/adr/0005-no-untyped-findbyid.md
+++ b/docs/adr/0005-no-untyped-findbyid.md
@@ -1,0 +1,82 @@
+# ADR 0005 — No untyped `findById`; single-row reads via typed `findOne`
+
+- Status: Accepted
+- Date: 2026-06-30
+
+## Context
+
+`findById(id: Any)` was the single read in the API that took an untyped argument. Kormium's whole
+pitch is a typed DSL where a wrong column or wrong value is a **compile error** — but `findById`
+quietly accepted anything: `Users.findById("not-a-uuid")` for a `Uuid` key compiled and only failed
+at runtime (or, on a lax engine, silently matched nothing). It also bound the raw `id` directly,
+bypassing the primary-key column's converter (unlike `Users.id eq id`, which binds through it), and
+threw at runtime on a composite key.
+
+A typed alternative already existed and is strictly safer: `find(Query(Users.id eq id))`. The id is
+checked against the column's type at compile time and bound through its converter. Its only gap vs
+`findById` was the return shape — `find` returns `List<T>`, while `findById` returned `T?`.
+
+This surfaced during an audit of the compiler messages agents hit (the most common mistake — a
+wrong-typed predicate value — plus this untyped-id hole). `findById` is exactly the kind of
+convenience that reads well but defeats the type-safety that makes the DSL worth using, especially
+for AI agents that reach for the obvious `findById(x)` and get no feedback on a wrong id.
+
+## Decision
+
+Remove `findById` entirely (no deprecation — the project is pre-1.0). Add a typed single-row read:
+
+```kotlin
+fun <T : Entity> Table<G, T>.findOne(query: Query): T?                       // LIMIT 1, or null
+fun <T : Entity> Table<G, T>.findOne(block: QueryBuilder.() -> Unit): T?     // block form
+```
+
+By-id becomes `Users.findOne { where { Users.id eq id } }` (or `findOne(Query(Users.id eq id))`):
+
+- the id is **type-checked** against the column and **bound through its converter**;
+- it reads by **any unique column**, not only the primary key (`findOne { where { Users.email eq e } }`);
+- composite keys are just an `and` of `eq`s — no special-cased runtime throw;
+- `LIMIT 1` is applied, so it is at least as efficient as the old direct-by-pk SQL.
+
+A generic repository that needs a by-id method carries the typed primary-key column instead of
+relying on `Any` (see `samples/repository`):
+
+```kotlin
+abstract class Repository<G : Catalog, T : Entity, ID>(
+    db: SuspendDatabase<G>, table: Table<G, T>, private val idColumn: Column<ID, *, T>,
+) {
+    suspend fun findById(id: ID): T? = read { table.findOne { where { idColumn eq id } } }
+}
+```
+
+## Consequences
+
+Positive:
+
+- The read API is fully typed — no `Any` escape; a wrong-typed id is a compile error.
+- `findOne` subsumes `findById` (by-pk is just one predicate) and generalizes to any unique column.
+- The id binds through the column converter, like every other comparison — one consistent path.
+
+Negative / costs:
+
+- Breaking change: every `findById(id)` call site migrates to `findOne { where { col eq id } }`.
+  Mechanical, and the explicit column is more readable (and what an agent already knows from the
+  schema). Done across all tests, samples and docs in the same change.
+- A generic, schema-agnostic "by id" helper now needs the PK column passed in (typed `ID`), rather
+  than a bare `Any`. This is the typed repository pattern — a feature, not a workaround.
+
+## Alternatives considered
+
+- **Keep `findById`, document the gap.** Rejected: it leaves an untyped hole in a "typed DSL" and is
+  precisely the footgun the audit set out to remove.
+- **Type `findById` via a third `Table<G, T, ID>` type parameter.** Rejected as too invasive — it
+  changes every `object Users : Table<App, User>(…)` declaration. `findOne` gets the type-safety
+  with no new generic on `Table`, by naming the column at the call site.
+- **Deprecate rather than remove.** Unnecessary pre-1.0; a clean removal avoids carrying a known
+  footgun into the API surface.
+
+## Notes
+
+Removing `findById` came out of the same audit that narrowed `eq null` / `neq null` to nullable
+columns (so a wrong-typed value comparison reports against the real `eq(value)` candidate, not the
+`Nothing?` null overload). Both are small, deliberate moves toward "the obvious wrong thing does not
+compile" — the property the whole DSL is built to provide. Related: [[korm-ai-oriented-direction]].

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,3 +8,4 @@ rewrite.
 - [0002 — No `ilike`; case-insensitive matching is explicit via `lower()`](0002-no-ilike-explicit-lower.md)
 - [0003 — `dialect` is a public member of `Database` / `SuspendDatabase`](0003-public-dialect-on-database.md)
 - [0004 — Subqueries: correlated `EXISTS` via `any` / `none`, not a subquery-as-value](0004-correlated-exists-any-none.md)
+- [0005 — No untyped `findById`; single-row reads via typed `findOne`](0005-no-untyped-findbyid.md)

--- a/docs/api-cookbook.md
+++ b/docs/api-cookbook.md
@@ -431,11 +431,12 @@ Kormium does not ship a `Repository` type — like Exposed, you call table opera
 queries, this small base is the recommended pattern; copy it and adapt it (it is yours to change):
 
 ```kotlin
-abstract class Repository<G : Catalog, T : Entity>(
+abstract class Repository<G : Catalog, T : Entity, ID>(
     protected val db: SuspendDatabase<G>,
     protected val table: Table<G, T>,
+    private val idColumn: Column<ID, *, T>,   // typed primary key, so findById is checked
 ) {
-    suspend fun findById(id: Any) = db.suspendAutocommit { table.findById(id) }
+    suspend fun findById(id: ID) = db.suspendAutocommit { table.findOne { where { idColumn eq id } } }
     suspend fun all() = db.suspendAutocommit { table.all() }
     suspend fun insert(entity: T) = db.suspendTransaction { table.insert(entity) }
     fun observeAll(): Flow<List<T>> = table.observe(db)                 // needs kormium-observe

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -11,7 +11,7 @@ val all: List<User> = db.autocommit {
 }
 
 val one: User? = db.autocommit {
-    Users.findById(id)
+    Users.findOne { where { Users.id eq id } }
 }
 
 val adults: List<User> = db.autocommit {

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -100,7 +100,7 @@ db.transaction {
 }
 
 val ada: User? = db.autocommit {
-    Users.findById(user.id)
+    Users.findOne { where { Users.id eq user.id } }
 }
 
 val adults: List<User> = db.autocommit {

--- a/docs/tables-and-entities.md
+++ b/docs/tables-and-entities.md
@@ -86,9 +86,10 @@ Column.Text().nullable()
 Column.UUID().primaryKey()
 ```
 
-`findById` uses a single explicit primary key. If none is marked, it falls back to a column
-named `id`. For composite primary keys, use `find { ... }` or `find(Query(...))` instead
-of `findById`.
+`primaryKey()` marks the key that `upsert` / `insertOrIgnore` conflict on, and that backends
+without `RETURNING` re-select a written row by. To read a single row by it, compare it explicitly:
+`findOne { where { Users.id eq id } }` (typed — the id is checked against the column). For a
+composite key, AND each key column.
 
 A non-null column (one declared without `.nullable()`) is enforced on read as well as on write:
 if the database returns SQL `NULL` for it, hydration fails fast with a `ResultMappingException`

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -228,9 +228,12 @@ fun Column<*, *, *>.isNotNull(): Expression = IsNullOp(this, true)
 
 // `column eq null` / `column neq null` render as IS [NOT] NULL. The `Nothing?` parameter
 // makes the null literal bind here instead of the typed `eq(value: Z)` overload, so the
-// comparison vocabulary stays uniform (`note eq null` reads like `age gtEq 18`).
-infix fun Column<*, *, *>.eq(value: Nothing?): Expression = IsNullOp(this, false)
-infix fun Column<*, *, *>.neq(value: Nothing?): Expression = IsNullOp(this, true)
+// comparison vocabulary stays uniform (`note eq null` reads like `age gtEq 18`). Restricted to a
+// NULLABLE column: a non-null column is never NULL, so `eq null` on one is a bug — and keeping this
+// overload off non-null columns means a typed mismatch (`age eq "x"`) reports against the real
+// `eq(value: Z)` candidate ("Int expected") instead of this one ("Nothing? expected").
+infix fun Column.NullableColumn<*, *, *>.eq(value: Nothing?): Expression = IsNullOp(this, false)
+infix fun Column.NullableColumn<*, *, *>.neq(value: Nothing?): Expression = IsNullOp(this, true)
 
 /**
  * A typed numeric operand: a [Column] participates via the operators below, and every arithmetic

--- a/kormium-core/src/commonMain/kotlin/RenderSql.kt
+++ b/kormium-core/src/commonMain/kotlin/RenderSql.kt
@@ -24,7 +24,8 @@ class RenderScope<G : Catalog> internal constructor(val dialect: Dialect, val ty
     // ---- reads ----
     fun <T : Entity> Table<G, T>.find(query: Query): RenderedSql = RenderedSql(selectSql(query, dialect, typeMapper))
     fun <T : Entity> Table<G, T>.find(block: QueryBuilder.() -> Unit): RenderedSql = find(QueryBuilder().apply(block).build())
-    fun <T : Entity> Table<G, T>.findById(id: Any): RenderedSql = RenderedSql(selectByIdSql(id, dialect, typeMapper))
+    fun <T : Entity> Table<G, T>.findOne(query: Query): RenderedSql = RenderedSql(selectSql(query.copy(limit = 1u), dialect, typeMapper))
+    fun <T : Entity> Table<G, T>.findOne(block: QueryBuilder.() -> Unit): RenderedSql = findOne(QueryBuilder().apply(block).build())
     fun <T : Entity> Table<G, T>.all(): RenderedSql = RenderedSql(selectAllSql(dialect) to emptyMap())
     fun <T : Entity> Table<G, T>.count(query: Query = Query()): RenderedSql = RenderedSql(countSql(query, dialect, typeMapper))
     fun <T : Entity> Table<G, T>.count(block: QueryBuilder.() -> Unit): RenderedSql = count(QueryBuilder().apply(block).build())

--- a/kormium-core/src/commonMain/kotlin/Scope.kt
+++ b/kormium-core/src/commonMain/kotlin/Scope.kt
@@ -96,7 +96,12 @@ class Scope<G : Catalog> internal constructor(
     /** Block form of [find]: `Users.find { where { ... }; orderBy DESC col; limit = 50 }`. */
     fun <T : Entity> Table<G, T>.find(block: QueryBuilder.() -> Unit): List<T> =
         select(QueryBuilder().apply(block).build(), exec)
-    fun <T : Entity> Table<G, T>.findById(id: Any): T? = selectById(id, exec)
+    /** The first row matching [query] (typically a unique predicate), or null. Applies `LIMIT 1`. */
+    fun <T : Entity> Table<G, T>.findOne(query: Query): T? = select(query.copy(limit = 1u), exec).firstOrNull()
+
+    /** Block form of [findOne]: `Users.findOne { where { Users.id eq id } }`. */
+    fun <T : Entity> Table<G, T>.findOne(block: QueryBuilder.() -> Unit): T? =
+        findOne(QueryBuilder().apply(block).build())
     fun <T : Entity> Table<G, T>.all(): List<T> = selectAll(exec)
     /** Updates rows matching [query] with the present fields of [entity]; returns the affected row count. */
     fun <T : Entity> Table<G, T>.update(query: Query, entity: T): Long {

--- a/kormium-core/src/commonMain/kotlin/SuspendScope.kt
+++ b/kormium-core/src/commonMain/kotlin/SuspendScope.kt
@@ -82,7 +82,12 @@ class SuspendScope<G : Catalog> internal constructor(
     /** Block form of [find]; see [Scope.find]. */
     suspend fun <T : Entity> Table<G, T>.find(block: QueryBuilder.() -> Unit): List<T> =
         select(QueryBuilder().apply(block).build(), exec)
-    suspend fun <T : Entity> Table<G, T>.findById(id: Any): T? = selectById(id, exec)
+    /** The first row matching [query] (typically a unique predicate), or null. Applies `LIMIT 1`. */
+    suspend fun <T : Entity> Table<G, T>.findOne(query: Query): T? = select(query.copy(limit = 1u), exec).firstOrNull()
+
+    /** Block form of [findOne]: `Users.findOne { where { Users.id eq id } }`. */
+    suspend fun <T : Entity> Table<G, T>.findOne(block: QueryBuilder.() -> Unit): T? =
+        findOne(QueryBuilder().apply(block).build())
     suspend fun <T : Entity> Table<G, T>.all(): List<T> = selectAll(exec)
     /** Updates rows matching [query] with the present fields of [entity]; returns the affected row count. */
     suspend fun <T : Entity> Table<G, T>.update(query: Query, entity: T): Long {

--- a/kormium-core/src/commonMain/kotlin/Table.kt
+++ b/kormium-core/src/commonMain/kotlin/Table.kt
@@ -114,18 +114,6 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
 
     // ---- pure SQL builders (no I/O) — shared by the blocking and suspend runners ----
 
-    internal fun selectByIdSql(id: Any, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
-        val pk = primaryKey.singleOrNull()
-            ?: throw IllegalStateException(
-                "findById requires a single-column primary key on $tableName; " +
-                    "use find(...) for composite (or missing) keys",
-            )
-        val builder = paramBuilder(dialect, typeMapper)
-        val idPlaceholder = builder.bind(id)
-        val sql = "SELECT ${getColumnNames(dialect).joinToString(", ")} FROM ${qualifiedTableName(dialect)} WHERE ${dialect.quoteIdentifier(pk.name)} = $idPlaceholder"
-        return sql.trimIndent() to builder.params
-    }
-
     // Re-selects a just-written row by its primary key, for backends without RETURNING (MySQL):
     // the insert/upsert runs first, then this reads the stored row back (DB defaults applied).
     private fun selectByPkSql(entity: T, dialect: Dialect, typeMapper: TypeMapper): Pair<String, Map<String, Any?>> {
@@ -355,11 +343,6 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         exec.execute(sql = sql.trimIndent())
     }
 
-    internal fun selectById(id: Any, exec: SqlExecutor): T? {
-        val (sql, params) = selectByIdSql(id, exec.dialect, exec.typeMapper)
-        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
-    }
-
     internal fun select(query: Query, exec: SqlExecutor): List<T> {
         val (sql, params) = selectSql(query, exec.dialect, exec.typeMapper)
         return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }
@@ -449,11 +432,6 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
 
     internal suspend fun runRaw(sql: String, exec: SuspendSqlExecutor) {
         exec.execute(sql = sql.trimIndent())
-    }
-
-    internal suspend fun selectById(id: Any, exec: SuspendSqlExecutor): T? {
-        val (sql, params) = selectByIdSql(id, exec.dialect, exec.typeMapper)
-        return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
     }
 
     internal suspend fun select(query: Query, exec: SuspendSqlExecutor): List<T> {

--- a/kormium-core/src/commonTest/kotlin/SuspendTest.kt
+++ b/kormium-core/src/commonTest/kotlin/SuspendTest.kt
@@ -1,3 +1,4 @@
+import io.github.kormium.eq
 import io.github.kormium.suspendAutocommit
 import io.github.kormium.suspendTransaction
 import kotlinx.coroutines.test.runTest
@@ -11,7 +12,7 @@ class SuspendTest {
     @Test
     fun suspendTransactionRunsTheBlock() = runTest {
         TableTest.suspendDb.suspendTransaction {
-            TestTable.findById(Uuid.random())
+            TestTable.findOne { where { TestTable.id eq Uuid.random() } }
         }
         assertTrue(TableTest.databaseMockObj.internalSql.contains("SELECT"))
     }

--- a/kormium-core/src/commonTest/kotlin/TableTest.kt
+++ b/kormium-core/src/commonTest/kotlin/TableTest.kt
@@ -581,10 +581,10 @@ class TableTest {
     }
 
     @Test
-    fun testFindById() {
+    fun testFindOneByPrimaryKey() {
         val uuid = Uuid.random()
-        val expectedResult = """SELECT "id", "price", "position", "text", "nullableTest" FROM "products" WHERE "id" = :p0"""
-        db.transaction { TestTable.findById(uuid) }
+        val expectedResult = """SELECT "id", "price", "position", "text", "nullableTest" FROM "products" WHERE "id" = :p0 LIMIT 1"""
+        db.transaction { TestTable.findOne { where { TestTable.id eq uuid } } }
         assertEquals(remoteNewLinesAndSpaces(expectedResult), remoteNewLinesAndSpaces(databaseMockObj.internalSql))
         assertEquals(mapOf("p0" to uuid.toString()), databaseMockObj.internalParams)
     }
@@ -781,17 +781,12 @@ class TableTest {
     }
 
     @Test
-    fun testFindByIdUsesMarkedPrimaryKeyColumn() {
-        db.autocommit { Coded.findById("abc") }
-        assertTrue(remoteNewLinesAndSpaces(databaseMockObj.internalSql).contains("""WHERE"code"=:p0"""))
+    fun testFindOneRendersPredicateAndLimitsToOne() {
+        db.autocommit { Coded.findOne { where { Coded.code eq "abc" } } }
+        val sql = remoteNewLinesAndSpaces(databaseMockObj.internalSql)
+        assertTrue(sql.contains("""WHERE"code"=:p0"""), sql)
+        assertTrue(sql.contains("LIMIT1"), sql)
         assertEquals(mapOf("p0" to "abc"), databaseMockObj.internalParams)
-    }
-
-    @Test
-    fun testFindByIdFailsForCompositeKey() {
-        assertFailsWith<IllegalStateException> {
-            db.autocommit { CompositeKey.findById(Uuid.random()) }
-        }
     }
 
     companion object {

--- a/kormium-mysql-node/src/wasmJsTest/kotlin/io/github/kormium/mysql/node/MySqlIntegrationTest.kt
+++ b/kormium-mysql-node/src/wasmJsTest/kotlin/io/github/kormium/mysql/node/MySqlIntegrationTest.kt
@@ -55,7 +55,7 @@ class MySqlIntegrationTest {
                 Widgets.insert(Widget().apply { this.id = id; this.name = "node-mysql"; this.qty = 7 })
             }
 
-            val found = db.suspendAutocommit { Widgets.findById(id) }
+            val found = db.suspendAutocommit { Widgets.findOne { where { Widgets.id eq id } } }
             assertEquals(id, found?.id)
             assertEquals("node-mysql", found?.name)
             assertEquals(7, found?.qty)
@@ -65,7 +65,7 @@ class MySqlIntegrationTest {
             assertTrue(db.suspendAutocommit { Widgets.count() } >= 1)
 
             db.suspendTransaction { Widgets.deleteWhere { where { Widgets.id eq id } } }
-            assertNull(db.suspendAutocommit { Widgets.findById(id) })
+            assertNull(db.suspendAutocommit { Widgets.findOne { where { Widgets.id eq id } } })
         } finally {
             db.close()
         }
@@ -79,7 +79,7 @@ class MySqlIntegrationTest {
             val id = Uuid.random()
             val payload = byteArrayOf(0, 1, 2, 42, 127, -1, -128, 99)
             db.suspendTransaction { Blobs.insert(BlobRow().apply { this.id = id; this.data = payload }) }
-            val found = db.suspendAutocommit { Blobs.findById(id) }
+            val found = db.suspendAutocommit { Blobs.findOne { where { Blobs.id eq id } } }
             assertContentEquals(payload, found?.data)
         } finally {
             db.close()
@@ -100,7 +100,7 @@ class MySqlIntegrationTest {
             } catch (_: IllegalStateException) {
                 // expected
             }
-            assertNull(db.suspendAutocommit { Widgets.findById(id) })
+            assertNull(db.suspendAutocommit { Widgets.findOne { where { Widgets.id eq id } } })
         } finally {
             db.close()
         }

--- a/kormium-mysql/src/jvmTest/kotlin/TableIntegrationTest.kt
+++ b/kormium-mysql/src/jvmTest/kotlin/TableIntegrationTest.kt
@@ -44,7 +44,7 @@ class TableIntegrationTest {
                 this.rank = null
             })
 
-            val found = ItProducts.findById(id)
+            val found = ItProducts.findOne { where { ItProducts.id eq id } }
             assertEquals(id, found?.id)
             assertEquals(5, found?.qty)
             assertEquals("widget", found?.displayName)
@@ -54,10 +54,10 @@ class TableIntegrationTest {
             assertEquals(0, BigDecimal.fromInt(100).compareTo(found?.price!!))
 
             ItProducts.update(Query(ItProducts.id eq id), ItProduct().apply { this.qty = 9 })
-            assertEquals(9, ItProducts.findById(id)?.qty)
+            assertEquals(9, ItProducts.findOne { where { ItProducts.id eq id } }?.qty)
 
             ItProducts.deleteWhere(Query(ItProducts.id eq id))
-            assertNull(ItProducts.findById(id))
+            assertNull(ItProducts.findOne { where { ItProducts.id eq id } })
         }
     }
 
@@ -75,7 +75,7 @@ class TableIntegrationTest {
                 this.displayName = tricky
                 this.note = null
             })
-            assertEquals(tricky, ItProducts.findById(id)?.displayName)
+            assertEquals(tricky, ItProducts.findOne { where { ItProducts.id eq id } }?.displayName)
         }
     }
 
@@ -156,7 +156,7 @@ class TableIntegrationTest {
                 update = ItProduct().apply { this.qty = 99 },
             )
         }
-        val row = ItDatabase.autocommit { ItProducts.findById(id) }
+        val row = ItDatabase.autocommit { ItProducts.findOne { where { ItProducts.id eq id } } }
         assertEquals(99, row?.qty)
         assertEquals("orig", row?.displayName) // update only touched qty
         ItDatabase.transaction { ItProducts.deleteWhere(Query(ItProducts.id eq id)) }
@@ -182,7 +182,7 @@ class TableIntegrationTest {
                 onConflict = ItProducts.id,
             )
         }
-        assertEquals("keep", ItDatabase.autocommit { ItProducts.findById(id) }?.displayName)
+        assertEquals("keep", ItDatabase.autocommit { ItProducts.findOne { where { ItProducts.id eq id } } }?.displayName)
         ItDatabase.transaction { ItProducts.deleteWhere(Query(ItProducts.id eq id)) }
     }
 
@@ -235,7 +235,7 @@ class TableIntegrationTest {
                 throw RuntimeException("boom")
             }
         }
-        assertNull(ItDatabase.autocommit { ItProducts.findById(id) })
+        assertNull(ItDatabase.autocommit { ItProducts.findOne { where { ItProducts.id eq id } } })
     }
 
     /** Migrations apply in order, exactly once, and re-running the list is a no-op. */
@@ -292,7 +292,7 @@ class TableIntegrationTest {
                 this.aDateTime = dateTime
             })
         }
-        val row = ItDatabase.autocommit { AllTypes.findById(id) }!!
+        val row = ItDatabase.autocommit { AllTypes.findOne { where { AllTypes.id eq id } } }!!
         assertEquals(42, row.anInt)
         assertEquals(2.5, row.aDouble)
         assertEquals(true, row.aBool)

--- a/kormium-mysql/src/nativeTest/kotlin/NativeMySqlTest.kt
+++ b/kormium-mysql/src/nativeTest/kotlin/NativeMySqlTest.kt
@@ -91,7 +91,7 @@ class NativeMySqlTest {
                     this.aDateTime = dateTime
                 })
             }
-            val row = db.autocommit { NativeAllTypes.findById(id) }!!
+            val row = db.autocommit { NativeAllTypes.findOne { where { NativeAllTypes.id eq id } } }!!
             assertEquals(42, row.anInt)
             assertEquals(2.5, row.aDouble)
             assertEquals(true, row.aBool)
@@ -123,13 +123,13 @@ class NativeMySqlTest {
                     this.id = id; this.qty = 5; this.name = tricky
                 })
             }
-            val found = db.autocommit { NativeProducts.findById(id) }
+            val found = db.autocommit { NativeProducts.findOne { where { NativeProducts.id eq id } } }
             assertEquals(5, found?.qty)
             assertEquals(tricky, found?.name)
             db.transaction {
                 NativeProducts.update(Query(NativeProducts.id eq id), NativeProduct().apply { qty = 9 })
             }
-            assertEquals(9, db.autocommit { NativeProducts.findById(id) }?.qty)
+            assertEquals(9, db.autocommit { NativeProducts.findOne { where { NativeProducts.id eq id } } }?.qty)
             db.transaction { NativeProducts.deleteWhere(Query(NativeProducts.id eq id)) }
         }
     }
@@ -172,7 +172,7 @@ class NativeMySqlTest {
                     update = NativeProduct().apply { this.qty = 99 },
                 )
             }
-            assertEquals(99, db.autocommit { NativeProducts.findById(id) }?.qty)
+            assertEquals(99, db.autocommit { NativeProducts.findOne { where { NativeProducts.id eq id } } }?.qty)
 
             db.transaction {
                 NativeProducts.insertOrIgnore(
@@ -180,7 +180,7 @@ class NativeMySqlTest {
                     onConflict = NativeProducts.id,
                 )
             }
-            assertEquals("orig", db.autocommit { NativeProducts.findById(id) }?.name) // unchanged
+            assertEquals("orig", db.autocommit { NativeProducts.findOne { where { NativeProducts.id eq id } } }?.name) // unchanged
             db.transaction { NativeProducts.deleteWhere(Query(NativeProducts.id eq id)) }
         }
     }
@@ -197,7 +197,7 @@ class NativeMySqlTest {
                 NativeProducts.deleteWhere(Query(NativeProducts.id eq id))
                 NativeProducts.insert(NativeProduct().apply { this.id = id; this.qty = 1; this.name = text })
             }
-            assertEquals(text, db.autocommit { NativeProducts.findById(id) }?.name)
+            assertEquals(text, db.autocommit { NativeProducts.findOne { where { NativeProducts.id eq id } } }?.name)
             db.transaction { NativeProducts.deleteWhere(Query(NativeProducts.id eq id)) }
         }
     }
@@ -235,7 +235,7 @@ class NativeMySqlTest {
                     throw RuntimeException("boom")
                 }
             }
-            assertEquals(null, db.autocommit { NativeProducts.findById(id) })
+            assertEquals(null, db.autocommit { NativeProducts.findOne { where { NativeProducts.id eq id } } })
         }
     }
 }

--- a/kormium-postgres-node/src/wasmJsTest/kotlin/io/github/kormium/postgres/node/PgIntegrationTest.kt
+++ b/kormium-postgres-node/src/wasmJsTest/kotlin/io/github/kormium/postgres/node/PgIntegrationTest.kt
@@ -56,7 +56,7 @@ class PgIntegrationTest {
                 Widgets.insert(Widget().apply { this.id = id; this.name = "node-pg"; this.qty = 7 })
             }
 
-            val found = db.suspendAutocommit { Widgets.findById(id) }
+            val found = db.suspendAutocommit { Widgets.findOne { where { Widgets.id eq id } } }
             assertEquals(id, found?.id)
             assertEquals("node-pg", found?.name)
             assertEquals(7, found?.qty)
@@ -66,7 +66,7 @@ class PgIntegrationTest {
             assertTrue(db.suspendAutocommit { Widgets.count() } >= 1)
 
             db.suspendTransaction { Widgets.deleteWhere { where { Widgets.id eq id } } }
-            assertNull(db.suspendAutocommit { Widgets.findById(id) })
+            assertNull(db.suspendAutocommit { Widgets.findOne { where { Widgets.id eq id } } })
         } finally {
             db.close()
         }
@@ -80,7 +80,7 @@ class PgIntegrationTest {
             val id = Uuid.random()
             val payload = byteArrayOf(0, 1, 2, 42, 127, -1, -128, 99)
             db.suspendTransaction { Blobs.insert(BlobRow().apply { this.id = id; this.data = payload }) }
-            val found = db.suspendAutocommit { Blobs.findById(id) }
+            val found = db.suspendAutocommit { Blobs.findOne { where { Blobs.id eq id } } }
             assertContentEquals(payload, found?.data)
         } finally {
             db.close()
@@ -101,7 +101,7 @@ class PgIntegrationTest {
             } catch (_: IllegalStateException) {
                 // expected
             }
-            assertNull(db.suspendAutocommit { Widgets.findById(id) })
+            assertNull(db.suspendAutocommit { Widgets.findOne { where { Widgets.id eq id } } })
         } finally {
             db.close()
         }

--- a/kormium-postgres/src/jvmTest/kotlin/EdgeCaseTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/EdgeCaseTest.kt
@@ -37,7 +37,7 @@ class EdgeCaseTest {
 
     @Test
     fun findByIdMissingReturnsNull() {
-        assertNull(ItDatabase.autocommit { EdgeTable.findById(Uuid.random()) })
+        assertNull(ItDatabase.autocommit { EdgeTable.findOne { where { EdgeTable.id eq Uuid.random() } } })
     }
 
     @Test
@@ -52,7 +52,7 @@ class EdgeCaseTest {
         ItDatabase.transaction {
             EdgeTable.insert(EdgeRow().apply { this.id = id; n = null; t = null; big = null; num = 1 })
         }
-        val row = ItDatabase.autocommit { EdgeTable.findById(id) }!!
+        val row = ItDatabase.autocommit { EdgeTable.findOne { where { EdgeTable.id eq id } } }!!
         assertNull(row.n)
         assertNull(row.t)
         assertNull(row.big)
@@ -110,14 +110,14 @@ class EdgeCaseTest {
         val id = Uuid.random()
         val tricky = "a'b\"c\\d\neé\t--; DROP TABLE edge; --"
         ItDatabase.transaction { EdgeTable.insert(EdgeRow().apply { this.id = id; t = tricky; num = 1 }) }
-        assertEquals(tricky, ItDatabase.autocommit { EdgeTable.findById(id) }?.t)
+        assertEquals(tricky, ItDatabase.autocommit { EdgeTable.findOne { where { EdgeTable.id eq id } } }?.t)
     }
 
     @Test
     fun boundaryIntegerValuesRoundTrip() {
         val id = Uuid.random()
         ItDatabase.transaction { EdgeTable.insert(EdgeRow().apply { this.id = id; n = Int.MIN_VALUE; num = Int.MAX_VALUE }) }
-        val row = ItDatabase.autocommit { EdgeTable.findById(id) }!!
+        val row = ItDatabase.autocommit { EdgeTable.findOne { where { EdgeTable.id eq id } } }!!
         assertEquals(Int.MIN_VALUE, row.n)
         assertEquals(Int.MAX_VALUE, row.num)
     }
@@ -153,16 +153,16 @@ class EdgeCaseTest {
                 }
             }
         }
-        assertEquals(keep, ItDatabase.autocommit { EdgeTable.findById(keep) }?.id)
-        assertNull(ItDatabase.autocommit { EdgeTable.findById(mid) })
-        assertNull(ItDatabase.autocommit { EdgeTable.findById(inner) })
+        assertEquals(keep, ItDatabase.autocommit { EdgeTable.findOne { where { EdgeTable.id eq keep } } }?.id)
+        assertNull(ItDatabase.autocommit { EdgeTable.findOne { where { EdgeTable.id eq mid } } })
+        assertNull(ItDatabase.autocommit { EdgeTable.findOne { where { EdgeTable.id eq inner } } })
     }
 
     @Test
     fun reservedWordColumnNameRoundTrips() {
         val id = Uuid.random()
         ItDatabase.transaction { Reserved.insert(ReservedRow().apply { this.id = id; order = 7 }) }
-        assertEquals(7, ItDatabase.autocommit { Reserved.findById(id) }?.order)
+        assertEquals(7, ItDatabase.autocommit { Reserved.findOne { where { Reserved.id eq id } } }?.order)
     }
 }
 

--- a/kormium-postgres/src/jvmTest/kotlin/TableIntegrationTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/TableIntegrationTest.kt
@@ -54,7 +54,7 @@ class TableIntegrationTest {
             this.rank = null
         })
 
-        val found = ItProducts.findById(id)
+        val found = ItProducts.findOne { where { ItProducts.id eq id } }
         assertEquals(id, found?.id)
         assertEquals(5, found?.qty)
         assertEquals("widget", found?.displayName)
@@ -69,10 +69,10 @@ class TableIntegrationTest {
 
         // Partial update: only non-null fields go into SET.
         ItProducts.update(Query(ItProducts.id eq id), ItProduct().apply { this.qty = 9 })
-        assertEquals(9, ItProducts.findById(id)?.qty)
+        assertEquals(9, ItProducts.findOne { where { ItProducts.id eq id } }?.qty)
 
         ItProducts.deleteWhere(Query(ItProducts.id eq id))
-        assertNull(ItProducts.findById(id))
+        assertNull(ItProducts.findOne { where { ItProducts.id eq id } })
         }
     }
 
@@ -94,7 +94,7 @@ class TableIntegrationTest {
             this.note = null
         })
 
-        assertEquals(tricky, ItProducts.findById(id)?.displayName)
+        assertEquals(tricky, ItProducts.findOne { where { ItProducts.id eq id } }?.displayName)
         }
     }
 
@@ -129,7 +129,7 @@ class TableIntegrationTest {
                 this.note = null
                 this.rank = null
             })
-            ItProducts.findById(id)
+            ItProducts.findOne { where { ItProducts.id eq id } }
             }
         }
     }
@@ -212,7 +212,7 @@ class TableIntegrationTest {
             }
         }
         // The insert above must not have been committed.
-        assertNull(ItDatabase.autocommit { ItProducts.findById(id) })
+        assertNull(ItDatabase.autocommit { ItProducts.findOne { where { ItProducts.id eq id } } })
     }
 
     /**
@@ -247,8 +247,8 @@ class TableIntegrationTest {
                 }
             }
         }
-        assertEquals("kept", ItDatabase.autocommit { ItProducts.findById(kept) }?.displayName)
-        assertNull(ItDatabase.autocommit { ItProducts.findById(rolled) })
+        assertEquals("kept", ItDatabase.autocommit { ItProducts.findOne { where { ItProducts.id eq kept } } }?.displayName)
+        assertNull(ItDatabase.autocommit { ItProducts.findOne { where { ItProducts.id eq rolled } } })
     }
 
     /** new() returns the stored row via RETURNING. */
@@ -352,7 +352,7 @@ class TableIntegrationTest {
                 this.aDateTime = dateTime
             })
         }
-        val row = ItDatabase.autocommit { AllTypes.findById(id) }!!
+        val row = ItDatabase.autocommit { AllTypes.findOne { where { AllTypes.id eq id } } }!!
         assertEquals(42, row.anInt)
         assertEquals(2.5, row.aDouble)
         assertEquals(true, row.aBool)

--- a/kormium-postgres/src/nativeTest/kotlin/NativeBenchmark.kt
+++ b/kormium-postgres/src/nativeTest/kotlin/NativeBenchmark.kt
@@ -62,7 +62,7 @@ private fun newRow(rowName: String) =
 
 private fun runOp(db: Database<BenchCatalog>, op: Op) {
     when (op) {
-        Op.FIND_BY_ID -> db.autocommit { BenchTable.findById(benchSeedId) }
+        Op.FIND_BY_ID -> db.autocommit { BenchTable.findOne { where { BenchTable.id eq benchSeedId } } }
         Op.SELECT_WHERE -> db.autocommit { BenchTable.find(Query(BenchTable.name eq "seed")) }
         Op.SELECT_MANY -> db.autocommit { BenchTable.find(Query(BenchTable.name eq "bulk")) }
         Op.INSERT -> db.transaction { BenchTable.insert(newRow("x")) }

--- a/kormium-postgres/src/nativeTest/kotlin/NativeTableIntegrationTest.kt
+++ b/kormium-postgres/src/nativeTest/kotlin/NativeTableIntegrationTest.kt
@@ -72,7 +72,7 @@ class NativeTableIntegrationTest {
             this.rank = null
         })
 
-        val found = NativeProducts.findById(id)
+        val found = NativeProducts.findOne { where { NativeProducts.id eq id } }
         assertEquals(id, found?.id)
         assertEquals(5, found?.qty)
         assertEquals("widget", found?.displayName)
@@ -81,7 +81,7 @@ class NativeTableIntegrationTest {
         assertEquals(0, BigDecimal.fromInt(100).compareTo(found?.price!!))
 
         NativeProducts.deleteWhere(Query(NativeProducts.id eq id))
-        assertNull(NativeProducts.findById(id))
+        assertNull(NativeProducts.findOne { where { NativeProducts.id eq id } })
         }
     }
 
@@ -155,7 +155,7 @@ class NativeTableIntegrationTest {
                 throw RuntimeException("boom")
             }
         }
-        assertNull(NativeDatabase.autocommit { NativeProducts.findById(id) })
+        assertNull(NativeDatabase.autocommit { NativeProducts.findOne { where { NativeProducts.id eq id } } })
     }
 
     /** A duplicate primary key surfaces as a typed UniqueViolationException (SQLSTATE 23505). */
@@ -207,8 +207,8 @@ class NativeTableIntegrationTest {
                 }
             }
         }
-        assertEquals(keep, NativeDatabase.autocommit { NativeProducts.findById(keep) }?.id)
-        assertNull(NativeDatabase.autocommit { NativeProducts.findById(inner) })
+        assertEquals(keep, NativeDatabase.autocommit { NativeProducts.findOne { where { NativeProducts.id eq keep } } }?.id)
+        assertNull(NativeDatabase.autocommit { NativeProducts.findOne { where { NativeProducts.id eq inner } } })
         NativeDatabase.transaction { NativeProducts.deleteWhere(Query(NativeProducts.id eq keep)) }
     }
 

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/MySqlR2dbcIntegrationTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/MySqlR2dbcIntegrationTest.kt
@@ -74,7 +74,7 @@ class MySqlR2dbcIntegrationTest {
                 })
             }
 
-            val found = database.suspendAutocommit { MyWidgets.findById(id) }
+            val found = database.suspendAutocommit { MyWidgets.findOne { where { MyWidgets.id eq id } } }
             assertEquals(id, found?.id)
             assertEquals("async-widget", found?.name)
             assertEquals(7, found?.qty)
@@ -105,7 +105,7 @@ class MySqlR2dbcIntegrationTest {
                 }
             }
 
-            assertNull(database.suspendAutocommit { MyWidgets.findById(id) })
+            assertNull(database.suspendAutocommit { MyWidgets.findOne { where { MyWidgets.id eq id } } })
         }
     }
 

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcCancellationTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcCancellationTest.kt
@@ -71,7 +71,7 @@ class R2dbcCancellationTest {
                 }
             }
             // Rolled back, and the single pooled connection is back (else this query would block).
-            val found = withTimeout(5_000) { database.suspendAutocommit { Widgets.findById(id) } }
+            val found = withTimeout(5_000) { database.suspendAutocommit { Widgets.findOne { where { Widgets.id eq id } } } }
             assertNull(found)
         }
     }
@@ -90,7 +90,7 @@ class R2dbcCancellationTest {
                 }
             }
             // Connection released: a normal query completes.
-            withTimeout(5_000) { database.suspendAutocommit { Widgets.findById(Uuid.random()) } }
+            withTimeout(5_000) { database.suspendAutocommit { Widgets.findOne { where { Widgets.id eq Uuid.random() } } } }
         }
     }
 }

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcEdgeCaseTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcEdgeCaseTest.kt
@@ -146,8 +146,8 @@ class R2dbcEdgeCaseTest {
                     }
                 }
             }
-            assertEquals(keep, db!!.suspendAutocommit { EParent.findById(keep) }?.id)
-            assertNull(db!!.suspendAutocommit { EParent.findById(inner) })
+            assertEquals(keep, db!!.suspendAutocommit { EParent.findOne { where { EParent.id eq keep } } }?.id)
+            assertNull(db!!.suspendAutocommit { EParent.findOne { where { EParent.id eq inner } } })
         }
     }
 

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcIntegrationTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcIntegrationTest.kt
@@ -72,7 +72,7 @@ class R2dbcIntegrationTest {
                 })
             }
 
-            val found = database.suspendAutocommit { Widgets.findById(id) }
+            val found = database.suspendAutocommit { Widgets.findOne { where { Widgets.id eq id } } }
             assertEquals(id, found?.id)
             assertEquals("async-widget", found?.name)
             assertEquals(7, found?.qty)
@@ -103,7 +103,7 @@ class R2dbcIntegrationTest {
                 }
             }
 
-            assertNull(database.suspendAutocommit { Widgets.findById(id) })
+            assertNull(database.suspendAutocommit { Widgets.findOne { where { Widgets.id eq id } } })
         }
     }
 

--- a/kormium-sqlite-node/src/wasmJsTest/kotlin/io/github/kormium/sqlite/node/NodeSqliteIntegrationTest.kt
+++ b/kormium-sqlite-node/src/wasmJsTest/kotlin/io/github/kormium/sqlite/node/NodeSqliteIntegrationTest.kt
@@ -34,7 +34,7 @@ class NodeSqliteIntegrationTest {
                 Widgets.insert(Widget().apply { this.id = id; this.name = "node-sqlite"; this.qty = 7 })
             }
 
-            val found = db.suspendAutocommit { Widgets.findById(id) }
+            val found = db.suspendAutocommit { Widgets.findOne { where { Widgets.id eq id } } }
             assertEquals(id, found?.id)
             assertEquals("node-sqlite", found?.name)
             assertEquals(7, found?.qty)
@@ -58,7 +58,7 @@ class NodeSqliteIntegrationTest {
                 Blobs.execSql(blobsDdl)
                 Blobs.insert(BlobRow().apply { this.id = id; this.data = payload })
             }
-            val found = db.suspendAutocommit { Blobs.findById(id) }
+            val found = db.suspendAutocommit { Blobs.findOne { where { Blobs.id eq id } } }
             assertContentEquals(payload, found?.data)
         } finally {
             db.close()
@@ -79,7 +79,7 @@ class NodeSqliteIntegrationTest {
             } catch (_: IllegalStateException) {
                 // expected
             }
-            assertNull(db.suspendAutocommit { Widgets.findById(id) })
+            assertNull(db.suspendAutocommit { Widgets.findOne { where { Widgets.id eq id } } })
         } finally {
             db.close()
         }

--- a/kormium-sqlite-wasm/src/wasmJsTest/kotlin/io/github/kormium/sqlite/wasm/SqliteWasmIntegrationTest.kt
+++ b/kormium-sqlite-wasm/src/wasmJsTest/kotlin/io/github/kormium/sqlite/wasm/SqliteWasmIntegrationTest.kt
@@ -40,7 +40,7 @@ class SqliteWasmIntegrationTest {
                 Widgets.insert(Widget().apply { this.id = id; this.name = "wasm-sqlite"; this.qty = 7 })
             }
 
-            val found = db.suspendAutocommit { Widgets.findById(id) }
+            val found = db.suspendAutocommit { Widgets.findOne { where { Widgets.id eq id } } }
             assertEquals(id, found?.id)
             assertEquals("wasm-sqlite", found?.name)
             assertEquals(7, found?.qty)
@@ -64,7 +64,7 @@ class SqliteWasmIntegrationTest {
                 Blobs.execSql(blobsDdl)
                 Blobs.insert(BlobRow().apply { this.id = id; this.data = payload })
             }
-            val found = db.suspendAutocommit { Blobs.findById(id) }
+            val found = db.suspendAutocommit { Blobs.findOne { where { Blobs.id eq id } } }
             assertContentEquals(payload, found?.data)
         } finally {
             db.close()
@@ -85,7 +85,7 @@ class SqliteWasmIntegrationTest {
             } catch (_: IllegalStateException) {
                 // expected
             }
-            assertNull(db.suspendAutocommit { Widgets.findById(id) })
+            assertNull(db.suspendAutocommit { Widgets.findOne { where { Widgets.id eq id } } })
         } finally {
             db.close()
         }

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteBuilderTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteBuilderTest.kt
@@ -3,6 +3,7 @@ import io.github.kormium.BatchInsertMode
 import io.github.kormium.autocommit
 import io.github.kormium.createSqliteDatabase
 import io.github.kormium.database.Database
+import io.github.kormium.eq
 import io.github.kormium.transaction
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -35,7 +36,7 @@ class SqliteBuilderTest {
                     this.rank = null
                 })
             }
-            assertEquals("from-builder", db.autocommit { Products.findById(id) }?.displayName)
+            assertEquals("from-builder", db.autocommit { Products.findOne { where { Products.id eq id } } }?.displayName)
         }
     }
 }

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteCancellationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteCancellationTest.kt
@@ -47,7 +47,7 @@ class SqliteCancellationTest {
         }
 
         // The insert must have been rolled back, and the single connection must be back in the pool.
-        val found = withTimeout(5_000) { db.suspendAutocommit { CxlItems.findById(id) } }
+        val found = withTimeout(5_000) { db.suspendAutocommit { CxlItems.findOne { where { CxlItems.id eq id } } } }
         assertNull(found)
     }
 
@@ -66,7 +66,7 @@ class SqliteCancellationTest {
 
         // No transaction to roll back; the contract is that the connection is released. With a
         // single connection, this query proves it (it would block forever if the conn leaked).
-        withTimeout(5_000) { db.suspendAutocommit { CxlItems.findById(Uuid.random()) } }
+        withTimeout(5_000) { db.suspendAutocommit { CxlItems.findOne { where { CxlItems.id eq Uuid.random() } } } }
         Unit
     }
 }

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteColumnTypeTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteColumnTypeTest.kt
@@ -53,7 +53,7 @@ class SqliteColumnTypeTest {
             })
         }
 
-        val item = db.suspendAutocommit { Items.findById(id) }!!
+        val item = db.suspendAutocommit { Items.findOne { where { Items.id eq id } } }!!
         assertEquals(Grade.B, item.grade)
         assertEquals(255, item.hex)   // stored as "ff", read back as Int
 

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteEdgeCaseTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteEdgeCaseTest.kt
@@ -42,7 +42,7 @@ class SqliteEdgeCaseTest {
     @Test
     fun findByIdMissingReturnsNull() {
         freshSchema()
-        assertNull(db.autocommit { EdgeTbl.findById(Uuid.random()) })
+        assertNull(db.autocommit { EdgeTbl.findOne { where { EdgeTbl.id eq Uuid.random() } } })
     }
 
     @Test
@@ -50,7 +50,7 @@ class SqliteEdgeCaseTest {
         freshSchema()
         val id = Uuid.random()
         db.transaction { EdgeTbl.insert(EdgeR().apply { this.id = id; n = null; t = null; num = 1 }) }
-        val row = db.autocommit { EdgeTbl.findById(id) }!!
+        val row = db.autocommit { EdgeTbl.findOne { where { EdgeTbl.id eq id } } }!!
         assertNull(row.n)
         assertNull(row.t)
         assertEquals(1, row.num)
@@ -93,7 +93,7 @@ class SqliteEdgeCaseTest {
         val id = Uuid.random()
         val tricky = "a'b\"c\\d\neé\t--; DROP TABLE edge; --"
         db.transaction { EdgeTbl.insert(EdgeR().apply { this.id = id; t = tricky; num = 1 }) }
-        assertEquals(tricky, db.autocommit { EdgeTbl.findById(id) }?.t)
+        assertEquals(tricky, db.autocommit { EdgeTbl.findOne { where { EdgeTbl.id eq id } } }?.t)
     }
 
     @Test
@@ -101,7 +101,7 @@ class SqliteEdgeCaseTest {
         freshSchema()
         val id = Uuid.random()
         db.transaction { EdgeTbl.insert(EdgeR().apply { this.id = id; n = Int.MIN_VALUE; num = Int.MAX_VALUE }) }
-        val row = db.autocommit { EdgeTbl.findById(id) }!!
+        val row = db.autocommit { EdgeTbl.findOne { where { EdgeTbl.id eq id } } }!!
         assertEquals(Int.MIN_VALUE, row.n)
         assertEquals(Int.MAX_VALUE, row.num)
     }
@@ -136,16 +136,16 @@ class SqliteEdgeCaseTest {
                 }
             }
         }
-        assertEquals(keep, db.autocommit { EdgeTbl.findById(keep) }?.id)
-        assertNull(db.autocommit { EdgeTbl.findById(mid) })
-        assertNull(db.autocommit { EdgeTbl.findById(inner) })
+        assertEquals(keep, db.autocommit { EdgeTbl.findOne { where { EdgeTbl.id eq keep } } }?.id)
+        assertNull(db.autocommit { EdgeTbl.findOne { where { EdgeTbl.id eq mid } } })
+        assertNull(db.autocommit { EdgeTbl.findOne { where { EdgeTbl.id eq inner } } })
     }
 
     @Test
     fun savepointRequiresTransaction() {
         freshSchema()
         assertFailsWith<IllegalStateException> {
-            db.autocommit { savepoint { EdgeTbl.findById(Uuid.random()) } }
+            db.autocommit { savepoint { EdgeTbl.findOne { where { EdgeTbl.id eq Uuid.random() } } } }
         }
     }
 
@@ -154,7 +154,7 @@ class SqliteEdgeCaseTest {
         freshSchema()
         val id = Uuid.random()
         db.transaction { ReservedTbl.insert(ReservedR().apply { this.id = id; order = 7 }) }
-        assertEquals(7, db.autocommit { ReservedTbl.findById(id) }?.order)
+        assertEquals(7, db.autocommit { ReservedTbl.findOne { where { ReservedTbl.id eq id } } }?.order)
     }
 }
 

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -70,7 +70,7 @@ class SqliteIntegrationTest {
             })
         }
 
-        val found = db.autocommit { Products.findById(id) }
+        val found = db.autocommit { Products.findOne { where { Products.id eq id } } }
         assertEquals(id, found?.id)
         assertEquals(5, found?.qty)
         assertEquals("widget", found?.displayName)
@@ -100,7 +100,7 @@ class SqliteIntegrationTest {
             Products.update(Product().apply { this.qty = 9 }) { where { Products.id eq id } }
         }
         assertEquals(1L, updated)
-        assertEquals(9, db.autocommit { Products.findById(id) }?.qty)
+        assertEquals(9, db.autocommit { Products.findOne { where { Products.id eq id } } }?.qty)
         // No row matches → 0 affected.
         assertEquals(0L, db.transaction {
             Products.update(Product().apply { this.qty = 1 }) { where { Products.id eq Uuid.random() } }
@@ -108,7 +108,22 @@ class SqliteIntegrationTest {
 
         val deleted = db.transaction { Products.deleteWhere { where { Products.id eq id } } }
         assertEquals(1L, deleted)
-        assertNull(db.autocommit { Products.findById(id) })
+        assertNull(db.autocommit { Products.findOne { where { Products.id eq id } } })
+    }
+
+    /** `findOne` reads a single row by any column (not just the PK) and returns null on no match. */
+    @Test
+    fun testFindOneByNonPrimaryKeyColumnAndMiss() {
+        val tag = "one-${Uuid.random()}"
+        db.transaction {
+            Products.execSql(productsDdl)
+            Products.insert(Product().apply { id = Uuid.random(); price = BigDecimal.fromInt(1); qty = 7; displayName = tag; note = null; rank = null })
+        }
+        val hit = db.autocommit { Products.findOne { where { Products.displayName eq tag } } }
+        assertEquals(7, hit?.qty)
+        val miss = db.autocommit { Products.findOne { where { Products.displayName eq "nope-$tag" } } }
+        assertNull(miss)
+        db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
     }
 
     @Test
@@ -124,7 +139,7 @@ class SqliteIntegrationTest {
                 update = Product().apply { qty = 2 },
             )
         }
-        assertEquals(1, db.autocommit { Products.findById(id) }?.qty)
+        assertEquals(1, db.autocommit { Products.findOne { where { Products.id eq id } } }?.qty)
 
         // upsert again on the same id → DO UPDATE applies the patch.
         db.transaction {
@@ -134,7 +149,7 @@ class SqliteIntegrationTest {
                 update = Product().apply { qty = 2 },
             )
         }
-        assertEquals(2, db.autocommit { Products.findById(id) }?.qty)
+        assertEquals(2, db.autocommit { Products.findOne { where { Products.id eq id } } }?.qty)
 
         // insertOrIgnore: existing id → 0 affected, new id → 1 affected.
         assertEquals(0L, db.transaction {
@@ -177,7 +192,7 @@ class SqliteIntegrationTest {
                 this.displayName = tricky; this.note = null; this.rank = null
             })
         }
-        assertEquals(tricky, db.autocommit { Products.findById(id) }?.displayName)
+        assertEquals(tricky, db.autocommit { Products.findOne { where { Products.id eq id } } }?.displayName)
         db.transaction { Products.deleteWhere(Query(Products.id eq id)) }
     }
 
@@ -209,7 +224,7 @@ class SqliteIntegrationTest {
                 this.aDateTime = dateTime
             })
         }
-        val row = db.autocommit { AllTypes.findById(id) }!!
+        val row = db.autocommit { AllTypes.findOne { where { AllTypes.id eq id } } }!!
         assertEquals(42, row.anInt)
         assertEquals(2.5, row.aDouble)
         assertEquals(true, row.aBool)
@@ -356,7 +371,7 @@ class SqliteIntegrationTest {
                 throw RuntimeException("boom")
             }
         }
-        assertNull(db.autocommit { Products.findById(id) })
+        assertNull(db.autocommit { Products.findOne { where { Products.id eq id } } })
     }
 
     /** A duplicate primary key surfaces as a typed UniqueViolationException. */

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteQueryObserverTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteQueryObserverTest.kt
@@ -40,7 +40,7 @@ class SqliteQueryObserverTest {
             ObsItems.insert(ObsItem().apply { this.id = id; name = "a" })
         }
         events.clear()
-        val found = db.autocommit { ObsItems.findById(id) }
+        val found = db.autocommit { ObsItems.findOne { where { ObsItems.id eq id } } }
         assertEquals("a", found?.name)
 
         val select = events.single { it.kind == QueryKind.Select }

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteResultMappingTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteResultMappingTest.kt
@@ -36,7 +36,7 @@ class SqliteResultMappingTest {
             executeUpdate("INSERT INTO rm_items (id, note) VALUES (:id, :note)", mapOf("id" to id.toString(), "note" to "x"))
         }
         val ex = assertFailsWith<ResultMappingException> {
-            db.autocommit { RmItems.findById(id) }
+            db.autocommit { RmItems.findOne { where { RmItems.id eq id } } }
         }
         val msg = ex.message ?: ""
         assertTrue("rm_items" in msg && "name" in msg, "should name table+column: $msg")
@@ -55,7 +55,7 @@ class SqliteResultMappingTest {
                 mapOf("id" to id.toString(), "ref" to "not-a-uuid", "status" to "ACTIVE"),
             )
         }
-        val ex = assertFailsWith<ResultMappingException> { db.autocommit { RmTyped.findById(id) } }
+        val ex = assertFailsWith<ResultMappingException> { db.autocommit { RmTyped.findOne { where { RmTyped.id eq id } } } }
         val msg = ex.message ?: ""
         assertTrue("rm_typed" in msg && "ref" in msg, "should name table+column: $msg")
         assertTrue("Uuid" in msg, "should name expected Korm type: $msg")
@@ -72,7 +72,7 @@ class SqliteResultMappingTest {
                 mapOf("id" to id.toString(), "ref" to Uuid.random().toString(), "status" to "BOGUS"),
             )
         }
-        val ex = assertFailsWith<ResultMappingException> { db.autocommit { RmTyped.findById(id) } }
+        val ex = assertFailsWith<ResultMappingException> { db.autocommit { RmTyped.findOne { where { RmTyped.id eq id } } } }
         val msg = ex.message ?: ""
         assertTrue("rm_typed" in msg && "status" in msg, "should name table+column: $msg")
         assertTrue("converted" in msg, "should mark the type as a converted ColumnType: $msg")
@@ -86,7 +86,7 @@ class SqliteResultMappingTest {
             RmItems.execSql(rmDdlNameNullable)
             executeUpdate("INSERT INTO rm_items (id, name) VALUES (:id, :name)", mapOf("id" to id.toString(), "name" to "ok"))
         }
-        val row = db.autocommit { RmItems.findById(id) }
+        val row = db.autocommit { RmItems.findOne { where { RmItems.id eq id } } }
         assertEquals("ok", row?.name)
         assertNull(row?.note, "a nullable column with DB NULL must hydrate as null")
         db.transaction { RmItems.deleteWhere(Query(RmItems.id eq id)) }

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteSuspendTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteSuspendTest.kt
@@ -1,6 +1,7 @@
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import io.github.kormium.createSqliteDatabase
 import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.eq
 import io.github.kormium.suspendAutocommit
 import io.github.kormium.suspendTransaction
 import kotlinx.coroutines.test.runTest
@@ -34,7 +35,7 @@ class SqliteSuspendTest {
             })
         }
 
-        val found = db.suspendAutocommit { Products.findById(id) }
+        val found = db.suspendAutocommit { Products.findOne { where { Products.id eq id } } }
         assertEquals(id, found?.id)
         assertEquals("async-widget", found?.displayName)
         assertEquals(3, found?.qty)
@@ -60,7 +61,7 @@ class SqliteSuspendTest {
         }
 
         // The insert must have been rolled back with the transaction.
-        val found = db.suspendAutocommit { Products.findById(id) }
+        val found = db.suspendAutocommit { Products.findOne { where { Products.id eq id } } }
         assertEquals(null, found)
     }
 }

--- a/samples/cross-instance-cache/src/commonMain/kotlin/Sample.kt
+++ b/samples/cross-instance-cache/src/commonMain/kotlin/Sample.kt
@@ -86,7 +86,7 @@ class ProductCache(private val db: Database<Shop>) {
             return byId[id]
         }
         println("cache MISS $id -> read Postgres")
-        val name = db.autocommit { Products.findById(id)?.name }
+        val name = db.autocommit { Products.findOne { where { Products.id eq id } }?.name }
         byId[id] = name
         return name
     }

--- a/samples/crud-sqlite/README.md
+++ b/samples/crud-sqlite/README.md
@@ -5,7 +5,7 @@ A standalone console app — **no server, no external database**. It does migrat
 on Kotlin/Native.
 
 Shows: `createSqliteDatabase()`, `Database.migrate(...)`, `transaction { }` / `autocommit { }`,
-`insert` / `findById` / `find { ... }` / `update` / `deleteWhere`.
+`insert` / `findOne { ... }` / `find { ... }` / `update` / `deleteWhere`.
 
 ## Run
 
@@ -19,5 +19,5 @@ Run from the repository root. No Docker needed.
 ```
 
 It uses an in-memory database by default; pass a path to `createSqliteDatabase("app.db")` in
-`Main.kt` to persist to a file instead. The run prints `findById`, a filtered query, and the rows
-remaining after an update + delete.
+`Main.kt` to persist to a file instead. The run prints a single-row `findOne` lookup, a filtered
+query, and the rows remaining after an update + delete.

--- a/samples/crud-sqlite/src/commonMain/kotlin/Main.kt
+++ b/samples/crud-sqlite/src/commonMain/kotlin/Main.kt
@@ -47,8 +47,8 @@ fun main() {
             Users.insertAll(listOf(user(1, "Alice", 30), user(2, "Bob", 25), user(3, "Carol", 41)))
         }
 
-        val carol = db.autocommit { Users.findById(3) }
-        println("findById(3) = ${carol?.name}")
+        val carol = db.autocommit { Users.findOne { where { Users.id eq 3 } } }
+        println("findOne(id=3) = ${carol?.name}")
 
         val over28 = db.autocommit { Users.find(Query(Users.age gt 28)) }
         println("age > 28   = ${over28.map { it.name }}")

--- a/samples/crud-sqlite/src/commonTest/kotlin/CrudSqliteTest.kt
+++ b/samples/crud-sqlite/src/commonTest/kotlin/CrudSqliteTest.kt
@@ -29,7 +29,7 @@ class CrudSqliteTest {
                 Users.insertAll(listOf(user(1, "Alice", 30), user(2, "Bob", 25), user(3, "Carol", 41)))
             }
 
-            assertEquals("Carol", db.autocommit { Users.findById(3) }?.name)
+            assertEquals("Carol", db.autocommit { Users.findOne { where { Users.id eq 3 } } }?.name)
             assertEquals(
                 listOf("Alice", "Carol"),
                 db.autocommit { Users.find(Query(Users.age gt 28)) }.mapNotNull { it.name },

--- a/samples/ktor-di/src/commonMain/kotlin/Application.kt
+++ b/samples/ktor-di/src/commonMain/kotlin/Application.kt
@@ -75,7 +75,7 @@ fun Application.configure() {
             val patch = call.receive<ProductDTO>().toDomain()
             val updated = call.transaction<AppCatalog, _> {
                 ProductTable.update(Query(ProductTable.id eq id), patch)
-                ProductTable.findById(id)
+                ProductTable.findOne { where { ProductTable.id eq id } }
             }
             call.respond(updated!!.toDto())
         }

--- a/samples/ktor-koin/src/commonMain/kotlin/Application.kt
+++ b/samples/ktor-koin/src/commonMain/kotlin/Application.kt
@@ -81,7 +81,7 @@ fun Application.configure() {
             val patch = call.receive<ProductDTO>().toDomain()
             val updated = call.transaction<AppCatalog, _> {
                 ProductTable.update(Query(ProductTable.id eq id), patch)
-                ProductTable.findById(id)
+                ProductTable.findOne { where { ProductTable.id eq id } }
             }
             call.respond(updated!!.toDto())
         }

--- a/samples/r2dbc/src/jvmMain/kotlin/Application.kt
+++ b/samples/r2dbc/src/jvmMain/kotlin/Application.kt
@@ -74,7 +74,7 @@ fun Application.configure() {
             val patch = call.receive<ProductDTO>().toDomain()
             val updated = call.transaction<AppCatalog, _> {
                 ProductTable.update(Query(ProductTable.id eq id), patch)
-                ProductTable.findById(id)
+                ProductTable.findOne { where { ProductTable.id eq id } }
             }
             call.respond(updated!!.toDto())
         }

--- a/samples/repository/src/commonMain/kotlin/Main.kt
+++ b/samples/repository/src/commonMain/kotlin/Main.kt
@@ -49,12 +49,12 @@ internal val ordersDdl =
 
 // ---- repositories (extend the copied Repository base, add domain queries) ----
 
-class UserRepository(db: SuspendDatabase<Shop>) : Repository<Shop, User>(db, Users) {
+class UserRepository(db: SuspendDatabase<Shop>) : Repository<Shop, User, Int>(db, Users, Users.id) {
     suspend fun adults(): List<User> = read { Users.find { where { Users.age gtEq 18 } } }
     fun observeAdults(): Flow<List<User>> = Users.observe(db) { where { Users.age gtEq 18 } }
 }
 
-class OrderRepository(db: SuspendDatabase<Shop>) : Repository<Shop, Order>(db, Orders)
+class OrderRepository(db: SuspendDatabase<Shop>) : Repository<Shop, Order, Int>(db, Orders, Orders.id)
 
 // ---- a service that needs a cross-repository transaction ----
 

--- a/samples/repository/src/commonMain/kotlin/Repository.kt
+++ b/samples/repository/src/commonMain/kotlin/Repository.kt
@@ -1,11 +1,13 @@
 package io.github.kormium.samples.repository
 
 import io.github.kormium.Catalog
+import io.github.kormium.Column
 import io.github.kormium.Entity
 import io.github.kormium.QueryBuilder
 import io.github.kormium.SuspendScope
 import io.github.kormium.Table
 import io.github.kormium.database.SuspendDatabase
+import io.github.kormium.eq
 import io.github.kormium.observe.observe
 import io.github.kormium.suspendAutocommit
 import io.github.kormium.suspendTransaction
@@ -21,11 +23,13 @@ import kotlinx.coroutines.flow.Flow
  * operations atomic, wrap their table operations in one outer `suspendTransaction { }` instead —
  * see [ShopService.register].
  */
-abstract class Repository<G : Catalog, T : Entity>(
+abstract class Repository<G : Catalog, T : Entity, ID>(
     protected val db: SuspendDatabase<G>,
     protected val table: Table<G, T>,
+    // The primary-key column, so `findById` is type-checked: passing the wrong id type won't compile.
+    private val idColumn: Column<ID, *, T>,
 ) {
-    suspend fun findById(id: Any): T? = read { table.findById(id) }
+    suspend fun findById(id: ID): T? = read { table.findOne { where { idColumn eq id } } }
     suspend fun all(): List<T> = read { table.all() }
     suspend fun insert(entity: T): T? = write { table.insert(entity) }
     suspend fun deleteWhere(block: QueryBuilder.() -> Unit): Long = write { table.deleteWhere(block) }

--- a/samples/sharding/src/commonMain/kotlin/Main.kt
+++ b/samples/sharding/src/commonMain/kotlin/Main.kt
@@ -7,6 +7,7 @@ import io.github.kormium.Table
 import io.github.kormium.autocommit
 import io.github.kormium.createSqliteDatabase
 import io.github.kormium.database.Database
+import io.github.kormium.eq
 import io.github.kormium.transaction
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
@@ -53,7 +54,7 @@ class ShardedAccounts(private val shards: List<Database<AccountsCatalog>>) {
         return shard
     }
 
-    fun get(id: Int): Account? = shards[shardOf(id)].autocommit { Accounts.findById(id) }
+    fun get(id: Int): Account? = shards[shardOf(id)].autocommit { Accounts.findOne { where { Accounts.id eq id } } }
 
     fun countPerShard(): List<Long> = shards.map { it.autocommit { Accounts.count() } }
 }

--- a/samples/sqlite-cache/src/commonMain/kotlin/Main.kt
+++ b/samples/sqlite-cache/src/commonMain/kotlin/Main.kt
@@ -8,6 +8,7 @@ import io.github.kormium.autocommit
 import io.github.kormium.createSqliteDatabase
 import io.github.kormium.database.Database
 import io.github.kormium.database.createDatabase
+import io.github.kormium.eq
 import io.github.kormium.transaction
 
 // Two catalogs: the same "products" shape lives in Postgres (source of truth) and in a
@@ -49,11 +50,11 @@ class ProductRepository(
     private val cache: Database<CacheCatalog>,
 ) {
     fun get(id: Int): Product? {
-        cache.autocommit { CachedProducts.findById(id) }?.let {
+        cache.autocommit { CachedProducts.findOne { where { CachedProducts.id eq id } } }?.let {
             println("cache HIT  $id")
             return it.toProduct()
         }
-        val fromPg = pg.autocommit { PgProducts.findById(id) }?.toProduct()
+        val fromPg = pg.autocommit { PgProducts.findOne { where { PgProducts.id eq id } } }?.toProduct()
         if (fromPg == null) {
             println("cache MISS $id (not in Postgres)")
             return null


### PR DESCRIPTION
Outcome of **#5 — auditing DSL compile-error quality**. An empirical pass (feeding typical agent mistakes through the compiler) surfaced two real type-safety holes, both fixed here, plus structural errors that can't be improved in-message and are instead pre-empted in `AGENTS.md`.

## 1. `findById(id: Any)` → typed `findOne` (breaking)

`findById` was the **only untyped read** in the API: `Users.findById("not-a-uuid")` for a `Uuid` key compiled and only failed at runtime, it bypassed the PK column's converter, and threw at runtime on a composite key — the exact footgun an agent hits reaching for the obvious call.

Removed (pre-1.0, no deprecation). New typed single-row read:

```kotlin
Users.findOne { where { Users.id eq id } }     // -> T?, applies LIMIT 1
Users.findOne(Query(Users.id eq id))
```

The id is type-checked against the column and bound through its converter; the same form reads by **any unique column**, not just the PK. A generic repository now carries the typed PK column (`Repository<G, T, ID>(db, table, idColumn)`) instead of `Any`. All call sites in tests, samples and docs migrated. **ADR 0005.**

## 2. `eq null` / `neq null` restricted to nullable columns

These render `IS [NOT] NULL`. The null overload's receiver was `Column<*,*,*>`, which **poisoned the most common error message**: `Users.age eq "x"` reported *"actual 'String', but 'Nothing?' was expected"* (against the null overload) instead of the real `eq(value: Z)` candidate.

Narrowing the receiver to `Column.NullableColumn<*,*,*>` makes that report *"'Int' was expected"* — and a meaningless `nonNullCol eq null` now fails to compile.

## 3. AGENTS.md Gotchas — pre-empt the structural errors

Some confusing compiler messages can't be improved (receiver-scoped DSL, parser-level). Documented instead: outside-scope → resolves to `kotlin.collections.find`; cross-catalog → "receiver type mismatch"; `orderBy` needs `ASC`/`DESC`; column-to-column comparisons aren't cross-type-checked.

## Verification

JVM tests green for core, sqlite, and the sqlite-based samples (`repository`, `crud-sqlite`); all-module JVM test sources compile; `kormium-sqlite-node` wasmJs test compiles. Native targets left to CI (same `commonTest` source already passes on JVM; target-specific test files verified to import `eq`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)