### PR TITLE
fix(bench): two missed update(query,entity) call sites (native CI)

### DIFF
--- a/benchmarks/src/jmh/kotlin/ComparisonBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/ComparisonBenchmark.kt
@@ -219,8 +219,8 @@ open class ComparisonBenchmark {
     @Benchmark
     fun kormiumUpdateById(): Any? = kormiumDb.transaction {
         CmpTable.update(
-            Query(CmpTable.id eq updateKormiumIds[randomUpdateIndex()]),
             CmpRow().apply { amount = KormiumBigDecimal.fromInt(2) },
+            Query(CmpTable.id eq updateKormiumIds[randomUpdateIndex()]),
         )
     }
 

--- a/kormium-postgres/src/nativeTest/kotlin/NativeBenchmark.kt
+++ b/kormium-postgres/src/nativeTest/kotlin/NativeBenchmark.kt
@@ -69,9 +69,9 @@ private fun runOp(db: Database<BenchCatalog>, op: Op) {
         Op.BATCH_INSERT -> db.transaction { BenchTable.insertAll(List(BATCH_SIZE) { newRow("x") }) }
         Op.UPDATE_BY_ID -> db.transaction {
             BenchTable.update(
-                Query(BenchTable.id eq updateIds[Random.nextInt(UPDATE_ROWS)]),
-                BenchRow().apply { amount = BigDecimal.fromInt(2) },
-            )
+            BenchRow().apply { amount = BigDecimal.fromInt(2) },
+            Query(BenchTable.id eq updateIds[Random.nextInt(UPDATE_ROWS)]),
+        )
         }
     }
 }


### PR DESCRIPTION
Fixes the #88 native CI failure:
`NativeBenchmark.kt:72 Argument type mismatch: actual type is 'Query', but 'BenchRow' was expected.`

## Cause

The #114 arg-order swap (`update(query, entity)` → `update(entity, query)`) used a script keyed on the substring `.update(Query(`. Two call sites write it **multi-line** — `Query(...)` on the line after `.update(` — so the substring didn't match and the files were skipped:

- `kormium-postgres/src/nativeTest/kotlin/NativeBenchmark.kt`
- `benchmarks/src/jmh/kotlin/ComparisonBenchmark.kt`

Neither source set is compiled by `compileTestKotlinJvm` (native test + JMH), so my JVM verification didn't catch them — only the native CI leg did.

## Fix

Both swapped to entity-first. Re-scanned the whole repo with a balanced-paren parser (handles newlines): **no other old-order `update(Query, …)` remains.**

**Verified locally:** `:benchmarks:compileJmhKotlin` + the postgres / sqlite / mysql `macosArm64` test source sets all compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)