### PR TITLE
docs(agents): fix upsert param name conflict -> onConflict

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,8 +141,8 @@ db.transaction {
     Users.update(User().apply { age = 37 }) { where { Users.id eq id } }   // only assigned fields
     Users.deleteWhere { where { Users.name eq "Ada" } }
 
-    Users.upsert(user, conflict = listOf(Users.id), update = patch)        // INSERT ... ON CONFLICT
-    Users.insertOrIgnore(user, conflict = listOf(Users.id))
+    Users.upsert(user, onConflict = listOf(Users.id), update = patch)      // INSERT ... ON CONFLICT
+    Users.insertOrIgnore(user, onConflict = listOf(Users.id))
 }
 ```
 


### PR DESCRIPTION
The `AGENTS.md` Write section showed `Users.upsert(user, conflict = listOf(Users.id), ...)` / `insertOrIgnore(user, conflict = ...)`, but the parameter is `onConflict` — the copy-ready snippet wouldn't compile. Fixed. Audit axis 6 (last consolidation item). Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)