### PR TITLE
refactor(core)!: rename predicates less -> lt, lessEq -> ltEq

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ val all: List<User> = db.autocommit { Users.all() }
 val n: Long       = db.autocommit { Users.count { where { Users.age gtEq 18 } } }
 ```
 
-Predicates: `eq`, `neq`, `gt`, `gtEq`, `less`, `lessEq`, `between (lo..hi)`, `like`,
+Predicates: `eq`, `neq`, `gt`, `gtEq`, `lt`, `ltEq`, `between (lo..hi)`, `like`,
 `inList(...)`, `eq null` / `neq null` (render as `IS [NOT] NULL`), combined with
 `and` / `or` / `not(...)`. Values are typed (`Users.age eq 18`, not `"18"`) and always bound
 as parameters. `between` takes an inclusive Kotlin range (`Users.age between 18..65`); an empty
@@ -269,7 +269,7 @@ of an ordered, unique key:
 ```kotlin
 fun page(after: Instant?, size: Int = 50) = db.autocommit {
     Users.find {
-        if (after != null) where { Users.createdAt less after }
+        if (after != null) where { Users.createdAt lt after }
         orderBy DESC Users.createdAt
         limit = size
     }
@@ -360,7 +360,7 @@ retrying {
 - `eq null` / `neq null` (→ `IS [NOT] NULL`) work only on **nullable** columns; on a non-null column
   they don't compile (it can never be NULL).
 - `orderBy` needs a direction — `orderBy ASC col` / `orderBy DESC col`; bare `orderBy col` is a syntax error.
-- Predicate names are `less` / `lessEq` (not `lt` / `ltEq`) and `neq` (not `ne`).
+- Predicate names are `lt` / `ltEq` (not `less` / `lessEq` or `<`) and `neq` (not `ne`).
 - Read nullable join columns with `getOrNull`; `row[col]` throws on NULL/absent.
 - Not modeled by the typed DSL: subqueries other than correlated `EXISTS` (use `any`/`none`; scalar →
   compare against a `RawExpression`), `UNION`, CTEs, window functions, `RIGHT`/`FULL`/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,13 +49,16 @@ All notable changes to Kormium are documented here. The format is based on
   This also makes a wrong-typed value comparison (`age eq "x"`) report against the real
   `eq(value)` candidate ("Int expected") instead of the null overload ("Nothing? expected").
 - **Comparison / membership operators unified onto `Operand<Z>`.** The typed-literal forms of `eq`,
-  `neq`, `less`, `lessEq`, `gt`, `gtEq`, `inList`, `between` and `like` were declared separately on
+  `neq`, `lt`, `ltEq`, `gt`, `gtEq`, `inList`, `between` and `like` were declared separately on
   `Column` / `NumericExpr` / `StringExpr` / `CoalesceOp` / `CaseOp` (≈30 overloads, with gaps), and
   aggregates had none. They are now defined once over a new `Operand<Z>` interface (a `Selectable`
   that carries its `ColumnType`) that every typed expression implements. Existing code compiles
   unchanged and renders identical SQL; the change is additive — the gaps close, so e.g. `case { … }
   inList listOf(…)`, `col.coalesce(0) between 1..10` and `total.sum() gt 100` (no `Value(…)` wrapper)
   now work uniformly. A new expression type composes for free.
+- **Predicates renamed `less` → `lt`, `lessEq` → `ltEq`.** The comparison operators are now symmetric
+  (`lt` / `ltEq` paired with `gt` / `gtEq`, instead of the abbreviated `gt` against the spelled-out
+  `less`), matching the common `lt`/`gt` convention. `eq` / `neq` / `gt` / `gtEq` are unchanged.
 
 ## [0.8.0] — Cross-instance notifications, Windows async, expression UPDATE
 

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -26,7 +26,7 @@ val adults: List<User> = db.autocommit {
 ```kotlin
 Users.find { where { Users.id eq id } }
 Users.find { where { Users.age gt 18 } }
-Users.find { where { Users.age lessEq 65 } }
+Users.find { where { Users.age ltEq 65 } }
 Users.find { where { Users.age between 18..65 } }     // inclusive both ends
 Users.find { where { Users.name like "A%" } }
 Users.find { where { Users.id inList listOf(id1, id2) } }
@@ -448,7 +448,7 @@ Not modeled by the typed DSL today:
   on `UPDATE` / `DELETE`, no `LOCK` / `FOR UPDATE` clauses, and no DDL through the query DSL.
   (`INSERT ... ON CONFLICT` *is* available — see `upsert` and `insertOrIgnore`.)
 
-The supported `WHERE` / `HAVING` predicates are exactly: `eq`, `neq`, `less`, `lessEq`, `gt`,
+The supported `WHERE` / `HAVING` predicates are exactly: `eq`, `neq`, `lt`, `ltEq`, `gt`,
 `gtEq`, `between` (an inclusive `lo..hi` range; an empty range matches nothing), `like`,
 `inList`, `eq null` / `neq null` (rendered as `IS [NOT] NULL`), and the `and` / `or` / `not(...)`
 combinators.

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -156,12 +156,12 @@ infix fun <T : Expression, T2 : Expression> T.neq(other: T2): Expression = NeqOp
 /** Checks that the left operand is less than the right. */
 class LessOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "<")
 
-infix fun <T : Expression, T2 : Expression> T.less(other: T2): Expression = LessOp(this, other)
+infix fun <T : Expression, T2 : Expression> T.lt(other: T2): Expression = LessOp(this, other)
 
 /** Checks that the left operand is less than or equal to the right. */
 class LessEqOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "<=")
 
-infix fun <T : Expression, T2 : Expression> T.lessEq(other: T2): Expression = LessEqOp(this, other)
+infix fun <T : Expression, T2 : Expression> T.ltEq(other: T2): Expression = LessEqOp(this, other)
 
 /** Checks that the left operand is greater than the right. */
 class GreaterOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, ">")
@@ -180,8 +180,8 @@ infix fun <T : Expression, T2 : Expression> T.gtEq(other: T2): Expression = Grea
 // column-to-column comparisons go through the generic `Expression` operators above.
 infix fun <Z> Operand<Z>.eq(value: Z): Expression = EqOp(this, columnType.lit(value))
 infix fun <Z> Operand<Z>.neq(value: Z): Expression = NeqOp(this, columnType.lit(value))
-infix fun <Z> Operand<Z>.less(value: Z): Expression = LessOp(this, columnType.lit(value))
-infix fun <Z> Operand<Z>.lessEq(value: Z): Expression = LessEqOp(this, columnType.lit(value))
+infix fun <Z> Operand<Z>.lt(value: Z): Expression = LessOp(this, columnType.lit(value))
+infix fun <Z> Operand<Z>.ltEq(value: Z): Expression = LessEqOp(this, columnType.lit(value))
 infix fun <Z> Operand<Z>.gt(value: Z): Expression = GreaterOp(this, columnType.lit(value))
 infix fun <Z> Operand<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, columnType.lit(value))
 
@@ -327,7 +327,7 @@ operator fun <Z> NumericExpr<Z>.rem(other: NumericExpr<Z>): NumericExpr<Z> = Ari
  * below (`lower()`, `upper()`, `trim()`, `ltrim()`, `rtrim()`), and each returns another
  * [StringExpr], so they chain (`name.trim().lower()`). Being a [Selectable] it can also be read
  * back from a row in `select(...)`. Compare it with `eq` / `neq` / `like` / `gt` / `gtEq` /
- * `less` / `lessEq` against a `String` literal, or — through the generic expression operators —
+ * `lt` / `ltEq` against a `String` literal, or — through the generic expression operators —
  * against another [StringExpr] (`a.lower() eq b.lower()`).
  */
 interface StringExpr : Operand<String> {


### PR DESCRIPTION
Audit axis 5 (naming), variant **L**. Makes the comparison operators symmetric.

## Why

The predicates were asymmetric: `gt` / `gtEq` (abbreviated) against `less` / `lessEq` (spelled out). Renaming `less` → `lt` and `lessEq` → `ltEq` gives a uniform `lt`/`ltEq`/`gt`/`gtEq` set — the common cross-language convention, and what callers (and AI agents) type by default. It also removes the recurring "unresolved reference `lt`" stumble (seen in the #5 compile-error audit). `eq` / `neq` / `gt` / `gtEq` are unchanged.

## Scope

Thanks to the `Operand<Z>` unification (#110), the operators are declared **once**, so this is just two renamed declarations (the generic `Expression` form + the typed `Operand` form) plus docs. **No call sites in tests or samples used `less` / `lessEq`**, so there was nothing to migrate.

Breaking (a rename), but pre-1.0. Verified: `kormium-core` + `kormium-sqlite` suites green; all module test sources compile.

Consolidation queue: ✅ Operand (#110) → ✅ rename L (this) → `isNull` on `Operand` → doc fixes (`conflict=`→`onConflict=`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)