### PR TITLE
feat(core): ConcurrencyConflictException (typed signal, no retry helper)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,8 +317,31 @@ val saved = db.transaction { Users.insertAll(newUsers, returning = true) }
 
 ```kotlin
 val user = db.transaction {
-    Users.insertOrIgnore(newUser, onConflict = Users.id)   // 1 = inserted, 0 = already there
-    Users.findById(newUser.id)!!                           // the row either way
+    Users.insertOrIgnore(newUser, onConflict = Users.id)        // 1 = inserted, 0 = already there
+    Users.findOne { where { Users.id eq newUser.id } }!!        // the row either way
+}
+```
+
+**Retry a transaction on a transient conflict.** Under `SERIALIZABLE` / `REPEATABLE READ`, or on a
+deadlock, the database aborts one transaction with a `ConcurrencyConflictException` (SQLSTATE
+`40001` / `40P01`) — it is **safe to retry the whole transaction**. Kormium ships the typed
+exception, not a retry loop: the policy (attempts, backoff) is yours, and the block must be
+idempotent outside the DB since it re-runs.
+
+```kotlin
+fun <R> retrying(max: Int = 3, block: () -> R): R {
+    repeat(max - 1) {
+        try { return block() } catch (_: ConcurrencyConflictException) { /* transient: retry */ }
+    }
+    return block()   // last attempt: let it throw
+}
+
+retrying {
+    db.transaction(isolation = TransactionIsolation.SERIALIZABLE) {
+        val item = Items.findOne { where { Items.id eq id } } ?: error("no item")
+        require(item.stock > 0) { "out of stock" }
+        Items.update(Item().apply { stock = item.stock - 1 }) { where { Items.id eq id } }
+    }
 }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ All notable changes to Kormium are documented here. The format is based on
   including `onConflict = Table.primaryKey`, are unchanged. A runtime backstop still rejects an
   empty target — and the rare same-entity-other-table case — with a clear `IllegalArgumentException`
   naming the column and tables (#32).
+- **`ConcurrencyConflictException`** — a typed signal for a transient serialization failure / deadlock
+  (SQLSTATE `40001` / `40P01`), so a caller can catch one portable type instead of matching SQLSTATE
+  strings to know a transaction is safe to retry. Kormium ships the exception, not a retry loop (the
+  policy is the application's) — see the retry recipe in `AGENTS.md` and
+  [ADR 0007](docs/adr/0007-concurrency-conflict-exception.md).
 
 ### Changed
 - `Table.primaryKey` is now `List<Column<*, *, T>>` (was `List<Column<*, *, *>>`) and the table's

--- a/docs/adr/0007-concurrency-conflict-exception.md
+++ b/docs/adr/0007-concurrency-conflict-exception.md
@@ -1,0 +1,81 @@
+# ADR 0007 — `ConcurrencyConflictException` as a typed signal, not a retry helper
+
+- Status: Accepted
+- Date: 2026-07-01
+
+## Context
+
+Under `SERIALIZABLE` / `REPEATABLE READ`, or on a lock-order deadlock, a database aborts one of the
+competing transactions with a transient error (PostgreSQL `40001` serialization_failure / `40P01`
+deadlock_detected; MySQL maps a deadlock to `40001`). This is **expected** — PostgreSQL's own docs
+say applications using `SERIALIZABLE` must be prepared to retry — and the correct response is to
+**re-run the whole transaction**, not to fail.
+
+Before this, such failures surfaced as a generic `QueryException`, so a caller could only react by
+matching raw SQLSTATE strings (and knowing that MySQL hides a deadlock under `40001`).
+
+The obvious convenience would be a `transactionRetrying(maxAttempts, …) { }` helper in the library.
+
+## Decision
+
+Add a typed exception, **`ConcurrencyConflictException`** (subtype of `QueryException`), and map
+SQLSTATE `40001` / `40P01` to it in `sqlException()`. Do **not** ship a retry helper. The retry loop
+lives in application code, catching this one type.
+
+Split of responsibility:
+
+- **The library owns the knowledge** — "this database error means a transient, retryable conflict",
+  including the per-engine SQLSTATE quirks. A caller can't be expected to know that, so it belongs in
+  the typed exception. This is the part with real library value.
+- **The application owns the policy** — attempt count, backoff (none / fixed / jittered exponential),
+  whether to treat deadlock differently, per-retry metrics/logging, circuit-breaking. Any default the
+  library picked (e.g. 3 attempts, no backoff) would be too naive for production yet too opinionated
+  to belong in the core.
+
+```kotlin
+fun <R> retrying(max: Int = 3, block: () -> R): R {
+    repeat(max - 1) {
+        try { return block() } catch (_: ConcurrencyConflictException) { /* transient: retry */ }
+    }
+    return block()
+}
+retrying { db.transaction(isolation = TransactionIsolation.SERIALIZABLE) { … } }
+```
+
+## Consequences
+
+Positive:
+
+- Callers catch one clear, portable type instead of matching SQLSTATE strings across engines.
+- No hidden control flow in the library: a transaction block is never silently re-run by Kormium —
+  consistent with the project's "no hidden magic / expose primitives" stance.
+- The retried block's idempotency requirement (it re-runs, so no pre-commit side effects) stays
+  visible in the caller's own loop, instead of being buried in a library helper.
+- Sidesteps a real portability snag: there is no portable `sleep` in `commonMain`, so a library
+  backoff would be half-baked; the application uses its platform's own (`delay` / `Thread.sleep`).
+
+Negative / costs:
+
+- No turnkey retry — every caller writes (or copies) the small loop. Mitigated by a ready-made recipe
+  in `AGENTS.md`, which is also where an agent learns the pattern (docs are the right nudge — see
+  [ADR 0006](0006-no-idiomatic-path-nudge.md)).
+- `40001` covers both PostgreSQL serialization failures and MySQL deadlocks under one type; a caller
+  that needs to tell them apart still reads `sqlState`. Accepted — the actionable fact ("retryable")
+  is the same for both.
+
+## Alternatives considered
+
+- **`transactionRetrying(maxAttempts, backoff, …) { }` helper.** Rejected: retry policy is
+  application-specific, a fixed default is wrong for many, a configurable one bloats the core, and it
+  bakes hidden re-execution (and an idempotency footgun) into the library. The user made this call.
+- **Two subtypes (`SerializationFailureException` + `DeadlockException`).** Rejected as more surface
+  for no actionable difference — both mean "retry"; and `40001` already conflates the two across
+  engines. One `ConcurrencyConflictException` is the thing you catch.
+- **Leave it a generic `QueryException`.** Rejected: forces callers to hardcode SQLSTATE strings and
+  to know the MySQL-deadlock-as-`40001` quirk — exactly the knowledge the library should encode.
+
+## Notes
+
+Mirrors the reasoning of [ADR 0006](0006-no-idiomatic-path-nudge.md): the library provides the typed
+primitive and the documentation steers; it does not wrap application policy in API. Related:
+[[korm-prod-ready-work]].

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,3 +10,4 @@ rewrite.
 - [0004 — Subqueries: correlated `EXISTS` via `any` / `none`, not a subquery-as-value](0004-correlated-exists-any-none.md)
 - [0005 — No untyped `findById`; single-row reads via typed `findOne`](0005-no-untyped-findbyid.md)
 - [0006 — No idiomatic-path nudge (no `@RequiresOptIn` marker, no detekt rule)](0006-no-idiomatic-path-nudge.md)
+- [0007 — `ConcurrencyConflictException` as a typed signal, not a retry helper](0007-concurrency-conflict-exception.md)

--- a/kormium-core/src/commonMain/kotlin/Exceptions.kt
+++ b/kormium-core/src/commonMain/kotlin/Exceptions.kt
@@ -36,6 +36,19 @@ class CheckViolationException(message: String, sqlState: String?, cause: Throwab
     QueryException(message, sqlState, cause)
 
 /**
+ * A transient serialization failure or deadlock (SQLSTATE 40001 / 40P01): the database aborted this
+ * transaction to preserve isolation. It is **safe to retry** — re-run the whole transaction. This is
+ * expected under `SERIALIZABLE` / `REPEATABLE READ` and on lock-order deadlocks (PostgreSQL reports
+ * `40001` / `40P01`; MySQL maps a deadlock to `40001`).
+ *
+ * Kormium deliberately ships this typed signal but no retry loop: the retry policy — attempt count,
+ * backoff — is the application's, and the retried block must be idempotent outside the database since
+ * it re-runs. See the retry recipe in `AGENTS.md` and [ADR 0007](../../docs/adr/0007-concurrency-conflict-exception.md).
+ */
+class ConcurrencyConflictException(message: String, sqlState: String?, cause: Throwable? = null) :
+    QueryException(message, sqlState, cause)
+
+/**
  * A database row could not be mapped into an entity. The common case: a column the entity
  * declares non-null came back as SQL `NULL` (a schema mismatch or a bad row). The message names
  * the table and column so the offending row/schema is easy to find.
@@ -48,5 +61,6 @@ fun sqlException(message: String, sqlState: String?, cause: Throwable? = null): 
     "23503" -> ForeignKeyViolationException(message, sqlState, cause)
     "23502" -> NotNullViolationException(message, sqlState, cause)
     "23514" -> CheckViolationException(message, sqlState, cause)
+    "40001", "40P01" -> ConcurrencyConflictException(message, sqlState, cause)
     else -> QueryException(message, sqlState, cause)
 }

--- a/kormium-core/src/commonTest/kotlin/ExceptionsTest.kt
+++ b/kormium-core/src/commonTest/kotlin/ExceptionsTest.kt
@@ -1,0 +1,32 @@
+import io.github.kormium.CheckViolationException
+import io.github.kormium.ConcurrencyConflictException
+import io.github.kormium.ForeignKeyViolationException
+import io.github.kormium.NotNullViolationException
+import io.github.kormium.QueryException
+import io.github.kormium.UniqueViolationException
+import io.github.kormium.sqlException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ExceptionsTest {
+
+    @Test
+    fun mapsSqlStateToTheMostSpecificSubtype() {
+        assertTrue(sqlException("x", "23505") is UniqueViolationException)
+        assertTrue(sqlException("x", "23503") is ForeignKeyViolationException)
+        assertTrue(sqlException("x", "23502") is NotNullViolationException)
+        assertTrue(sqlException("x", "23514") is CheckViolationException)
+        // 40001 (serialization failure / MySQL deadlock) and 40P01 (PG deadlock) are retryable.
+        assertTrue(sqlException("x", "40001") is ConcurrencyConflictException)
+        assertTrue(sqlException("x", "40P01") is ConcurrencyConflictException)
+    }
+
+    @Test
+    fun unknownOrNullSqlStateStaysGeneric() {
+        val unknown = sqlException("x", "99999")
+        assertTrue(unknown !is ConcurrencyConflictException)
+        assertEquals("99999", unknown.sqlState)
+        assertEquals(QueryException::class, sqlException("x", null)::class)
+    }
+}


### PR DESCRIPTION
## What

A transient **serialization failure / deadlock** (SQLSTATE `40001` / `40P01`; MySQL maps a deadlock to `40001`) means the database aborted the transaction to preserve isolation — it is **safe to retry**. These surfaced as a generic `QueryException`, so a caller had to match raw SQLSTATE strings (and know the MySQL quirk) to react.

Maps `40001` / `40P01` → a typed **`ConcurrencyConflictException`** in `sqlException()`, so a caller catches one portable type.

## Decision: no retry helper (ADR 0007)

The library owns the **knowledge** (this error = retryable transient conflict, incl. per-engine SQLSTATE quirks); the application owns the **policy** (attempts, backoff, metrics). A `transactionRetrying { }` helper would bake hidden re-execution + an idempotency footgun into the core, pick a default that's wrong for many, and `commonMain` has no portable `sleep` for backoff. So: ship the typed exception, document the ~8-line retry loop as an `AGENTS.md` recipe (docs are the right nudge — same logic as ADR 0006).

```kotlin
fun <R> retrying(max: Int = 3, block: () -> R): R {
    repeat(max - 1) { try { return block() } catch (_: ConcurrencyConflictException) {} }
    return block()
}
retrying { db.transaction(isolation = TransactionIsolation.SERIALIZABLE) { … } }
```

## Also

Fixes a **stale `findById`** in the AGENTS.md find-or-create recipe — it lived in the Recipes section (added by #105) and never textually conflicted with the `findById` removal (#106), so it slipped through both merges.

## Verification

`kormium-core:jvmTest` green, incl. a new `ExceptionsTest` covering the `40001` / `40P01` → `ConcurrencyConflictException` mapping (and that unknown/null SQLSTATE stays generic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)