### PR TITLE
docs: refresh stale roadmap / design / web-targets / compatibility

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -16,6 +16,7 @@ avoid unnecessary churn and document breaking changes in [CHANGELOG.md](../CHANG
 | Kotlin | 2.4.x project line |
 | Gradle | Gradle wrapper in the repository |
 | PostgreSQL | Tested with PostgreSQL 16 in CI/sample infrastructure |
+| MySQL / MariaDB | JDBC (`mysql-connector-j`), native (`libmariadb`) and r2dbc; driver versions pinned in Gradle files |
 | SQLite | Driver versions pinned in Gradle files |
 | Ktor | Version pinned in Ktor module Gradle files |
 | Android | minSdk 24, compileSdk 36 |

--- a/docs/design.md
+++ b/docs/design.md
@@ -20,10 +20,14 @@ transactions and indexes.
 
 | Module | Responsibility |
 | --- | --- |
-| `kormium-core` | DSL, table/entity model, query rendering contracts, scopes and migrations |
-| `kormium-postgres` | PostgreSQL dialect and backend factories for JDBC/libpq |
-| `kormium-sqlite` | SQLite dialect and backend factories for sqlite-jdbc/sqlite3/AndroidX SQLite |
-| `kormium-r2dbc` | Async PostgreSQL `SuspendDatabase` implementation |
+| `kormium-core` | DSL, table/entity model, query rendering contracts and scopes |
+| `kormium-<db>-dialect` | The pure SQL dialect per database (`postgres`/`sqlite`/`mysql`), compiled to every target — see [ADR 0001](adr/0001-standalone-dialect-modules.md) |
+| `kormium-postgres` | PostgreSQL backend factories for JDBC/libpq |
+| `kormium-mysql` | MySQL / MariaDB backend factories for JDBC/libmariadb |
+| `kormium-sqlite` | SQLite backend factories for sqlite-jdbc/sqlite3/AndroidX SQLite |
+| `kormium-r2dbc` | Async PostgreSQL and MySQL `SuspendDatabase` implementations |
+| `kormium-{sqlite-wasm,sqlite-node,postgres-node,mysql-node}` | Browser / Node engines (suspend-only), sharing `kormium-wasm-driver` |
+| `kormium-migrate` | Ordered, checksummed migration runner over raw SQL execution |
 | `kormium-observe` | Reactive `Flow` queries over core's `WriteListener` commit hook |
 | `kormium-jdbc` | Shared JVM JDBC execution, pooling and named parameter binding |
 | `kormium-ktor*` | Server integration over the suspend API |
@@ -131,24 +135,25 @@ join the caller's connection instead of opening their own.
 ## Joins and Result Rows
 
 Join SQL qualifies columns by table to avoid ambiguous identifiers. `ResultRow` maps
-selected fields by key:
+selected fields by a **structural** key (`Selectable.resultKey()`), because delegated column
+access and the expression operators create fresh instances per use:
 
-- columns are keyed by table name and column name because delegated column access may create
-  fresh column instances;
-- aggregate expressions are keyed by instance, so users should keep them in `val`s.
+- a column keys by table name and column name;
+- a computed expression (aggregate, `COALESCE`, `CASE`, arithmetic, string function) keys by its
+  structure — the function/shape over its operands' keys, including literals.
 
-That tradeoff keeps projection reads simple while preserving typed access:
+So a row reads back with a freshly built, identical expression — a `val` is handy for reuse (and
+in `having(...)`), not required:
 
 ```kotlin
-val total = Orders.total.sum()
 row[Users.name]
-row[total]
+row[Orders.total.sum()]   // fresh instance; no val needed
 ```
 
 ## Migrations
 
-Migrations live in core because they operate on scopes and raw execution. Backends only need
-to provide normal SQL execution.
+Migrations live in their own module, `kormium-migrate` (not core): they build on scopes and raw
+execution, so they need no backend-specific code. Backends only need to provide normal SQL execution.
 
 Each migration:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,8 +11,11 @@ Shipped today:
 - backend-agnostic Kotlin Multiplatform core;
 - PostgreSQL on JVM through JDBC/HikariCP;
 - PostgreSQL on Kotlin/Native through libpq;
+- MySQL / MariaDB on JVM (JDBC) and Kotlin/Native (libmariadb);
 - SQLite on JVM, Kotlin/Native and Android;
-- JVM-only async PostgreSQL through r2dbc;
+- async PostgreSQL and MySQL on JVM through r2dbc;
+- browser & Node engines (JS / Wasm): SQLite (wa-sqlite, better-sqlite3) and Node
+  Postgres/MySQL — see [Backends](backends.md) and [Web targets](web-targets.md);
 - typed table/entity DSL;
 - an open `ColumnType` system (built-ins + `enum`/`json` + custom converters);
 - typed predicates, joins and aggregations;
@@ -31,20 +34,24 @@ and a smaller chance that public API has to move later.
 
 ### API Hardening
 
-- Review naming consistency across blocking and suspend APIs.
 - Decide which APIs are stable enough to keep source-compatible after 1.0.
 - Make raw SQL extension points clearer and safer.
-- Improve compiler errors where catalog/type inference currently produces noisy messages.
 - Keep the entity model small unless a new abstraction removes real complexity.
-- Work through the sharp edges tracked in [API ergonomics review](api-ergonomics.md).
+
+(Done: blocking/suspend naming reviewed and made symmetric — `lt`/`ltEq` paired with `gt`/`gtEq`;
+comparison/membership operators unified onto one `Operand<Z>` abstraction; untyped `findById`
+replaced by typed `findOne`; `insert`/`upsert` return a non-null `T`; a compile-error-quality audit
+tightened predicate mismatch messages; the impl-only expression nodes are `internal`. See the
+[API ergonomics review](api-ergonomics.md).)
 
 ### Query Coverage
 
-- Consider richer update/delete result reporting.
-
 (Done: tests for joins with colliding column names; aggregation/`HAVING` coverage; pagination,
 projection and nullable-left-join recipes; an explicit unsupported-SQL section in
-[queries](queries.md).)
+[queries](queries.md). `RETURNING` on `UPDATE`/`DELETE` was considered and **declined** — it isn't
+portable (MySQL has none) without hidden multi-statement emulation; see
+[ADR 0008](adr/0008-no-returning-on-update-delete.md). Get the rows with an explicit two-step in one
+transaction.)
 
 ### Schema and Migrations
 
@@ -89,9 +96,11 @@ After 1.0 the project should optimize for compatibility and ecosystem fit:
 These are useful but should not distract from core reliability:
 
 - Windows Native hardening — drop the experimental label after a stable release cycle;
-- Kotlin web stack (JS / Wasm-JS / Wasm-WASI) — the typed DSL already compiles and tests
-  green on all three; next are SQLite (browser) and Node (sqlite/pg/mysql) engines. A PGlite
-  engine (Postgres in the browser) lives in a separate repo. See [Web targets](web-targets.md);
+- Kotlin web stack (JS / Wasm-JS / Wasm-WASI) — the typed DSL compiles and tests green on all
+  three, and the browser/Node engines have shipped (wa-sqlite in the browser, better-sqlite3 /
+  node-postgres / mysql2 on Node); still new, so treated as experimental. A PGlite engine
+  (Postgres in the browser) lives in a separate repo. Remaining: wasmWasi stays DSL-only until
+  WASI sockets mature. See [Web targets](web-targets.md);
 - more SQL dialects;
 - richer schema DSL;
 - generated entities or compiler plugin support;

--- a/docs/web-targets.md
+++ b/docs/web-targets.md
@@ -43,8 +43,10 @@ Near-term targets (have real DB access today):
   Compose Multiplatform todo app — `./gradlew :samples:wasm-todo:wasmJsBrowserDevelopmentRun`.
   Tested under Node in CI by passing the `.wasm` as `wasmBinary` (wa-sqlite's async build would
   otherwise `fetch()` it, which Node rejects for `file://`).
-- **Node — SQLite / Postgres / MySQL.** Kotlin compiled to JS/Wasm running under Node, against
-  real databases via the `node:sqlite` / `node-postgres` / `mysql2` packages. Next up.
+- **Node — SQLite / Postgres / MySQL** ✅ `kormium-sqlite-node` (better-sqlite3),
+  `kormium-postgres-node` (node-postgres, pooled), `kormium-mysql-node` (mysql2, pooled). Kotlin
+  compiled to JS/Wasm running under Node against real databases; suspend-only, sharing
+  `kormium-wasm-driver`.
 
 ### PGlite lives in a separate repo
 
@@ -55,11 +57,10 @@ target (~20 MB), kept out of core; use it when you specifically want Postgres-on
 parity between client and server. The patterns it proved (named-ESM `@file:JsModule` import,
 text binding, Promise→suspend, single-connection `Mutex`) carry over to the engines above.
 
-## Phase 2 — Breadth
+## Phase 2 — Breadth ✅ (done)
 
-- The remaining Node engines (whichever of sqlite/pg/mysql aren't done first).
-- Add web targets to the pure modules `kormium-migrate` and `kormium-observe` (after a
-  jvm-ism audit).
+- All three Node engines shipped (sqlite/pg/mysql, above).
+- The pure modules `kormium-migrate` and `kormium-observe` now ship web artifacts too.
 
 ## Phase 3 — Upstream + wasmWasi
 


### PR DESCRIPTION
Checked the docs you flagged (roadmap, web-targets, design, compatibility, backends, api-ergonomics, api-cookbook) against the shipped state. Findings + fixes:

| Doc | State | Fix |
|---|---|---|
| **design.md** | 🔴 stale | Module table missing `kormium-mysql`, dialect modules, web/Node engines, `kormium-migrate`; "migrations live in core" (they're in `kormium-migrate`); "aggregates keyed by instance → keep in `val`" (now **structural** keys — fresh instance reads back). All corrected. |
| **roadmap.md** | 🔴 stale | Baseline missing MySQL + web engines; naming-consistency & API-hardening items now done (lt/ltEq, Operand, findOne, non-null insert); RETURNING on UPDATE/DELETE recorded as declined (ADR 0008); exploratory web updated (engines shipped). |
| **web-targets.md** | 🟡 stale | Node engines were "next up" → shipped; Phase 2 (Node engines + migrate/observe web artifacts) done. |
| **compatibility.md** | 🟡 minor | Added MySQL / MariaDB to the runtime baseline. |
| **backends.md** | 🟢 current | Full engine matrix, RETURNING/error/lifecycle tables all accurate — no change. |
| **api-ergonomics.md** | 🟢 current | `onConflict`, block-form update, insert semantics accurate — no change. |
| **api-cookbook.md** | 🟢 current | Typed repository already updated; no stale patterns. |

Docs-only. No stale `findById` / `less` / `lessEq` / `conflict=` / old-order `update` anywhere in these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)