### PR TITLE
refactor(core): unify comparison operators onto Operand<Z>

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,7 +204,7 @@ val total  = Orders.total.sum()
 db.autocommit {
     (Users innerJoin Orders on (Users.id eq Orders.userId))
         .groupBy(Users.id)
-        .having(total gt Value(BigDecimal.fromInt(100)))
+        .having(total gt BigDecimal.fromInt(100))   // aggregate vs a typed literal, no Value(...) wrapper
         .select(Users.name, orders, total)
 }.forEach { row ->
     println("${row[Users.name]}: ${row[orders]} orders, ${row[total]}")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ All notable changes to Kormium are documented here. The format is based on
   non-null column the comparison is meaningless (it can never be NULL) and now fails to compile.
   This also makes a wrong-typed value comparison (`age eq "x"`) report against the real
   `eq(value)` candidate ("Int expected") instead of the null overload ("Nothing? expected").
+- **Comparison / membership operators unified onto `Operand<Z>`.** The typed-literal forms of `eq`,
+  `neq`, `less`, `lessEq`, `gt`, `gtEq`, `inList`, `between` and `like` were declared separately on
+  `Column` / `NumericExpr` / `StringExpr` / `CoalesceOp` / `CaseOp` (≈30 overloads, with gaps), and
+  aggregates had none. They are now defined once over a new `Operand<Z>` interface (a `Selectable`
+  that carries its `ColumnType`) that every typed expression implements. Existing code compiles
+  unchanged and renders identical SQL; the change is additive — the gaps close, so e.g. `case { … }
+  inList listOf(…)`, `col.coalesce(0) between 1..10` and `total.sum() gt 100` (no `Value(…)` wrapper)
+  now work uniformly. A new expression type composes for free.
 
 ## [0.8.0] — Cross-instance notifications, Windows async, expression UPDATE
 

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -360,7 +360,7 @@ val total = Orders.total.sum()
 val result = db.autocommit {
     (Users innerJoin Orders on (Users.id eq Orders.userId))
         .groupBy(Users.id)
-        .having(total gt Value(BigDecimal.fromInt(100)))
+        .having(total gt BigDecimal.fromInt(100))
         .select(Users.name, orders, total)
 }
 

--- a/kormium-core/src/commonMain/kotlin/Aggregate.kt
+++ b/kormium-core/src/commonMain/kotlin/Aggregate.kt
@@ -1,24 +1,23 @@
 package io.github.kormium
 
-import io.github.kormium.resultset.ResultSet
 import kotlin.jvm.JvmName
 
-// Aggregates are Selectable (appear in SELECT and are read from a ResultRow) and, since
-// Selectable is an Expression, can also appear in `having(...)` (e.g. `total gt Value(100)`).
+// Aggregates are Operand (appear in SELECT, are read from a ResultRow, and compare to a typed literal
+// like any operand — `total gt 100`), and since Operand is an Expression they also work in `having(...)`.
 
 /** `COUNT(*)` — the number of rows in the group. */
-fun count(): Selectable<Long> = object : Selectable<Long> {
+fun count(): Operand<Long> = object : Operand<Long> {
+    override val columnType = LongColumnType
     override fun toSql(builder: ParamBuilder) = "COUNT(*)"
-    override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Long? = rs.getLong(index)
     override fun resultKey() = "COUNT(*)"
 }
 
 /** `COUNT(column)` — the non-null values of the column in the group. */
-fun Column<*, *, *>.count(): Selectable<Long> {
+fun Column<*, *, *>.count(): Operand<Long> {
     val column = this
-    return object : Selectable<Long> {
+    return object : Operand<Long> {
+        override val columnType = LongColumnType
         override fun toSql(builder: ParamBuilder) = "COUNT(${column.toSql(builder)})"
-        override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Long? = rs.getLong(index)
         override fun resultKey() = "COUNT(${column.resultKey()})"
     }
 }
@@ -26,47 +25,47 @@ fun Column<*, *, *>.count(): Selectable<Long> {
 // MIN/MAX keep the column's type (read through its type mapping) — MIN/MAX of an integer is
 // still that integer. SUM is different: SUM over an integer column returns a wider type
 // server-side (Postgres: bigint), so reading it back through the Int mapping would overflow
-// (toInt() throws). The integer-family sum() overloads below therefore return Selectable<Long>
+// (toInt() throws). The integer-family sum() overloads below therefore return Operand<Long>
 // and read the aggregate as a Long; SUM of a BigDecimal/Double column keeps the column type
 // via the generic sum().
-fun <Z> Column<Z, *, *>.min(): Selectable<Z> = ColumnAggregate("MIN", this)
-fun <Z> Column<Z, *, *>.max(): Selectable<Z> = ColumnAggregate("MAX", this)
+fun <Z> Column<Z, *, *>.min(): Operand<Z> = ColumnAggregate("MIN", this)
+fun <Z> Column<Z, *, *>.max(): Operand<Z> = ColumnAggregate("MAX", this)
 
 /** `SUM(column)` for a non-integer column (e.g. BigDecimal/Double), read through its type. */
-fun <Z> Column<Z, *, *>.sum(): Selectable<Z> = ColumnAggregate("SUM", this)
+fun <Z> Column<Z, *, *>.sum(): Operand<Z> = ColumnAggregate("SUM", this)
 
 // More-specific sum() overloads for integer columns: they win overload resolution over the
-// generic sum() above and return Selectable<Long>, reading the (bigint) aggregate as a Long so
+// generic sum() above and return Operand<Long>, reading the (bigint) aggregate as a Long so
 // sums beyond Int.MAX_VALUE don't overflow. @JvmName disambiguates the otherwise-identical JVM
 // signatures (generic erasure collides with these).
 @JvmName("sumInt")
-fun Column<kotlin.Int, *, *>.sum(): Selectable<Long> = LongAggregate(this)
+fun Column<kotlin.Int, *, *>.sum(): Operand<Long> = LongAggregate(this)
 
 @JvmName("sumShort")
-fun Column<kotlin.Short, *, *>.sum(): Selectable<Long> = LongAggregate(this)
+fun Column<kotlin.Short, *, *>.sum(): Operand<Long> = LongAggregate(this)
 
 @JvmName("sumLong")
-fun Column<kotlin.Long, *, *>.sum(): Selectable<Long> = LongAggregate(this)
+fun Column<kotlin.Long, *, *>.sum(): Operand<Long> = LongAggregate(this)
 
-private class ColumnAggregate<Z>(private val fn: String, private val column: Column<Z, *, *>) : Selectable<Z> {
+private class ColumnAggregate<Z>(private val fn: String, private val column: Column<Z, *, *>) : Operand<Z> {
+    override val columnType: ColumnType<Z> = column.columnType
     override fun toSql(builder: ParamBuilder) = "$fn(${column.toSql(builder)})"
-    override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Z? = column.read(rs, index, typeMapper)
     override fun resultKey() = "$fn(${column.resultKey()})"
 }
 
 // SUM(column) read as a Long (the server-side bigint width), regardless of the column's own type.
-private class LongAggregate(private val column: Column<*, *, *>) : Selectable<Long> {
+private class LongAggregate(private val column: Column<*, *, *>) : Operand<Long> {
+    override val columnType = LongColumnType
     override fun toSql(builder: ParamBuilder) = "SUM(${column.toSql(builder)})"
-    override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Long? = rs.getLong(index)
     override fun resultKey() = "SUM(${column.resultKey()})"
 }
 
 /** `AVG(column)` as a Double. */
-fun Column<*, *, *>.avg(): Selectable<Double> {
+fun Column<*, *, *>.avg(): Operand<Double> {
     val column = this
-    return object : Selectable<Double> {
+    return object : Operand<Double> {
+        override val columnType = DoubleColumnType
         override fun toSql(builder: ParamBuilder) = "AVG(${column.toSql(builder)})"
-        override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Double? = rs.getDouble(index)
         override fun resultKey() = "AVG(${column.resultKey()})"
     }
 }

--- a/kormium-core/src/commonMain/kotlin/Column.kt
+++ b/kormium-core/src/commonMain/kotlin/Column.kt
@@ -34,8 +34,8 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
     /** Rendered SQL column identifier. Equals [fieldKey] unless a custom name was supplied. */
     val name: String,
     val nullable: kotlin.Boolean,
-    val columnType: ColumnType<Z>,
-) : Expression, Selectable<Z> {
+    override val columnType: ColumnType<Z>,
+) : Expression, Operand<Z> {
 
     open fun init() {
         logger.trace { "init column $fieldKey (sql: $name)" }
@@ -54,10 +54,6 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
 
     /** Whether this column is part of the table's primary key. */
     internal var isPrimaryKey: kotlin.Boolean = false
-
-    // As a selectable, read its value via its column type (its toSql is the SELECT SQL).
-    override fun read(rs: ResultSet, index: kotlin.Int, typeMapper: TypeMapper): Z? =
-        columnType.read(rs, index)
 
     // The property delegate yields a fresh Column per access, so identity can't key a result row;
     // table+SQL-name is the stable, dialect-independent key (aggregates embed this for their target).

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -147,37 +147,43 @@ abstract class ComparisonOp(
 class EqOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "=")
 
 infix fun <T : Expression, T2 : Expression> T.eq(other: T2): Expression = EqOp(this, other)
-infix fun <Z> Column<Z, *, *>.eq(value: Z): Expression = EqOp(this, Value(bindParam(value)))
 
 /** Checks that the operands are not equal. */
 class NeqOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "<>")
 
 infix fun <T : Expression, T2 : Expression> T.neq(other: T2): Expression = NeqOp(this, other)
-infix fun <Z> Column<Z, *, *>.neq(value: Z): Expression = NeqOp(this, Value(bindParam(value)))
 
 /** Checks that the left operand is less than the right. */
 class LessOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "<")
 
 infix fun <T : Expression, T2 : Expression> T.less(other: T2): Expression = LessOp(this, other)
-infix fun <Z> Column<Z, *, *>.less(value: Z): Expression = LessOp(this, Value(bindParam(value)))
 
 /** Checks that the left operand is less than or equal to the right. */
 class LessEqOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "<=")
 
 infix fun <T : Expression, T2 : Expression> T.lessEq(other: T2): Expression = LessEqOp(this, other)
-infix fun <Z> Column<Z, *, *>.lessEq(value: Z): Expression = LessEqOp(this, Value(bindParam(value)))
 
 /** Checks that the left operand is greater than the right. */
 class GreaterOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, ">")
 
 infix fun <T : Expression, T2 : Expression> T.gt(other: T2): Expression = GreaterOp(this, other)
-infix fun <Z> Column<Z, *, *>.gt(value: Z): Expression = GreaterOp(this, Value(bindParam(value)))
 
 /** Checks that the left operand is greater than or equal to the right. */
 class GreaterEqOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, ">=")
 
 infix fun <T : Expression, T2 : Expression> T.gtEq(other: T2): Expression = GreaterEqOp(this, other)
-infix fun <Z> Column<Z, *, *>.gtEq(value: Z): Expression = GreaterEqOp(this, Value(bindParam(value)))
+
+// The typed-value forms of the comparison and membership operators are defined ONCE over [Operand]
+// (a [Selectable] that carries its [ColumnType] — a Column, aggregate, arithmetic, COALESCE, CASE or
+// string function), so every operand compares to a same-typed literal the same way, the literal binds
+// through the operand's column type, and a new operand type composes for free. Operand-to-operand and
+// column-to-column comparisons go through the generic `Expression` operators above.
+infix fun <Z> Operand<Z>.eq(value: Z): Expression = EqOp(this, columnType.lit(value))
+infix fun <Z> Operand<Z>.neq(value: Z): Expression = NeqOp(this, columnType.lit(value))
+infix fun <Z> Operand<Z>.less(value: Z): Expression = LessOp(this, columnType.lit(value))
+infix fun <Z> Operand<Z>.lessEq(value: Z): Expression = LessEqOp(this, columnType.lit(value))
+infix fun <Z> Operand<Z>.gt(value: Z): Expression = GreaterOp(this, columnType.lit(value))
+infix fun <Z> Operand<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, columnType.lit(value))
 
 /** `column IN (v1, v2, ...)`. An empty list renders to `FALSE` (matches nothing). */
 class InListOp(private val column: Expression, private val values: List<*>) : Expression {
@@ -186,7 +192,7 @@ class InListOp(private val column: Expression, private val values: List<*>) : Ex
         else "${column.toSql(builder)} IN (${values.joinToString(", ") { builder.bind(it) }})"
 }
 
-infix fun <Z> Column<Z, *, *>.inList(values: List<Z>): Expression = InListOp(this, values.map { bindParam(it) })
+infix fun <Z> Operand<Z>.inList(values: List<Z>): Expression = InListOp(this, values.map { columnType.lit(it).value })
 
 /** The SQL `FALSE` literal — what a predicate over an empty set (`inList`, `between`) renders to. */
 internal object FalseExpression : Expression {
@@ -199,23 +205,22 @@ class BetweenOp(private val expr: Expression, private val low: Expression, priva
         "${expr.toSql(builder)} BETWEEN ${low.toSql(builder)} AND ${high.toSql(builder)}"
 }
 
-// `column between lo..hi` — inclusive both ends (SQL BETWEEN == Kotlin `..`). The Comparable bound
-// admits exactly the orderable column types (numbers, dates, text) and rejects Json/Bytes/Uuid at
-// compile time, where BETWEEN is meaningless. A reversed/empty range (lo > hi) renders to FALSE,
-// like an empty `inList`. Bounds bind through the column's converter, as in `eq` / `gtEq`.
-infix fun <Z : Comparable<Z>> Column<Z, *, *>.between(range: ClosedRange<Z>): Expression =
-    if (range.isEmpty()) FalseExpression
-    else BetweenOp(this, Value(bindParam(range.start)), Value(bindParam(range.endInclusive)))
-
-/** `(a + b) between lo..hi` — `between` over an arithmetic operand. */
-infix fun <Z : Comparable<Z>> NumericExpr<Z>.between(range: ClosedRange<Z>): Expression =
+// `operand between lo..hi` — inclusive both ends (SQL BETWEEN == Kotlin `..`). The Comparable bound
+// admits exactly the orderable types (numbers, dates, text) and rejects Json/Bytes/Uuid at compile
+// time, where BETWEEN is meaningless. A reversed/empty range (lo > hi) renders to FALSE, like an
+// empty `inList`. Bounds bind through the operand's column type, as in `eq` / `gtEq`.
+infix fun <Z : Comparable<Z>> Operand<Z>.between(range: ClosedRange<Z>): Expression =
     if (range.isEmpty()) FalseExpression
     else BetweenOp(this, columnType.lit(range.start), columnType.lit(range.endInclusive))
 
-/** `column LIKE pattern` (text columns only). */
+/** `column LIKE pattern` (text operands only). */
 class LikeOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "LIKE")
 
-infix fun Column<String, *, *>.like(pattern: String): Expression = LikeOp(this, Value(pattern))
+// `like` has no generic Expression form, so both the literal-pattern and operand-to-operand forms
+// live here. A bare string comparison follows the engine collation (see docs) — wrap both sides in
+// `lower()` for deterministic case folding.
+infix fun Operand<String>.like(pattern: String): Expression = LikeOp(this, Value(pattern))
+infix fun Operand<String>.like(other: Operand<String>): Expression = LikeOp(this, other)
 
 /** `column IS NULL` / `column IS NOT NULL`. */
 class IsNullOp(private val column: Expression, private val negated: Boolean) : Expression {
@@ -236,14 +241,22 @@ infix fun Column.NullableColumn<*, *, *>.eq(value: Nothing?): Expression = IsNul
 infix fun Column.NullableColumn<*, *, *>.neq(value: Nothing?): Expression = IsNullOp(this, true)
 
 /**
- * A typed numeric operand: a [Column] participates via the operators below, and every arithmetic
- * result is itself a [NumericExpr] of the same type [Z], so expressions chain and nest while
- * staying type-checked (`(base + bonus) * 2`). Carrying [columnType] lets a literal on either side
- * bind through the originating column's converter rather than a guessed mapping.
+ * A typed SQL operand: a [Selectable] that knows the [ColumnType] of the value it yields. Every
+ * comparable expression is one — a [Column], an aggregate, arithmetic, COALESCE, CASE, a string
+ * function — so the comparison / membership operators (`eq`, `gt`, `inList`, `between`, `like`) are
+ * defined once over `Operand<Z>` instead of per type, and reading a row defaults to the column type.
+ * Carrying [columnType] also lets a compared literal bind through the originating column's converter.
  */
-interface NumericExpr<Z> : Selectable<Z> {
+interface Operand<Z> : Selectable<Z> {
     val columnType: ColumnType<Z>
+    override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z? = columnType.read(rs, index)
 }
+
+/**
+ * A typed numeric operand: every arithmetic result is itself a [NumericExpr] of the same type [Z],
+ * so expressions chain and nest while staying type-checked (`(base + bonus) * 2`).
+ */
+interface NumericExpr<Z> : Operand<Z>
 
 /**
  * Arithmetic node: renders `left op right`, binding any literal as a parameter. A nested
@@ -258,8 +271,6 @@ class ArithmeticOp<Z>(
     override val columnType: ColumnType<Z>,
 ) : NumericExpr<Z> {
     override fun toSql(builder: ParamBuilder): String = "${render(left, builder)} $opSign ${render(right, builder)}"
-
-    override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z? = columnType.read(rs, index)
 
     override fun resultKey(): Any = "(${structuralKey(left)} $opSign ${structuralKey(right)})"
 
@@ -311,15 +322,6 @@ operator fun <Z> NumericExpr<Z>.rem(value: Z): NumericExpr<Z> = ArithmeticOp(thi
 operator fun <Z> NumericExpr<Z>.rem(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
 operator fun <Z> NumericExpr<Z>.rem(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
 
-// Compare a nested arithmetic expression to a same-typed literal: `(likes - dislikes) gtEq 100`.
-// (NumericExpr-vs-Column/Expression already works through the generic comparison operators.)
-infix fun <Z> NumericExpr<Z>.eq(value: Z): Expression = EqOp(this, columnType.lit(value))
-infix fun <Z> NumericExpr<Z>.neq(value: Z): Expression = NeqOp(this, columnType.lit(value))
-infix fun <Z> NumericExpr<Z>.less(value: Z): Expression = LessOp(this, columnType.lit(value))
-infix fun <Z> NumericExpr<Z>.lessEq(value: Z): Expression = LessEqOp(this, columnType.lit(value))
-infix fun <Z> NumericExpr<Z>.gt(value: Z): Expression = GreaterOp(this, columnType.lit(value))
-infix fun <Z> NumericExpr<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, columnType.lit(value))
-
 /**
  * A typed string-valued SQL expression. A string [Column] yields one via the scalar functions
  * below (`lower()`, `upper()`, `trim()`, `ltrim()`, `rtrim()`), and each returns another
@@ -328,7 +330,9 @@ infix fun <Z> NumericExpr<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, colu
  * `less` / `lessEq` against a `String` literal, or — through the generic expression operators —
  * against another [StringExpr] (`a.lower() eq b.lower()`).
  */
-interface StringExpr : Selectable<String>
+interface StringExpr : Operand<String> {
+    override val columnType: ColumnType<String> get() = TextColumnType
+}
 
 /**
  * A scalar SQL function rendered as `FN(arg, ...)`. The string-returning ones are [StringExpr],
@@ -337,7 +341,6 @@ interface StringExpr : Selectable<String>
  */
 class StringFunction(private val fn: String, private val args: List<Expression>) : StringExpr {
     override fun toSql(builder: ParamBuilder): String = "$fn(${args.joinToString(", ") { it.toSql(builder) }})"
-    override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): String? = rs.getString(index)
     override fun resultKey(): Any =
         "$fn(${args.joinToString(", ") { structuralKey(it).toString() }})"
 }
@@ -364,25 +367,11 @@ fun StringExpr.rtrim(): StringExpr = StringFunction("RTRIM", listOf(this))
 class LengthOp(private val arg: Expression) : NumericExpr<Int> {
     override val columnType: ColumnType<Int> = IntColumnType
     override fun toSql(builder: ParamBuilder): String = builder.dialect.renderCharLength(arg.toSql(builder))
-    override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Int? = columnType.read(rs, index)
     override fun resultKey(): Any = "CHAR_LENGTH(${structuralKey(arg)})"
 }
 
 fun Column<String, *, *>.length(): NumericExpr<Int> = LengthOp(this)
 fun StringExpr.length(): NumericExpr<Int> = LengthOp(this)
-
-// Comparing a StringExpr to a String literal. (StringExpr-to-StringExpr comparison already works
-// through the generic `Expression` operators above.) `like` has no generic form, so both its
-// literal and StringExpr forms are provided here. Note: a bare string comparison follows the
-// engine's collation (see docs) — wrap both sides in `lower()` for deterministic case folding.
-infix fun StringExpr.like(pattern: String): Expression = LikeOp(this, Value(pattern))
-infix fun StringExpr.like(other: StringExpr): Expression = LikeOp(this, other)
-infix fun StringExpr.eq(value: String): Expression = EqOp(this, Value(value))
-infix fun StringExpr.neq(value: String): Expression = NeqOp(this, Value(value))
-infix fun StringExpr.less(value: String): Expression = LessOp(this, Value(value))
-infix fun StringExpr.lessEq(value: String): Expression = LessEqOp(this, Value(value))
-infix fun StringExpr.gt(value: String): Expression = GreaterOp(this, Value(value))
-infix fun StringExpr.gtEq(value: String): Expression = GreaterEqOp(this, Value(value))
 
 /**
  * `COALESCE(a, b, ...)` — the first non-null argument. It is a [Selectable] (readable from a
@@ -394,10 +383,9 @@ infix fun StringExpr.gtEq(value: String): Expression = GreaterEqOp(this, Value(v
  */
 class CoalesceOp<Z> internal constructor(
     internal val args: List<Expression>,
-    internal val columnType: ColumnType<Z>,
-) : Selectable<Z> {
+    override val columnType: ColumnType<Z>,
+) : Operand<Z> {
     override fun toSql(builder: ParamBuilder): String = "COALESCE(${args.joinToString(", ") { it.toSql(builder) }})"
-    override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z? = columnType.read(rs, index)
     override fun resultKey(): Any = "COALESCE(${args.joinToString(", ") { structuralKey(it).toString() }})"
 }
 
@@ -416,15 +404,6 @@ fun <Z> CoalesceOp<Z>.coalesce(vararg others: Column<Z, *, *>): CoalesceOp<Z> =
 fun <Z> CoalesceOp<Z>.coalesce(default: Z): CoalesceOp<Z> =
     CoalesceOp(args + columnType.lit(default), columnType)
 
-// Comparing a COALESCE to a typed literal binds it through the source column's converter.
-// (COALESCE-to-expression comparison already works through the generic operators above.)
-infix fun <Z> CoalesceOp<Z>.eq(value: Z): Expression = EqOp(this, columnType.lit(value))
-infix fun <Z> CoalesceOp<Z>.neq(value: Z): Expression = NeqOp(this, columnType.lit(value))
-infix fun <Z> CoalesceOp<Z>.less(value: Z): Expression = LessOp(this, columnType.lit(value))
-infix fun <Z> CoalesceOp<Z>.lessEq(value: Z): Expression = LessEqOp(this, columnType.lit(value))
-infix fun <Z> CoalesceOp<Z>.gt(value: Z): Expression = GreaterOp(this, columnType.lit(value))
-infix fun <Z> CoalesceOp<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, columnType.lit(value))
-
 /**
  * A searched `CASE WHEN cond THEN value ... ELSE default END`. It is a [Selectable] (readable from
  * a `select(...)` projection) carrying the [columnType] that reads the result back and binds each
@@ -435,15 +414,13 @@ infix fun <Z> CoalesceOp<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, colum
 class CaseOp<Z> internal constructor(
     private val branches: List<Pair<Expression, Expression>>,
     private val elseValue: Expression?,
-    internal val columnType: ColumnType<Z>,
-) : Selectable<Z> {
+    override val columnType: ColumnType<Z>,
+) : Operand<Z> {
     override fun toSql(builder: ParamBuilder): String {
         val whens = branches.joinToString(" ") { (cond, value) -> "WHEN ${cond.toSql(builder)} THEN ${value.toSql(builder)}" }
         val elseSql = elseValue?.let { " ELSE ${it.toSql(builder)}" }.orEmpty()
         return "CASE $whens$elseSql END"
     }
-
-    override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z? = columnType.read(rs, index)
 
     // Key off the CASE rendered with its branch literals inlined (key-mode builder): that captures
     // the conditions and values — including literals that normally render as placeholders — so two
@@ -517,13 +494,6 @@ inline fun <reified Z> case(noinline block: CaseBuilder<Z>.() -> Unit): CaseOp<Z
     } as ColumnType<Z>
     return case(columnType, block)
 }
-
-infix fun <Z> CaseOp<Z>.eq(value: Z): Expression = EqOp(this, columnType.lit(value))
-infix fun <Z> CaseOp<Z>.neq(value: Z): Expression = NeqOp(this, columnType.lit(value))
-infix fun <Z> CaseOp<Z>.less(value: Z): Expression = LessOp(this, columnType.lit(value))
-infix fun <Z> CaseOp<Z>.lessEq(value: Z): Expression = LessEqOp(this, columnType.lit(value))
-infix fun <Z> CaseOp<Z>.gt(value: Z): Expression = GreaterOp(this, columnType.lit(value))
-infix fun <Z> CaseOp<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, columnType.lit(value))
 
 /** Groups an expression in parentheses so it composes safely with surrounding `AND`/`OR`. */
 class ParenExpression(private val expr: Expression) : Expression {

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -126,6 +126,52 @@ class SqliteIntegrationTest {
         db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
     }
 
+    /**
+     * Gaps the `Operand<Z>` unification closed: the comparison/membership operators now live once on
+     * every typed operand, so CASE composes with `inList`, COALESCE with `between`, and an aggregate
+     * compares to a typed literal directly (no `Value(...)` wrapper).
+     */
+    @Test
+    fun testOperandAlgebraClosesGaps() {
+        val tag = "operand-${Uuid.random()}"
+        db.transaction {
+            Products.execSql(productsDdl)
+            Products.insert(Product().apply { id = Uuid.random(); price = BigDecimal.fromInt(1); qty = 100; displayName = tag; note = null; rank = 5 })
+            Products.insert(Product().apply { id = Uuid.random(); price = BigDecimal.fromInt(1); qty = 5; displayName = tag; note = null; rank = null })
+        }
+
+        // CASE inList — CASE was eq/neq-only before; now any operand supports inList.
+        val big = db.autocommit {
+            Products.find {
+                where {
+                    (Products.displayName eq tag) and (case<String> {
+                        whenever(Products.qty gtEq 100) then "big"
+                        otherwise("small")
+                    } inList listOf("big"))
+                }
+            }
+        }
+        assertEquals(listOf(100), big.map { it.qty })
+
+        // COALESCE between — the null-rank row coalesces to 0 and falls in 0..0.
+        val zeroRank = db.autocommit {
+            Products.find { where { (Products.displayName eq tag) and (Products.rank.coalesce(0) between 0..0) } }
+        }
+        assertEquals(listOf(5), zeroRank.map { it.qty })
+
+        // Aggregate compared to a typed literal directly — no Value(...) wrapper.
+        val grouped = db.autocommit {
+            Products.query()
+                .where(Products.displayName eq tag)
+                .groupBy(Products.displayName)
+                .having(Products.qty.sum() gt 100L)   // SUM(qty) = 105
+                .select(Products.displayName)
+        }
+        assertEquals(1, grouped.size)
+
+        db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
+    }
+
     @Test
     fun testUpsertInsertOrIgnoreAndBatchOrder() {
         db.transaction { Products.execSql(productsDdl) }


### PR DESCRIPTION
Centrepiece of the pre-release **consistency consolidation** (axes 1, 2, 4 of the audit). No new feature — this makes the expression algebra closed, uniform and extensible by *removing* surface.

## Problem (audit Exhibit A)

The typed-literal comparison/membership operators were declared **per expression type**:

| Type | eq/neq/less/lessEq/gt/gtEq | inList | between | like |
|---|---|---|---|---|
| `Column<Z>` | ✅ | ✅ | ✅ | ✅ |
| `NumericExpr<Z>` | ✅ | ❌ | ✅ | — |
| `StringExpr` | ✅ | ❌ | ❌ | ✅ |
| `CoalesceOp<Z>` / `CaseOp<Z>` | ✅ | ❌ | ❌ | — |
| aggregates | ❌ (needed `Value(...)`) | ❌ | ❌ | — |

≈30 near-identical overloads, real gaps, and **not extensible** — a new operand type (window functions, …) would re-add the whole matrix.

## Change

Introduce `interface Operand<Z> : Selectable<Z> { val columnType: ColumnType<Z>; /* default read */ }` and define the operators **once** over `Operand<Z>`. `Column`, `NumericExpr`, `StringExpr`, `CoalesceOp`, `CaseOp` and the aggregates all implement it. ~30 overloads → ~8; the default `read` also dedups per-node readers.

Gaps now closed (additive): `case { … } inList listOf(…)`, `col.coalesce(0) between 1..10`, `total.sum() gt 100` (no `Value(…)`).

## Compatibility — nothing changes for the user

Source-compatible: every existing call site compiles unchanged and renders **identical** SQL (`columnType.lit` ≡ `Column.bindParam`; `TextColumnType.toParam` is identity). Purely additive — nothing that compiled stops compiling. (Not binary-compatible — moot pre-1.0.)

**Verified:** `kormium-core` + `kormium-sqlite` suites green; **all** module JVM test sources and **all** samples compile unchanged; new `testOperandAlgebraClosesGaps` exercises the newly-closed gaps. Native/wasm left to CI (same commonMain source).

## Follow-ups (separate PRs)

1. Naming variant **L** (`less`→`lt`, `lessEq`→`ltEq`) — the call-site sweep, kept out of this source-compatible refactor.
2. `isNull()` / `eq null` on `Operand` (computed nullable exprs).
3. Doc fixes (`conflict=`→`onConflict=`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)