### PR TITLE
docs(adr): ADR 0008 — no RETURNING on UPDATE/DELETE

### DIFF
--- a/docs/adr/0008-no-returning-on-update-delete.md
+++ b/docs/adr/0008-no-returning-on-update-delete.md
@@ -1,0 +1,79 @@
+# ADR 0008 — No `RETURNING` on `UPDATE` / `DELETE`
+
+- Status: Accepted
+- Date: 2026-07-01
+
+## Context
+
+`INSERT ... RETURNING` is supported (via `insert(returning = true)` / `upsert(returning = true)`),
+so a write can hand back DB-generated values. A natural extension is `RETURNING` on `UPDATE` and
+`DELETE` — "update and return the new row", "delete and return what was removed" (audit / outbox).
+
+PostgreSQL and SQLite (3.35+) support `UPDATE … RETURNING` / `DELETE … RETURNING`. **MySQL does not
+have `RETURNING` at all** (`Dialect.supportsReturning = false`). For `INSERT` that gap is bridged by
+re-selecting the written row by primary key. The same trick does **not** carry over:
+
+- `DELETE … RETURNING` cannot be emulated by a re-select — the rows are gone after the delete.
+- `UPDATE … RETURNING` would need a three-step dance in one transaction: `SELECT` the matching PKs →
+  `UPDATE` → `SELECT … WHERE pk IN (…)`. Multiple statements, a single-column-PK requirement, and
+  subtle semantics if the predicate touches an updated column.
+
+This was implemented once early on and then dropped (no ADR was written — this records it).
+
+## Decision
+
+Do **not** model `RETURNING` on `UPDATE` / `DELETE`. `update { }` / `update(entity)` and
+`deleteWhere { }` return the **affected-row count** (`Long`), nothing more.
+
+To get the rows, be explicit, inside one transaction:
+
+```kotlin
+db.transaction {
+    Users.update(patch) { where { Users.id eq id } }
+    Users.findOne { where { Users.id eq id } }          // the updated row
+}
+db.transaction {
+    val doomed = Users.find { where { Users.status eq "expired" } }   // capture first
+    Users.deleteWhere { where { Users.status eq "expired" } }
+    doomed                                                // what was removed
+}
+```
+
+On PostgreSQL / SQLite, a one-statement `… RETURNING` is available through `RawExpression` /
+`execute(...)` for callers who specifically want it.
+
+## Consequences
+
+Positive:
+
+- **No hidden multi-statement magic.** Kormium's contract is "the SQL is exactly what the DSL
+  renders"; emulating `UPDATE … RETURNING` as select→update→select (or `DELETE` as select→delete)
+  would render *several* statements behind one call — the opposite of that contract.
+- **Uniform across engines.** No dialect-gated method that works on PostgreSQL/SQLite and throws on
+  MySQL — every write operation behaves the same on all three backends.
+- The explicit two-step form is clear, portable, and (in a transaction) race-safe.
+
+Negative / costs:
+
+- A one-statement atomic "modify and return" isn't first-class; the two-step form is two statements
+  (still one transaction). For the rare case where the single-statement form matters on
+  PostgreSQL/SQLite, drop to `RawExpression` / `execute(...)`.
+
+## Alternatives considered
+
+- **A — Emulate to stay uniform** (native `RETURNING` on PG/SQLite; MySQL via select-before-delete /
+  capture-PK→update→re-select, mirroring how `insert(returning)` re-selects). Rejected: it bakes
+  hidden multi-statement behaviour into one call, which contradicts "the SQL is what the DSL renders".
+  The `insert(returning)` precedent is *milder* — a single re-select of a row you just created by a
+  PK you supplied — and was accepted only because `INSERT … RETURNING` is so common; it does not
+  justify the heavier `UPDATE`/`DELETE` emulation.
+- **B — Dialect-gated, throwing on MySQL.** Rejected: it would be the first operation whose behaviour
+  is not uniform across engines (works on PG/SQLite, throws on MySQL), breaking a core property.
+
+## Notes
+
+`INSERT … RETURNING` stays (already shipped): its emulation is a single by-PK re-select, mild enough
+that the convenience won. The asymmetry is deliberate, not an oversight. Same reasoning family as
+[ADR 0004](0004-correlated-exists-any-none.md) (don't model what doesn't fit cleanly) and
+[ADR 0007](0007-concurrency-conflict-exception.md) (no hidden control flow in the library). Related:
+[[korm-ai-oriented-direction]].

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,3 +10,4 @@ rewrite.
 - [0004 — Subqueries: correlated `EXISTS` via `any` / `none`, not a subquery-as-value](0004-correlated-exists-any-none.md)
 - [0005 — No untyped `findById`; single-row reads via typed `findOne`](0005-no-untyped-findbyid.md)
 - [0006 — No idiomatic-path nudge (no `@RequiresOptIn` marker, no detekt rule)](0006-no-idiomatic-path-nudge.md)
+- [0008 — No `RETURNING` on `UPDATE` / `DELETE`](0008-no-returning-on-update-delete.md)


### PR DESCRIPTION
Records the decision (option **C**) to **not** model `RETURNING` on `UPDATE` / `DELETE`. This was implemented once early on and then dropped without an ADR — this finally writes it down.

## Why

- **MySQL has no `RETURNING` at all.** For `INSERT` the gap is bridged by re-selecting the written row by PK; that doesn't carry over: `DELETE` rows are gone, and `UPDATE … RETURNING` would need select→update→select.
- **Emulation (option A) is hidden multi-statement magic** — several statements behind one call, contradicting Kormium's "the SQL is exactly what the DSL renders". The `insert(returning)` precedent is milder (one by-PK re-select of a row you just created) and doesn't justify the heavier UPDATE/DELETE version.
- **Dialect-gating (option B)** that throws on MySQL would be the first non-uniform op across engines.

`update` / `deleteWhere` return the affected-row count; to get rows, do an explicit two-step in one transaction (`update` then `findOne`; `find` then `deleteWhere`), or drop to `RawExpression` on PG/SQLite. `INSERT … RETURNING` stays — the asymmetry is deliberate.

Doc-only (one ADR + index line).

> Note: the index line lands after 0006; PR #108 adds the 0007 line. If they race, the `README.md` merge keeps both (order 0007, 0008).

🤖 Generated with [Claude Code](https://claude.com/claude-code)