### PR TITLE
feat(core): isNull() / isNotNull() on any Operand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,7 +358,8 @@ retrying {
   expected type). Column-to-column comparisons are NOT cross-checked — `intCol eq uuidCol` compiles,
   so match the types yourself.
 - `eq null` / `neq null` (→ `IS [NOT] NULL`) work only on **nullable** columns; on a non-null column
-  they don't compile (it can never be NULL).
+  they don't compile (it can never be NULL). For a computed expression that can be null (a `COALESCE`
+  of nullable columns, `rank + 1`, …), use `expr.isNull()` / `expr.isNotNull()` — available on any operand.
 - `orderBy` needs a direction — `orderBy ASC col` / `orderBy DESC col`; bare `orderBy col` is a syntax error.
 - Predicate names are `lt` / `ltEq` (not `less` / `lessEq` or `<`) and `neq` (not `ne`).
 - Read nullable join columns with `getOrNull`; `row[col]` throws on NULL/absent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ All notable changes to Kormium are documented here. The format is based on
 - **Predicates renamed `less` → `lt`, `lessEq` → `ltEq`.** The comparison operators are now symmetric
   (`lt` / `ltEq` paired with `gt` / `gtEq`, instead of the abbreviated `gt` against the spelled-out
   `less`), matching the common `lt`/`gt` convention. `eq` / `neq` / `gt` / `gtEq` are unchanged.
+- **`isNull()` / `isNotNull()` moved from `Column` to any `Operand`.** A computed expression that can be
+  null (a `COALESCE` of nullable columns, `rank + 1`, a `CASE`, …) can now be tested for NULL —
+  previously only a `Column` could. Additive; `eq null` / `neq null` stay as the nullable-column sugar.
 
 ## [0.8.0] — Cross-instance notifications, Windows async, expression UPDATE
 

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -450,8 +450,9 @@ Not modeled by the typed DSL today:
 
 The supported `WHERE` / `HAVING` predicates are exactly: `eq`, `neq`, `lt`, `ltEq`, `gt`,
 `gtEq`, `between` (an inclusive `lo..hi` range; an empty range matches nothing), `like`,
-`inList`, `eq null` / `neq null` (rendered as `IS [NOT] NULL`), and the `and` / `or` / `not(...)`
-combinators.
+`inList`, `eq null` / `neq null` on a nullable column (rendered as `IS [NOT] NULL`) or
+`expr.isNull()` / `expr.isNotNull()` on any operand (including a computed one), and the
+`and` / `or` / `not(...)` combinators.
 
 ## Observing Changes
 

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -228,15 +228,18 @@ class IsNullOp(private val column: Expression, private val negated: Boolean) : E
         "${column.toSql(builder)} IS ${if (negated) "NOT " else ""}NULL"
 }
 
-fun Column<*, *, *>.isNull(): Expression = IsNullOp(this, false)
-fun Column<*, *, *>.isNotNull(): Expression = IsNullOp(this, true)
+// `IS [NOT] NULL` on any operand — a column or a computed expression (`COALESCE` of nullable columns,
+// a `CASE`, an aggregate, …). This is the general form; nullable columns also get the `eq null` sugar
+// below. (A non-null column's `.isNull()` is allowed but always false — use it on the nullable ones.)
+fun Operand<*>.isNull(): Expression = IsNullOp(this, false)
+fun Operand<*>.isNotNull(): Expression = IsNullOp(this, true)
 
-// `column eq null` / `column neq null` render as IS [NOT] NULL. The `Nothing?` parameter
-// makes the null literal bind here instead of the typed `eq(value: Z)` overload, so the
-// comparison vocabulary stays uniform (`note eq null` reads like `age gtEq 18`). Restricted to a
-// NULLABLE column: a non-null column is never NULL, so `eq null` on one is a bug — and keeping this
-// overload off non-null columns means a typed mismatch (`age eq "x"`) reports against the real
-// `eq(value: Z)` candidate ("Int expected") instead of this one ("Nothing? expected").
+// `column eq null` / `column neq null` render as IS [NOT] NULL. The `Nothing?` parameter makes the
+// null literal bind here instead of the typed `eq(value: Z)` overload, so the comparison vocabulary
+// stays uniform (`note eq null` reads like `age gtEq 18`). Restricted to a NULLABLE column: a non-null
+// column is never NULL, so `eq null` on one is a bug — and keeping this overload off non-null columns
+// means a typed mismatch (`age eq "x"`) reports against the real `eq(value: Z)` candidate ("Int
+// expected") instead of this one ("Nothing? expected"). A computed nullable expression uses `.isNull()`.
 infix fun Column.NullableColumn<*, *, *>.eq(value: Nothing?): Expression = IsNullOp(this, false)
 infix fun Column.NullableColumn<*, *, *>.neq(value: Nothing?): Expression = IsNullOp(this, true)
 

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -21,12 +21,15 @@ import io.github.kormium.gt
 import io.github.kormium.gtEq
 import io.github.kormium.inList
 import io.github.kormium.innerJoin
+import io.github.kormium.isNotNull
+import io.github.kormium.isNull
 import io.github.kormium.leftJoin
 import io.github.kormium.length
 import io.github.kormium.lower
 import io.github.kormium.ltrim
 import io.github.kormium.none
 import io.github.kormium.not
+import io.github.kormium.plus
 import io.github.kormium.rtrim
 import io.github.kormium.trim
 import io.github.kormium.upper
@@ -169,6 +172,27 @@ class SqliteIntegrationTest {
         }
         assertEquals(1, grouped.size)
 
+        db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
+    }
+
+    /** `isNull()` / `isNotNull()` now work on any operand — here a computed (arithmetic) expression. */
+    @Test
+    fun testIsNullOnComputedExpression() {
+        val tag = "isnull-${Uuid.random()}"
+        db.transaction {
+            Products.execSql(productsDdl)
+            Products.insert(Product().apply { id = Uuid.random(); price = BigDecimal.fromInt(1); qty = 1; displayName = tag; note = null; rank = 5 })
+            Products.insert(Product().apply { id = Uuid.random(); price = BigDecimal.fromInt(1); qty = 2; displayName = tag; note = null; rank = null })
+        }
+        // `rank + 1` is NULL exactly when rank is — .isNull() on the computed expression finds it.
+        val nullRank = db.autocommit {
+            Products.find { where { (Products.displayName eq tag) and (Products.rank + 1).isNull() } }
+        }
+        assertEquals(listOf(2), nullRank.map { it.qty })
+        val hasRank = db.autocommit {
+            Products.find { where { (Products.displayName eq tag) and (Products.rank + 1).isNotNull() } }
+        }
+        assertEquals(listOf(1), hasRank.map { it.qty })
         db.transaction { Products.deleteWhere(Query(Products.displayName eq tag)) }
     }
 


### PR DESCRIPTION
Audit axis 4 (nullability). `IS [NOT] NULL` was only available on a `Column`, so a **computed** expression that can be null — a `COALESCE` of nullable columns, `rank + 1`, a `CASE` — couldn't be tested for NULL through the DSL.

## Change

Widen the `isNull()` / `isNotNull()` receiver from `Column<*,*,*>` to `Operand<*>` (the abstraction introduced in #110), so every operand supports it.

```kotlin
Products.find { where { (Products.rank + 1).isNull() } }        // computed expr — now works
Products.find { where { a.coalesce(b).isNotNull() } }
```

Additive: a `Column` is an `Operand`, so existing `col.isNull()` is unchanged. The `eq null` / `neq null` sugar stays restricted to **nullable columns** — extending the `Nothing?` overload to all operands would re-break the typed-mismatch error message fixed in #106 ("Int expected" not "Nothing? expected"); a computed expression uses `.isNull()`.

**Verified:** `kormium-core` + `kormium-sqlite` suites green (new `testIsNullOnComputedExpression`); all module test sources compile.

Consolidation queue: ✅ Operand (#110) → ✅ rename L (#111) → ✅ isNull (this) → doc fix (`conflict=`→`onConflict=`) next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)