### PR TITLE
refactor(core)!: insert / upsert return non-null T

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ All notable changes to Kormium are documented here. The format is based on
 - **`update(query, entity)` argument order flipped to `update(entity, query)`.** The `Query` form now
   takes the patch entity first, matching the block form `update(entity) { where { … } }` — the entity
   is in the same position in both. Migrate `update(Query(...), patch)` to `update(patch, Query(...))`.
+- **`insert` / `upsert` now return a non-null `T`** (was `T?`). They always yield a row — the passed
+  entity on the fast path, or the written row on `returning = true` — so the result no longer needs a
+  `!!`. The `returning = true` path now throws (instead of returning null) if the row can't be read
+  back, matching `insertAll`. `insertOrIgnore` still returns the affected-row count (`Long`).
 - **`findById(id: Any)` removed in favour of typed `findOne`.** The single untyped read in the API
   silently accepted a wrong-typed id (e.g. a `String` for a `Uuid` key) and bypassed the column's
   converter. Replaced by `findOne { where { Users.id eq id } }` / `findOne(Query(...))` → `T?`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ All notable changes to Kormium are documented here. The format is based on
 - `Table.primaryKey` is now `List<Column<*, *, T>>` (was `List<Column<*, *, *>>`) and the table's
   columns carry their entity type. Source-compatible for normal use; code that passed columns held
   as a bare `Column<*, *, *>` to `onConflict` must use the table's own columns.
+- **`update(query, entity)` argument order flipped to `update(entity, query)`.** The `Query` form now
+  takes the patch entity first, matching the block form `update(entity) { where { … } }` — the entity
+  is in the same position in both. Migrate `update(Query(...), patch)` to `update(patch, Query(...))`.
 - **`findById(id: Any)` removed in favour of typed `findOne`.** The single untyped read in the API
   silently accepted a wrong-typed id (e.g. a `String` for a `Uuid` key) and bypassed the column's
   converter. Replaced by `findOne { where { Users.id eq id } }` / `findOne(Query(...))` → `T?`

--- a/kormium-core/src/commonMain/kotlin/RenderSql.kt
+++ b/kormium-core/src/commonMain/kotlin/RenderSql.kt
@@ -54,11 +54,11 @@ class RenderScope<G : Catalog> internal constructor(val dialect: Dialect, val ty
     fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: List<Column<*, *, T>>): RenderedSql =
         RenderedSql(insertOrIgnoreSql(entity, onConflict, dialect, typeMapper))
 
-    fun <T : Entity> Table<G, T>.update(query: Query, entity: T): RenderedSql =
+    fun <T : Entity> Table<G, T>.update(entity: T, query: Query): RenderedSql =
         RenderedSql(updateSql(query, entity, dialect, typeMapper))
 
     fun <T : Entity> Table<G, T>.update(entity: T, block: QueryBuilder.() -> Unit): RenderedSql =
-        update(QueryBuilder().apply(block).build(), entity)
+        update(entity, QueryBuilder().apply(block).build())
 
     fun <T : Entity> Table<G, T>.update(block: UpdateBuilder.() -> Unit): RenderedSql {
         val builder = UpdateBuilder().apply(block)

--- a/kormium-core/src/commonMain/kotlin/Scope.kt
+++ b/kormium-core/src/commonMain/kotlin/Scope.kt
@@ -38,7 +38,7 @@ class Scope<G : Catalog> internal constructor(
      * path). Pass `returning = true` to fetch the stored row back via SQL `RETURNING`, e.g. to
      * read database-generated columns; then it returns that row (or null if none).
      */
-    fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): T? {
+    fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): T {
         markWritten()
         return insert(entity, exec, returning)
     }
@@ -61,13 +61,13 @@ class Scope<G : Catalog> internal constructor(
      * and on conflict with [onConflict] updates with [update]'s present fields. Pass
      * `returning = true` to fetch the resulting row.
      */
-    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, T>, update: T, returning: Boolean = false): T? {
+    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, T>, update: T, returning: Boolean = false): T {
         markWritten()
         return upsert(entity, listOf(onConflict), update, exec, returning)
     }
 
     /** Insert-or-update on a composite (multi-column) conflict target; see the single-column overload. */
-    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, T>>, update: T, returning: Boolean = false): T? {
+    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, T>>, update: T, returning: Boolean = false): T {
         markWritten()
         return upsert(entity, onConflict, update, exec, returning)
     }

--- a/kormium-core/src/commonMain/kotlin/Scope.kt
+++ b/kormium-core/src/commonMain/kotlin/Scope.kt
@@ -104,7 +104,7 @@ class Scope<G : Catalog> internal constructor(
         findOne(QueryBuilder().apply(block).build())
     fun <T : Entity> Table<G, T>.all(): List<T> = selectAll(exec)
     /** Updates rows matching [query] with the present fields of [entity]; returns the affected row count. */
-    fun <T : Entity> Table<G, T>.update(query: Query, entity: T): Long {
+    fun <T : Entity> Table<G, T>.update(entity: T, query: Query): Long {
         markWritten()
         return updateRows(query, entity, exec)
     }

--- a/kormium-core/src/commonMain/kotlin/SuspendScope.kt
+++ b/kormium-core/src/commonMain/kotlin/SuspendScope.kt
@@ -90,7 +90,7 @@ class SuspendScope<G : Catalog> internal constructor(
         findOne(QueryBuilder().apply(block).build())
     suspend fun <T : Entity> Table<G, T>.all(): List<T> = selectAll(exec)
     /** Updates rows matching [query] with the present fields of [entity]; returns the affected row count. */
-    suspend fun <T : Entity> Table<G, T>.update(query: Query, entity: T): Long {
+    suspend fun <T : Entity> Table<G, T>.update(entity: T, query: Query): Long {
         markWritten()
         return updateRows(query, entity, exec)
     }

--- a/kormium-core/src/commonMain/kotlin/SuspendScope.kt
+++ b/kormium-core/src/commonMain/kotlin/SuspendScope.kt
@@ -31,7 +31,7 @@ class SuspendScope<G : Catalog> internal constructor(
     }
 
     /** Inserts [entity]; see [Scope.insert]. */
-    suspend fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): T? {
+    suspend fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): T {
         markWritten()
         return insert(entity, exec, returning)
     }
@@ -47,13 +47,13 @@ class SuspendScope<G : Catalog> internal constructor(
     }
 
     /** Insert-or-update on a single-column conflict target; see [Scope.upsert]. */
-    suspend fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, T>, update: T, returning: Boolean = false): T? {
+    suspend fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, T>, update: T, returning: Boolean = false): T {
         markWritten()
         return upsert(entity, listOf(onConflict), update, exec, returning)
     }
 
     /** Insert-or-update on a composite conflict target; see [Scope.upsert]. */
-    suspend fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, T>>, update: T, returning: Boolean = false): T? {
+    suspend fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, T>>, update: T, returning: Boolean = false): T {
         markWritten()
         return upsert(entity, onConflict, update, exec, returning)
     }

--- a/kormium-core/src/commonMain/kotlin/Table.kt
+++ b/kormium-core/src/commonMain/kotlin/Table.kt
@@ -351,18 +351,20 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
     internal fun selectAll(exec: SqlExecutor): List<T> =
         exec.execute(selectAllSql(exec.dialect)) { rs -> mapToDao(rs, exec.typeMapper) }
 
-    internal fun insert(entity: T, exec: SqlExecutor, returning: Boolean): T? {
+    internal fun insert(entity: T, exec: SqlExecutor, returning: Boolean): T {
         val dialect = exec.dialect
         val emitReturning = returning && dialect.supportsReturning
         val (sql, params) = insertSql(entity, dialect, exec.typeMapper, emitReturning)
         if (returning && emitReturning) {
             return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+                ?: error("INSERT ... RETURNING returned no row in $tableName")
         }
         exec.executeUpdate(sql = sql, namedParameters = params)
         if (!returning) return entity
         // No RETURNING (MySQL): re-select the stored row by primary key.
         val (selSql, selParams) = selectByPkSql(entity, dialect, exec.typeMapper)
         return exec.execute(selSql, selParams) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+            ?: error("inserted row not found re-selecting by primary key in $tableName")
     }
 
     internal fun insertAll(entities: List<T>, exec: SqlExecutor, returning: Boolean, mode: BatchInsertMode): List<T> {
@@ -389,18 +391,20 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         }
     }
 
-    internal fun upsert(entity: T, conflict: List<Column<*, *, *>>, update: T, exec: SqlExecutor, returning: Boolean): T? {
+    internal fun upsert(entity: T, conflict: List<Column<*, *, *>>, update: T, exec: SqlExecutor, returning: Boolean): T {
         val dialect = exec.dialect
         val emitReturning = returning && dialect.supportsReturning
         val (sql, params) = upsertSql(entity, conflict, update, dialect, exec.typeMapper, emitReturning)
         if (returning && emitReturning) {
             return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+                ?: error("INSERT ... ON CONFLICT ... RETURNING returned no row in $tableName")
         }
         exec.executeUpdate(sql = sql, namedParameters = params)
         if (!returning) return entity
         // No RETURNING (MySQL): re-select the upserted row by primary key.
         val (selSql, selParams) = selectByPkSql(entity, dialect, exec.typeMapper)
         return exec.execute(selSql, selParams) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+            ?: error("upserted row not found re-selecting by primary key in $tableName")
     }
 
     internal fun insertOrIgnore(entity: T, conflict: List<Column<*, *, *>>, exec: SqlExecutor): Long {
@@ -442,17 +446,19 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
     internal suspend fun selectAll(exec: SuspendSqlExecutor): List<T> =
         exec.execute(selectAllSql(exec.dialect)) { rs -> mapToDao(rs, exec.typeMapper) }
 
-    internal suspend fun insert(entity: T, exec: SuspendSqlExecutor, returning: Boolean): T? {
+    internal suspend fun insert(entity: T, exec: SuspendSqlExecutor, returning: Boolean): T {
         val dialect = exec.dialect
         val emitReturning = returning && dialect.supportsReturning
         val (sql, params) = insertSql(entity, dialect, exec.typeMapper, emitReturning)
         if (returning && emitReturning) {
             return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+                ?: error("INSERT ... RETURNING returned no row in $tableName")
         }
         exec.executeUpdate(sql = sql, namedParameters = params)
         if (!returning) return entity
         val (selSql, selParams) = selectByPkSql(entity, dialect, exec.typeMapper)
         return exec.execute(selSql, selParams) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+            ?: error("inserted row not found re-selecting by primary key in $tableName")
     }
 
     internal suspend fun insertAll(entities: List<T>, exec: SuspendSqlExecutor, returning: Boolean, mode: BatchInsertMode): List<T> {
@@ -478,17 +484,19 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
         }
     }
 
-    internal suspend fun upsert(entity: T, conflict: List<Column<*, *, *>>, update: T, exec: SuspendSqlExecutor, returning: Boolean): T? {
+    internal suspend fun upsert(entity: T, conflict: List<Column<*, *, *>>, update: T, exec: SuspendSqlExecutor, returning: Boolean): T {
         val dialect = exec.dialect
         val emitReturning = returning && dialect.supportsReturning
         val (sql, params) = upsertSql(entity, conflict, update, dialect, exec.typeMapper, emitReturning)
         if (returning && emitReturning) {
             return exec.execute(sql, params) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+                ?: error("INSERT ... ON CONFLICT ... RETURNING returned no row in $tableName")
         }
         exec.executeUpdate(sql = sql, namedParameters = params)
         if (!returning) return entity
         val (selSql, selParams) = selectByPkSql(entity, dialect, exec.typeMapper)
         return exec.execute(selSql, selParams) { rs -> mapToDao(rs, exec.typeMapper) }.firstOrNull()
+            ?: error("upserted row not found re-selecting by primary key in $tableName")
     }
 
     internal suspend fun insertOrIgnore(entity: T, conflict: List<Column<*, *, *>>, exec: SuspendSqlExecutor): Long {

--- a/kormium-core/src/commonTest/kotlin/TableTest.kt
+++ b/kormium-core/src/commonTest/kotlin/TableTest.kt
@@ -490,19 +490,21 @@ class TableTest {
                         ("id", "price", "position", "text", "nullableTest")
                         VALUES (:p0, :p1, :p2, :p3, :p4)
                         RETURNING "id", "price", "position", "text", "nullableTest""""
-        db.transaction {
-            TestTable.insert(
-                TestEntity().apply {
-                    this.id = Uuid.random()
-                    this.price = BigDecimal.fromInt(1)
-                    this.position = 1
-                    this.text = "x"
-                    this.nullableTest = null
-                },
-                returning = true,
-            )
+        val entity = TestEntity().apply {
+            this.id = Uuid.random()
+            this.price = BigDecimal.fromInt(1)
+            this.position = 1
+            this.text = "x"
+            this.nullableTest = null
         }
-        assertEquals(remoteNewLinesAndSpaces(expectedResult), remoteNewLinesAndSpaces(databaseMockObj.internalSql))
+        databaseMockObj.result = listOf(entity)   // RETURNING yields the written row back (insert is non-null)
+        try {
+            val returned = db.transaction { TestTable.insert(entity, returning = true) }
+            assertEquals(entity, returned)
+            assertEquals(remoteNewLinesAndSpaces(expectedResult), remoteNewLinesAndSpaces(databaseMockObj.internalSql))
+        } finally {
+            databaseMockObj.result = null
+        }
     }
 
     @Test

--- a/kormium-core/src/commonTest/kotlin/TableTest.kt
+++ b/kormium-core/src/commonTest/kotlin/TableTest.kt
@@ -517,13 +517,13 @@ class TableTest {
             WHERE "id" = :p5
         """
         db.transaction {
-            TestTable.update(Query(TestTable.id eq uuid), TestEntity().apply {
+            TestTable.update(TestEntity().apply {
                 this.id = uuid
                 this.price = price
                 this.position = position
                 this.text = text
                 this.nullableTest = null
-            })
+            }, Query(TestTable.id eq uuid))
         }
         assertEquals(remoteNewLinesAndSpaces(expectedResult), remoteNewLinesAndSpaces(databaseMockObj.internalSql))
         assertEquals(
@@ -548,10 +548,7 @@ class TableTest {
         val uuid = Uuid.random()
         val expectedResult = """UPDATE "products" SET "nullableTest"=:p0 WHERE "id" = :p1"""
         db.transaction {
-            TestTable.update(
-                Query(TestTable.id eq uuid),
-                TestEntity().apply { this.nullableTest = null },
-            )
+            TestTable.update(TestEntity().apply { this.nullableTest = null }, Query(TestTable.id eq uuid))
         }
         assertEquals(remoteNewLinesAndSpaces(expectedResult), remoteNewLinesAndSpaces(databaseMockObj.internalSql))
         assertEquals(mapOf("p0" to null, "p1" to uuid.toString()), databaseMockObj.internalParams)
@@ -656,7 +653,7 @@ class TableTest {
     @Test
     fun testUpdateWithNoNonNullFieldsFails() {
         assertFailsWith<IllegalArgumentException> {
-            db.transaction { TestTable.update(Query(TestTable.id eq Uuid.random()), TestEntity()) }
+            db.transaction { TestTable.update(TestEntity(), Query(TestTable.id eq Uuid.random())) }
         }
     }
 

--- a/kormium-mysql/src/jvmTest/kotlin/TableIntegrationTest.kt
+++ b/kormium-mysql/src/jvmTest/kotlin/TableIntegrationTest.kt
@@ -53,7 +53,7 @@ class TableIntegrationTest {
             assertNull(found?.rank)
             assertEquals(0, BigDecimal.fromInt(100).compareTo(found?.price!!))
 
-            ItProducts.update(Query(ItProducts.id eq id), ItProduct().apply { this.qty = 9 })
+            ItProducts.update(ItProduct().apply { this.qty = 9 }, Query(ItProducts.id eq id))
             assertEquals(9, ItProducts.findOne { where { ItProducts.id eq id } }?.qty)
 
             ItProducts.deleteWhere(Query(ItProducts.id eq id))

--- a/kormium-mysql/src/nativeTest/kotlin/NativeMySqlTest.kt
+++ b/kormium-mysql/src/nativeTest/kotlin/NativeMySqlTest.kt
@@ -127,7 +127,7 @@ class NativeMySqlTest {
             assertEquals(5, found?.qty)
             assertEquals(tricky, found?.name)
             db.transaction {
-                NativeProducts.update(Query(NativeProducts.id eq id), NativeProduct().apply { qty = 9 })
+                NativeProducts.update(NativeProduct().apply { qty = 9 }, Query(NativeProducts.id eq id))
             }
             assertEquals(9, db.autocommit { NativeProducts.findOne { where { NativeProducts.id eq id } } }?.qty)
             db.transaction { NativeProducts.deleteWhere(Query(NativeProducts.id eq id)) }

--- a/kormium-postgres/src/jvmTest/kotlin/EdgeCaseTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/EdgeCaseTest.kt
@@ -126,7 +126,7 @@ class EdgeCaseTest {
     fun updateMatchingNoRowsIsNoOp() {
         // Must not throw, and must change nothing.
         ItDatabase.transaction {
-            EdgeTable.update(Query(EdgeTable.id eq Uuid.random()), EdgeRow().apply { num = 5 })
+            EdgeTable.update(EdgeRow().apply { num = 5 }, Query(EdgeTable.id eq Uuid.random()))
         }
     }
 

--- a/kormium-postgres/src/jvmTest/kotlin/TableIntegrationTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/TableIntegrationTest.kt
@@ -68,7 +68,7 @@ class TableIntegrationTest {
         assertEquals(1, byQty.size)
 
         // Partial update: only non-null fields go into SET.
-        ItProducts.update(Query(ItProducts.id eq id), ItProduct().apply { this.qty = 9 })
+        ItProducts.update(ItProduct().apply { this.qty = 9 }, Query(ItProducts.id eq id))
         assertEquals(9, ItProducts.findOne { where { ItProducts.id eq id } }?.qty)
 
         ItProducts.deleteWhere(Query(ItProducts.id eq id))

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteEdgeCaseTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteEdgeCaseTest.kt
@@ -109,7 +109,7 @@ class SqliteEdgeCaseTest {
     @Test
     fun updateMatchingNoRowsIsNoOp() {
         freshSchema()
-        db.transaction { EdgeTbl.update(Query(EdgeTbl.id eq Uuid.random()), EdgeR().apply { num = 5 }) }
+        db.transaction { EdgeTbl.update(EdgeR().apply { num = 5 }, Query(EdgeTbl.id eq Uuid.random())) }
     }
 
     @Test

--- a/samples/cross-instance-cache/src/commonMain/kotlin/Sample.kt
+++ b/samples/cross-instance-cache/src/commonMain/kotlin/Sample.kt
@@ -130,7 +130,7 @@ suspend fun runSample(
             // Instance A updates the row. Its commit is published to Redis; instance B receives it
             // and clears its cache — even though the write never went through B.
             dbA.transaction {
-                Products.update(Query(Products.id eq 1), Product().apply { id = 1; name = "Mechanical Keyboard" })
+                Products.update(Product().apply { id = 1; name = "Mechanical Keyboard" }, Query(Products.id eq 1))
             }
             delay(1_000) // let the notification propagate through Redis
 

--- a/samples/crud-sqlite/src/commonMain/kotlin/Main.kt
+++ b/samples/crud-sqlite/src/commonMain/kotlin/Main.kt
@@ -53,7 +53,7 @@ fun main() {
         val over28 = db.autocommit { Users.find(Query(Users.age gt 28)) }
         println("age > 28   = ${over28.map { it.name }}")
 
-        db.transaction { Users.update(Query(Users.id eq 2), user(2, "Bob", 26)) }
+        db.transaction { Users.update(user(2, "Bob", 26), Query(Users.id eq 2)) }
         db.transaction { Users.deleteWhere(Query(Users.id eq 1)) }
 
         val remaining = db.autocommit { Users.all() }

--- a/samples/crud-sqlite/src/commonTest/kotlin/CrudSqliteTest.kt
+++ b/samples/crud-sqlite/src/commonTest/kotlin/CrudSqliteTest.kt
@@ -35,7 +35,7 @@ class CrudSqliteTest {
                 db.autocommit { Users.find(Query(Users.age gt 28)) }.mapNotNull { it.name },
             )
 
-            db.transaction { Users.update(Query(Users.id eq 2), user(2, "Bob", 26)) }
+            db.transaction { Users.update(user(2, "Bob", 26), Query(Users.id eq 2)) }
             db.transaction { Users.deleteWhere(Query(Users.id eq 1)) }
 
             val remaining = db.autocommit { Users.all() }.map { "${it.name}:${it.age}" }.sorted()

--- a/samples/ktor-di/src/commonMain/kotlin/Application.kt
+++ b/samples/ktor-di/src/commonMain/kotlin/Application.kt
@@ -74,7 +74,7 @@ fun Application.configure() {
             val id = Uuid.parse(call.parameters["id"].orEmpty())
             val patch = call.receive<ProductDTO>().toDomain()
             val updated = call.transaction<AppCatalog, _> {
-                ProductTable.update(Query(ProductTable.id eq id), patch)
+                ProductTable.update(patch, Query(ProductTable.id eq id))
                 ProductTable.findOne { where { ProductTable.id eq id } }
             }
             call.respond(updated!!.toDto())

--- a/samples/ktor-koin/src/commonMain/kotlin/Application.kt
+++ b/samples/ktor-koin/src/commonMain/kotlin/Application.kt
@@ -80,7 +80,7 @@ fun Application.configure() {
             val id = Uuid.parse(call.parameters["id"].orEmpty())
             val patch = call.receive<ProductDTO>().toDomain()
             val updated = call.transaction<AppCatalog, _> {
-                ProductTable.update(Query(ProductTable.id eq id), patch)
+                ProductTable.update(patch, Query(ProductTable.id eq id))
                 ProductTable.findOne { where { ProductTable.id eq id } }
             }
             call.respond(updated!!.toDto())

--- a/samples/r2dbc/src/jvmMain/kotlin/Application.kt
+++ b/samples/r2dbc/src/jvmMain/kotlin/Application.kt
@@ -73,7 +73,7 @@ fun Application.configure() {
             val id = Uuid.parse(call.parameters["id"].orEmpty())
             val patch = call.receive<ProductDTO>().toDomain()
             val updated = call.transaction<AppCatalog, _> {
-                ProductTable.update(Query(ProductTable.id eq id), patch)
+                ProductTable.update(patch, Query(ProductTable.id eq id))
                 ProductTable.findOne { where { ProductTable.id eq id } }
             }
             call.respond(updated!!.toDto())


### PR DESCRIPTION
Repeat-audit finding (write-side). `insert` / `upsert` returned `T?`, but they **always** yield a row — the passed entity on the fast path, or the written row on `returning = true`. So the `T?` forced a needless `!!`/`?.` on the common path.

Narrow the return to **`T`**. The `returning = true` path now **throws** if the row can't be read back (instead of silently returning null), matching what `insertAll` already does. `insertOrIgnore` still returns the affected-row count (`Long`) — it may legitimately insert nothing on conflict.

Source-compatible for callers (a `T` is usable wherever `T?` was; a now-redundant `!!` becomes a warning). **Verified:** core + sqlite suites green (mock test updated to supply the RETURNING row); all module test sources + samples compile.

> Stacked on #114 (update arg order) — both touch `Scope.kt` in distant methods. Merge #114 first; this PR's diff then reduces to just the insert/upsert change.

Closes the write-side consolidation: ✅ update arg order (#114) → ✅ insert/upsert non-null (this). C (insert-family return asymmetry) and D (all()/find{} redundancy) accepted as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)