### PR TITLE
Raw SQL: mandatory params/invalidates, gate behind @DelicateKormiumApi

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,4 +367,6 @@ retrying {
   compare against a `RawExpression`), `UNION`, CTEs, window functions, `RIGHT`/`FULL`/
   `CROSS`/self-joins, `ILIKE` operator (use `lower()`), regex, simple `CASE expr WHEN` (searched
   `case { }` is supported), scalar functions beyond `lower`/`upper`/`trim`/`ltrim`/`rtrim`/`length`,
-  `RETURNING` on `UPDATE`/`DELETE`, `FOR UPDATE`. Drop to `RawExpression` or `execute(...)` for those.
+  `RETURNING` on `UPDATE`/`DELETE`, `FOR UPDATE`. Drop to `RawExpression` or `execute(...)` for
+  those — both require `@OptIn(DelicateKormiumApi::class)`, and `execute`/`executeUpdate` require
+  `params`/`invalidates` explicitly (`emptyMap()`/`emptyList()` when there's nothing to pass).

--- a/benchmarks/src/jmh/kotlin/ComparisonBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/ComparisonBenchmark.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package kormium.bench
 
 import com.zaxxer.hikari.HikariConfig
@@ -151,7 +153,7 @@ open class ComparisonBenchmark {
         kormiumDb.transaction {
             CmpTable.execSql("DROP TABLE IF EXISTS \"cmp_bench\"")
             CmpTable.execSql(cmpBenchDdl)
-            executeUpdate("""CREATE INDEX IF NOT EXISTS cmp_bench_name_idx ON "public"."cmp_bench" ("name")""")
+            executeUpdate("""CREATE INDEX IF NOT EXISTS cmp_bench_name_idx ON "public"."cmp_bench" ("name")""", params = emptyMap(), invalidates = emptyList())
         }
 
         exposedDs = HikariDataSource(HikariConfig().apply {
@@ -181,7 +183,7 @@ open class ComparisonBenchmark {
     @Setup(Level.Iteration)
     fun resetTable() {
         kormiumDb.transaction {
-            executeUpdate("""TRUNCATE "public"."cmp_bench"""")
+            executeUpdate("""TRUNCATE "public"."cmp_bench"""", params = emptyMap(), invalidates = emptyList())
             CmpTable.insert(CmpRow().apply { id = seededKormiumId; name = "seed"; amount = KormiumBigDecimal.fromInt(1) })
             CmpTable.insertAll(List(BULK_ROWS) { newKormiumRow("bulk") })
             CmpTable.insertAll(updateKormiumIds.map { rowId ->

--- a/benchmarks/src/jmh/kotlin/KormiumBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/KormiumBenchmark.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package kormium.bench
 
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
@@ -79,7 +81,7 @@ open class KormiumBenchmark {
         )
         db.transaction {
             BenchTable.execSql(benchDdl)
-            executeUpdate("""CREATE INDEX IF NOT EXISTS bench_name_idx ON "public"."bench" ("name")""")
+            executeUpdate("""CREATE INDEX IF NOT EXISTS bench_name_idx ON "public"."bench" ("name")""", params = emptyMap(), invalidates = emptyList())
         }
     }
 
@@ -88,7 +90,7 @@ open class KormiumBenchmark {
     @Setup(Level.Iteration)
     fun resetTable() {
         db.transaction {
-            executeUpdate("""TRUNCATE "public"."bench"""")
+            executeUpdate("""TRUNCATE "public"."bench"""", params = emptyMap(), invalidates = emptyList())
             BenchTable.insert(BenchRow().apply { id = seededId; name = "seed"; amount = BigDecimal.fromInt(1) })
         }
     }

--- a/docs/adr/0006-no-idiomatic-path-nudge.md
+++ b/docs/adr/0006-no-idiomatic-path-nudge.md
@@ -1,6 +1,8 @@
 # ADR 0006 — No idiomatic-path nudge (no `@RequiresOptIn` marker, no detekt rule)
 
-- Status: Accepted
+- Status: Partially superseded by [ADR 0009](0009-delicate-raw-sql-optin.md) — the `@RequiresOptIn`
+  rejection below no longer holds for `execute` / `executeUpdate` / `execSql` / `RawExpression`. The
+  detekt-rule rejection and the "don't gate `.select()`" point still stand.
 - Date: 2026-06-30
 
 ## Context
@@ -15,8 +17,9 @@ Examining the actual surface, the premise mostly does not hold:
 - `(A innerJoin B).select()` + `row[col]` is **not** an escape hatch — it is the first-class typed
   way to read columns / aggregates from a join (the alternative to entity hydration via `find()`).
   Marking it "low-level" would gate normal, recommended API.
-- `Scope.execute(sql, params)` runs raw SQL but **binds parameters**, and is the legitimate path for
-  DDL (`execSql`) and SQL the typed DSL doesn't model. Gating every migration is pure friction.
+- `Scope.execute(sql, params, invalidates)` runs raw SQL but **binds parameters**, and is the
+  legitimate path for DDL (`execSql`) and SQL the typed DSL doesn't model. Gating every migration is
+  pure friction.
 - `RawExpression(string)` is the only genuinely unsafe form: verbatim SQL that does **not** bind
   parameters. It is already named `Raw` and documented as unsafe.
 

--- a/docs/adr/0008-no-returning-on-update-delete.md
+++ b/docs/adr/0008-no-returning-on-update-delete.md
@@ -40,7 +40,8 @@ db.transaction {
 ```
 
 On PostgreSQL / SQLite, a one-statement `… RETURNING` is available through `RawExpression` /
-`execute(...)` for callers who specifically want it.
+`execute(...)` for callers who specifically want it (both require
+`@OptIn(DelicateKormiumApi::class)`; `execute` also requires `params`/`invalidates` explicitly).
 
 ## Consequences
 

--- a/docs/adr/0009-delicate-raw-sql-optin.md
+++ b/docs/adr/0009-delicate-raw-sql-optin.md
@@ -1,0 +1,96 @@
+# ADR 0009 — Raw SQL requires `@OptIn(DelicateKormiumApi::class)` (supersedes ADR 0006 in part)
+
+- Status: Accepted
+- Date: 2026-07-03
+- Supersedes: [ADR 0006](0006-no-idiomatic-path-nudge.md), for `execute` / `executeUpdate` / `execSql` /
+  `RawExpression` only. ADR 0006's rejection of a detekt rule and of gating `.select()` still stands.
+
+## Context
+
+While closing the roadmap's "make raw SQL extension points clearer and safer" item, two real gaps
+turned up in `Scope`/`SuspendScope`'s raw-SQL surface:
+
+- `invalidates: List<Table<G, *>> = emptyList()` defaulted to empty, so a raw write could silently
+  skip notifying `kormium-observe` — nothing failed, `Flow` queries just went stale.
+- `params: Map<String, Any?> = emptyMap()` also defaulted to empty, so the parameterized path was
+  never *shorter* than string-concatenating a value into the SQL text — the opposite of what should
+  be true for the safer option.
+- `execute(sql, params, invalidates): Long` and `executeUpdate(sql, params, invalidates)` were the
+  same underlying call under two names, one of them silently discarding the driver's row count.
+
+Fixing this made both `params` and `invalidates` required arguments (no defaults) on the merged
+`execute`/`executeUpdate`, which raised the question ADR 0006 already answered once: should raw SQL
+also carry a compile-time marker?
+
+[ADR 0006](0006-no-idiomatic-path-nudge.md) (2026-06-30) considered exactly this and said no,
+reasoning that (a) `execute`/`executeUpdate`/`execSql` "bind parameters" and are the legitimate path
+for DDL, so gating them is pure friction on every migration, and (b) even for `RawExpression` — the
+one form it called genuinely unsafe — a marker adds only marginal value over its existing name and
+docs, and (c) the right lever for steering an AI agent is documentation read *before* code is
+written (`AGENTS.md`), not compile friction discovered *after*.
+
+## Decision
+
+Add `DelicateKormiumApi`, a `@RequiresOptIn(level = ERROR)` marker, and apply it to `RawExpression`,
+`Scope.execute` / `Scope.executeUpdate` / `Table.execSql`, and their `SuspendScope` counterparts.
+Callers add `@OptIn(DelicateKormiumApi::class)` (typically `@file:OptIn(...)`) once per file that
+uses raw SQL. `.select()` / the join API is untouched — it stays first-class per ADR 0006.
+
+This reverses ADR 0006's conclusion for the escape-hatch functions specifically, for three reasons
+not in play when 0006 was written:
+
+- **The marginal-friction argument weakens once `params`/`invalidates` are mandatory.** ADR 0006's
+  strongest point was "gating `execSql`/`execute` nags on every legitimate DDL call." That call site
+  now already stops to supply `params`/`invalidates` explicitly — the opt-in is one more line next to
+  arguments the caller must write anyway, not a fresh source of friction on an otherwise-terse call.
+- **Docs-first steering and a compile-time gate solve different failures.** ADR 0006 is right that
+  `AGENTS.md` is what stops an agent from *reaching for* raw SQL when the typed DSL would do — that
+  reasoning is unchanged and still governs the recipes. But it does not catch code copied from an
+  older example, a maintainer reaching for `execute(...)` out of habit, or an agent that never loaded
+  `AGENTS.md` this session. A `@RequiresOptIn` marker is not a substitute steering mechanism; it is a
+  backstop for the moment steering fails, which docs alone cannot provide.
+- **The risk was underestimated, not just under-signposted.** ADR 0006 treated `execute`/`execSql` as
+  safe because they "bind parameters" — true, but the default-empty `params` map made *not* binding
+  them the path of least resistance, and the default-empty `invalidates` made a real write silently
+  invisible to `kormium-observe`. Both are now fixed at the signature level; the annotation is the
+  visible marker that a caller is on the hatch where those two footguns used to live, paired with the
+  arguments that closed them.
+
+`ERROR`, not the `WARNING` level ADR 0006's "Alternatives considered" weighed and rejected for
+`RawExpression` alone — a warning is easy to ignore across a whole codebase; the intent here is one
+explicit, permanent acknowledgment per file, not a nag that accumulates as noise.
+
+## Consequences
+
+Positive:
+
+- A raw-SQL call site cannot compile without a visible, grep-able `@OptIn(DelicateKormiumApi::class)`
+  — a real backstop where docs-first steering (still the primary lever, per ADR 0006/0007) fails to
+  reach.
+- One annotation documents the whole raw-SQL risk surface (unparameterized text, untracked writes) at
+  its point of use, next to the arguments that already mitigate it.
+
+Negative / costs:
+
+- Breaking, pre-1.0: every existing caller of `execute`/`executeUpdate`/`execSql`/`RawExpression`
+  across the repo needs the opt-in added (done as part of this same change — core, tests, samples,
+  benchmarks, docs).
+- Re-litigates a 3-day-old accepted decision. Recorded here rather than editing ADR 0006, per the
+  project's append-only ADR convention.
+
+## Alternatives considered
+
+- **Leave ADR 0006 as-is; ship only the mandatory `params`/`invalidates`.** Closes the two concrete
+  footguns without touching the opt-in question. Rejected: it leaves no compile-time signal that a
+  particular call has left the typed/parameterized path at all — a reader (or a future refactor) has
+  to know `execute`/`executeUpdate`/`execSql` are special by convention alone.
+- **Mark `RawExpression` only, leave `execute`/`executeUpdate`/`execSql` unmarked.** The narrower
+  reading of ADR 0006's own "the only genuinely unsafe form" line. Rejected: `execute`/`executeUpdate`
+  had the exact same silent-default problems as `RawExpression` (params, invalidates) — treating them
+  as safe because they *can* bind parameters ignored that the defaults made not doing so the easy path.
+
+## Notes
+
+`AGENTS.md` and its recipes remain the primary steering mechanism (ADR 0006's core point, unchanged);
+this ADR adds a compile-time floor under it for the raw-SQL surface specifically. Related:
+[[korm-prod-ready-work]].

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,3 +12,4 @@ rewrite.
 - [0006 — No idiomatic-path nudge (no `@RequiresOptIn` marker, no detekt rule)](0006-no-idiomatic-path-nudge.md)
 - [0007 — `ConcurrencyConflictException` as a typed signal, not a retry helper](0007-concurrency-conflict-exception.md)
 - [0008 — No `RETURNING` on `UPDATE` / `DELETE`](0008-no-returning-on-update-delete.md)
+- [0009 — Raw SQL requires `@OptIn(DelicateKormiumApi::class)` (supersedes 0006 in part)](0009-delicate-raw-sql-optin.md)

--- a/docs/api-cookbook.md
+++ b/docs/api-cookbook.md
@@ -46,7 +46,9 @@ db.migrate(
 ## Foreign Keys and Check Constraints
 
 Kormium does not model foreign keys, composite/partial indexes or check constraints in the
-table DSL — declare them in the same raw SQL that creates the table (or in a migration).
+table DSL — declare them in the same raw SQL that creates the table (or in a migration). Raw SQL
+needs `@OptIn(DelicateKormiumApi::class)` in scope, and `executeUpdate` always takes `params` and
+`invalidates` explicitly:
 
 ```kotlin
 db.transaction {
@@ -57,8 +59,14 @@ db.transaction {
              "total" integer NOT NULL CHECK ("total" >= 0),
              PRIMARY KEY ("id")
            )""",
+        params = emptyMap(),
+        invalidates = emptyList(),
     )
-    executeUpdate("""CREATE INDEX IF NOT EXISTS orders_user_idx ON "orders" ("userId")""")
+    executeUpdate(
+        """CREATE INDEX IF NOT EXISTS orders_user_idx ON "orders" ("userId")""",
+        params = emptyMap(),
+        invalidates = emptyList(),
+    )
 }
 ```
 
@@ -186,11 +194,16 @@ Users.find { where { Users.name.lower() eq Users.email.lower() } }
 ```
 
 `LOWER("name")` cannot use a plain index on `name`. If you match on it often, add a functional
-index so the lookup stays fast:
+index so the lookup stays fast (raw SQL, so `@OptIn(DelicateKormiumApi::class)` and explicit
+`params`/`invalidates` apply here too):
 
 ```kotlin
 db.transaction {
-    executeUpdate("""CREATE INDEX IF NOT EXISTS users_name_lower_idx ON "users" (LOWER("name"))""")
+    executeUpdate(
+        """CREATE INDEX IF NOT EXISTS users_name_lower_idx ON "users" (LOWER("name"))""",
+        params = emptyMap(),
+        invalidates = emptyList(),
+    )
 }
 ```
 
@@ -391,6 +404,8 @@ val db: Database<App> = createSqliteDatabase()
 db.transaction {
     executeUpdate(
         """CREATE TABLE IF NOT EXISTS "users" ("id" INTEGER NOT NULL, "name" TEXT NOT NULL, PRIMARY KEY ("id"))""",
+        params = emptyMap(),
+        invalidates = emptyList(),
     )
 }
 ```

--- a/docs/api-ergonomics.md
+++ b/docs/api-ergonomics.md
@@ -150,12 +150,26 @@ The conflict target is validated on two levels:
 ## Raw SQL
 
 Raw SQL is the escape hatch for schema, backend-specific features and complex conflict
-targets. Prefer parameter maps for values:
+targets — `execute`, `executeUpdate`, `execSql` and `RawExpression` all count as raw SQL. It is
+an explicit opt-in: calling any of them requires `@OptIn(DelicateKormiumApi::class)` in scope
+(a `@file:OptIn(DelicateKormiumApi::class)` at the top of the file is the usual form), so reaching
+for raw SQL is a visible, deliberate act rather than something that slips in unnoticed.
+
+`execute` and `executeUpdate` take `params` and `invalidates` as required arguments — there is no
+default to fall back on, even when the answer is "nothing":
 
 ```kotlin
 executeUpdate(
     """CREATE UNIQUE INDEX IF NOT EXISTS users_email_idx ON "users" ("email")""",
+    params = emptyMap(),
+    invalidates = emptyList(),
 )
 ```
 
-Use `RawExpression` only for controlled SQL fragments, never for concatenated user input.
+Making `params` mandatory means parameterizing a value is never more effort than concatenating it
+into the SQL string — pass `params = mapOf("email" to email)` and reference `:email` in the SQL.
+Making `invalidates` mandatory means a write is never silently invisible to observers — every call
+site states, in the open, which tables it touches (or `emptyList()`, deliberately, if none).
+
+Use `RawExpression` only for controlled SQL fragments, never for concatenated user input; it also
+requires `@OptIn(DelicateKormiumApi::class)`.

--- a/docs/observe.md
+++ b/docs/observe.md
@@ -57,17 +57,26 @@ val dashboard: Flow<Dashboard> = db.observe(setOf("users", "orders")) {
 
 ## Raw SQL
 
-Kormium cannot see which tables raw SQL touches, so declare them with `invalidates` so observers
+Kormium cannot see which tables raw SQL touches, so `executeUpdate`/`execute` require `invalidates`
+as an explicit argument — there's no defaulted-away value to forget. List the tables so observers
 (and any future cache) are notified on commit — the analog of Room's
-`@RawQuery(observedEntities = …)`:
+`@RawQuery(observedEntities = …)`. Raw SQL also requires `@OptIn(DelicateKormiumApi::class)`:
 
 ```kotlin
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 db.transaction {
-    executeUpdate("UPDATE products SET price = price * 2", invalidates = listOf(Products))
+    executeUpdate(
+        "UPDATE products SET price = price * 2",
+        params = emptyMap(),
+        invalidates = listOf(Products),
+    )
 }
 ```
 
-Without `invalidates`, a raw write commits normally but does not fire observers.
+Pass `invalidates = emptyList()` for a raw write that genuinely touches no observed table; passing
+the wrong (too-narrow) list still commits normally but does not fire observers for the tables you
+left out.
 
 ## Boundaries
 

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -393,7 +393,8 @@ val byAge = db.autocommit {
 ## Raw Expressions
 
 `RawExpression` embeds SQL verbatim. It is useful for controlled SQL fragments, but unsafe
-with untrusted input.
+with untrusted input. Like the other raw-SQL escape hatches, it requires
+`@OptIn(DelicateKormiumApi::class)` in scope.
 
 Prefer:
 
@@ -416,7 +417,8 @@ Kormium covers a deliberate slice of SQL: typed `SELECT`/`WHERE`/`ORDER BY`/`LIM
 predicate vocabulary below. The DSL does not try to model all of SQL. Anything outside that
 slice runs through raw SQL — either a `RawExpression` inside the DSL or `execute(...)` /
 `executeUpdate(...)` on a scope (see [Raw Expressions](#raw-expressions) and the
-[API cookbook](api-cookbook.md)).
+[API cookbook](api-cookbook.md)). All of these require `@OptIn(DelicateKormiumApi::class)`;
+`execute`/`executeUpdate` also require `params` and `invalidates` as explicit arguments.
 
 Not modeled by the typed DSL today:
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -61,7 +61,9 @@ catalog-agnostic.
 ## 4. Create the Table
 
 Kormium maps queries and rows; it does not own schema management. Create tables with raw
-SQL (or a migration tool / `Database.migrate`):
+SQL (or a migration tool / `Database.migrate`). Raw SQL is an explicit escape hatch: it needs
+`@OptIn(DelicateKormiumApi::class)` in scope (e.g. `@file:OptIn(DelicateKormiumApi::class)` at the
+top of the file), and `executeUpdate` always takes `params` and `invalidates` explicitly:
 
 ```kotlin
 import io.github.kormium.transaction
@@ -77,6 +79,8 @@ db.transaction {
             PRIMARY KEY ("id")
         )
         """,
+        params = emptyMap(),
+        invalidates = emptyList(),
     )
 }
 ```

--- a/docs/tables-and-entities.md
+++ b/docs/tables-and-entities.md
@@ -157,7 +157,8 @@ Kormium does not own schema management. A `Table` describes how rows map to enti
 queries, inserts and updates — not the full database schema. Create and evolve schema with
 a migration tool (Flyway, Liquibase) or raw SQL, which also gives you indexes, foreign
 keys, checks, defaults and generated columns that the mapping layer intentionally does not
-model:
+model. Raw SQL needs `@OptIn(DelicateKormiumApi::class)` in scope, and `executeUpdate` always
+takes `params` and `invalidates` explicitly:
 
 ```kotlin
 db.transaction {
@@ -170,8 +171,14 @@ db.transaction {
             PRIMARY KEY ("id")
         )
         """,
+        params = emptyMap(),
+        invalidates = emptyList(),
     )
-    executeUpdate("""CREATE INDEX IF NOT EXISTS users_name_idx ON "users" ("name")""")
+    executeUpdate(
+        """CREATE INDEX IF NOT EXISTS users_name_idx ON "users" ("name")""",
+        params = emptyMap(),
+        invalidates = emptyList(),
+    )
 }
 ```
 

--- a/kormium-core/src/commonMain/kotlin/DelicateKormiumApi.kt
+++ b/kormium-core/src/commonMain/kotlin/DelicateKormiumApi.kt
@@ -1,0 +1,17 @@
+package io.github.kormium
+
+/**
+ * Marks raw-SQL escape hatches: [RawExpression] and the `execute`/`executeUpdate`/`execSql`
+ * members of [Scope]/[SuspendScope]. These bypass the typed DSL — you are responsible for
+ * parameterizing values (never concatenate untrusted input into the SQL text) and, for
+ * `execute`/`executeUpdate`, for declaring which tables a write touches via `invalidates` so
+ * `kormium-observe` sees it. Opt in with `@OptIn(DelicateKormiumApi::class)` at the call site.
+ */
+@RequiresOptIn(
+    message = "Raw SQL bypasses Kormium's typed DSL. You are responsible for parameterization " +
+        "(never concatenate untrusted input) and, for execute/executeUpdate, for declaring which " +
+        "tables a write touches via `invalidates`.",
+    level = RequiresOptIn.Level.ERROR,
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class DelicateKormiumApi

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -101,6 +101,7 @@ internal fun structuralKey(expr: Expression): Any = when (expr) {
  * input — prefer [Value] and the typed operators below. Use only for SQL you
  * fully control.
  */
+@DelicateKormiumApi
 class RawExpression(val expression: String) : Expression {
     override fun toSql(builder: ParamBuilder): String = expression
 }

--- a/kormium-core/src/commonMain/kotlin/Scope.kt
+++ b/kormium-core/src/commonMain/kotlin/Scope.kt
@@ -146,6 +146,7 @@ class Scope<G : Catalog> internal constructor(
         return deleteRows(QueryBuilder().apply(block).build(), exec)
     }
 
+    @DelicateKormiumApi
     fun <T : Entity> Table<G, T>.execSql(sql: String) {
         markWritten()
         runRaw(sql, exec)
@@ -188,37 +189,31 @@ class Scope<G : Catalog> internal constructor(
 
     /**
      * Runs a raw query on the pinned connection, mapping each row with [handler]. Kormium can't
-     * see which tables raw SQL touches, so pass any it writes in [invalidates] to notify write
-     * listeners (e.g. `kormium-observe`) on commit; leave it empty for a pure read.
+     * see which tables raw SQL touches, so [invalidates] must list any it writes to notify write
+     * listeners (e.g. `kormium-observe`) on commit — pass `emptyList()` for a pure read. [params]
+     * must be given explicitly too, even when empty, so the parameterized path is never more
+     * effort than concatenating values into [sql].
      */
+    @DelicateKormiumApi
     fun <R> execute(
         sql: String,
-        params: Map<String, Any?> = emptyMap(),
-        invalidates: List<Table<G, *>> = emptyList(),
+        params: Map<String, Any?>,
+        invalidates: List<Table<G, *>>,
         handler: (ResultSet) -> R,
     ): List<R> {
         invalidates.forEach { it.markWritten() }
         return exec.execute(sql, params, handler)
     }
 
-    /** Runs raw SQL on the pinned connection, returning the row/update count. See [invalidates]. */
-    fun execute(
-        sql: String,
-        params: Map<String, Any?> = emptyMap(),
-        invalidates: List<Table<G, *>> = emptyList(),
-    ): Long {
-        invalidates.forEach { it.markWritten() }
-        return exec.execute(sql, params)
-    }
-
-    /** Runs a raw statement (DDL/DML) on the pinned connection. See [invalidates]. */
+    /** Runs a raw statement (DDL/DML) on the pinned connection, returning the affected row count. See [execute]. */
+    @DelicateKormiumApi
     fun executeUpdate(
         sql: String,
-        params: Map<String, Any?> = emptyMap(),
-        invalidates: List<Table<G, *>> = emptyList(),
-    ) {
+        params: Map<String, Any?>,
+        invalidates: List<Table<G, *>>,
+    ): Long {
         invalidates.forEach { it.markWritten() }
-        exec.executeUpdate(sql, params)
+        return exec.executeUpdate(sql, params)
     }
 
     /**

--- a/kormium-core/src/commonMain/kotlin/SuspendScope.kt
+++ b/kormium-core/src/commonMain/kotlin/SuspendScope.kt
@@ -120,6 +120,7 @@ class SuspendScope<G : Catalog> internal constructor(
         return deleteRows(QueryBuilder().apply(block).build(), exec)
     }
 
+    @DelicateKormiumApi
     suspend fun <T : Entity> Table<G, T>.execSql(sql: String) {
         markWritten()
         runRaw(sql, exec)
@@ -161,38 +162,29 @@ class SuspendScope<G : Catalog> internal constructor(
         hydrateLeftPairs(left, right, runSelect(exec, asJoin(), pairSelectFields(left, right)))
 
     /**
-     * Runs a raw query on the pinned connection, mapping each row with [handler]. Pass any
-     * tables the SQL writes in [invalidates] to notify write listeners on commit; see
+     * Runs a raw query on the pinned connection, mapping each row with [handler]. See
      * [Scope.execute].
      */
+    @DelicateKormiumApi
     suspend fun <R> execute(
         sql: String,
-        params: Map<String, Any?> = emptyMap(),
-        invalidates: List<Table<G, *>> = emptyList(),
+        params: Map<String, Any?>,
+        invalidates: List<Table<G, *>>,
         handler: (ResultSet) -> R,
     ): List<R> {
         invalidates.forEach { it.markWritten() }
         return exec.execute(sql, params, handler)
     }
 
-    /** Runs raw SQL on the pinned connection, returning the row/update count. See [invalidates]. */
-    suspend fun execute(
-        sql: String,
-        params: Map<String, Any?> = emptyMap(),
-        invalidates: List<Table<G, *>> = emptyList(),
-    ): Long {
-        invalidates.forEach { it.markWritten() }
-        return exec.execute(sql, params)
-    }
-
-    /** Runs a raw statement (DDL/DML) on the pinned connection. See [invalidates]. */
+    /** Runs a raw statement (DDL/DML) on the pinned connection, returning the affected row count. See [Scope.executeUpdate]. */
+    @DelicateKormiumApi
     suspend fun executeUpdate(
         sql: String,
-        params: Map<String, Any?> = emptyMap(),
-        invalidates: List<Table<G, *>> = emptyList(),
-    ) {
+        params: Map<String, Any?>,
+        invalidates: List<Table<G, *>>,
+    ): Long {
         invalidates.forEach { it.markWritten() }
-        exec.executeUpdate(sql, params)
+        return exec.executeUpdate(sql, params)
     }
 
     /**

--- a/kormium-core/src/commonTest/kotlin/QueryObserverTest.kt
+++ b/kormium-core/src/commonTest/kotlin/QueryObserverTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.Catalog
 import io.github.kormium.KormiumConfig
 import io.github.kormium.QueryEvent
@@ -29,7 +31,7 @@ class QueryObserverTest {
     fun selectIsObservedWithKindRowCountAndBackend() {
         val events = mutableListOf<QueryEvent>()
         val db = mock({ events += it }, listOf(1, 2, 3))
-        val rows = db.autocommit { execute("SELECT 1") { it.getInt(0) } }
+        val rows = db.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) } }
         assertEquals(3, rows.size)
         assertEquals(1, events.size)
         val e = events.single()
@@ -47,7 +49,7 @@ class QueryObserverTest {
     fun updateReportsAffectedRowCountAndKind() {
         val events = mutableListOf<QueryEvent>()
         val db = mock({ events += it }, 5L)
-        val affected = db.transaction { execute("UPDATE t SET x = :x", mapOf("x" to 1)) }
+        val affected = db.transaction { executeUpdate("UPDATE t SET x = :x", params = mapOf("x" to 1), invalidates = emptyList()) }
         assertEquals(5L, affected)
         val e = events.single()
         assertEquals(QueryKind.Update, e.kind)
@@ -58,7 +60,9 @@ class QueryObserverTest {
     fun observerNeverSeesParameterValues() {
         val events = mutableListOf<QueryEvent>()
         val db = mock({ events += it }, 1L)
-        db.transaction { executeUpdate("INSERT INTO t (secret) VALUES (:secret)", mapOf("secret" to "hunter2")) }
+        db.transaction {
+            executeUpdate("INSERT INTO t (secret) VALUES (:secret)", params = mapOf("secret" to "hunter2"), invalidates = emptyList())
+        }
         // The SQL template is reported verbatim; the value must not appear anywhere on the event.
         assertEquals("INSERT INTO t (secret) VALUES (:secret)", events.single().sql)
         assertEquals(QueryKind.Insert, events.single().kind)
@@ -68,14 +72,14 @@ class QueryObserverTest {
     fun nullObserverDoesNotWrapOrCrash() {
         val db = mock(null, listOf(42))
         // No observer configured: the call path must work exactly as before.
-        assertEquals(listOf(42), db.autocommit { execute("SELECT 1") { it.getInt(0) } })
+        assertEquals(listOf(42), db.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) } })
     }
 
     @Test
     fun throwingObserverDoesNotBreakTheQuery() {
         val db = mock({ throw RuntimeException("observer boom") }, listOf(7))
         // A misbehaving observer is swallowed; the query result is unaffected.
-        assertEquals(listOf(7), db.autocommit { execute("SELECT 1") { it.getInt(0) } })
+        assertEquals(listOf(7), db.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) } })
     }
 
     @Test
@@ -85,7 +89,7 @@ class QueryObserverTest {
             config = KormiumConfig(queryObserver = { events += it })
             result = listOf(1, 2)
         }
-        val rows = db.suspendAutocommit { execute("SELECT 1") { it.getInt(0) } }
+        val rows = db.suspendAutocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) } }
         assertEquals(2, rows.size)
         val e = events.single()
         assertEquals(QueryKind.Select, e.kind)

--- a/kormium-core/src/commonTest/kotlin/WriteListenerTest.kt
+++ b/kormium-core/src/commonTest/kotlin/WriteListenerTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.autocommit
 import io.github.kormium.database.Database
 import io.github.kormium.database.SuspendDatabase
@@ -98,11 +100,19 @@ class WriteListenerTest {
         db.writeListeners.add { fired = it }
 
         // Raw SQL with no declared tables: Kormium can't know what it touched → no notification.
-        db.transaction { executeUpdate("UPDATE products SET position = 0") }
+        db.transaction {
+            executeUpdate("UPDATE products SET position = :position", params = mapOf("position" to 0), invalidates = emptyList())
+        }
         assertEquals(null, fired, "undeclared raw write must not notify")
 
         // Declaring the affected table opts the raw write into notification.
-        db.transaction { executeUpdate("UPDATE products SET position = 0", invalidates = listOf(TestTable)) }
+        db.transaction {
+            executeUpdate(
+                "UPDATE products SET position = :position",
+                params = mapOf("position" to 0),
+                invalidates = listOf(TestTable),
+            )
+        }
         assertEquals(setOf("products"), fired)
     }
 

--- a/kormium-migrate/src/backendTest/kotlin/MigrateTest.kt
+++ b/kormium-migrate/src/backendTest/kotlin/MigrateTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.Catalog
 import io.github.kormium.autocommit
 import io.github.kormium.createSqliteDatabase
@@ -19,7 +21,9 @@ class MigrateTest {
     private fun db(): Database<Cat> = createSqliteDatabase()
 
     private fun Database<Cat>.rowCount(table: String): Int =
-        autocommit { execute("SELECT COUNT(*) FROM $table") { it.getInt(0)!! } }.first()
+        autocommit {
+            execute("SELECT COUNT(*) FROM $table", params = emptyMap(), invalidates = emptyList()) { it.getInt(0)!! }
+        }.first()
 
     @Test
     fun appliesPendingOnceAndIsIdempotent() {
@@ -35,7 +39,11 @@ class MigrateTest {
             assertEquals(1, db.rowCount("items"))
             // Both ids recorded, in order, with populated metadata.
             val journal = db.autocommit {
-                execute("SELECT id, checksum, applied_at, idx FROM kormium_migrations ORDER BY idx") { rs ->
+                execute(
+                    "SELECT id, checksum, applied_at, idx FROM kormium_migrations ORDER BY idx",
+                    params = emptyMap(),
+                    invalidates = emptyList(),
+                ) { rs ->
                     listOf(rs.getString(0), rs.getString(1), rs.getString(2), rs.getInt(3))
                 }
             }
@@ -65,7 +73,11 @@ class MigrateTest {
             // Both statements ran: the table exists and the index can be queried via sqlite_master.
             assertEquals(0, db.rowCount("users"))
             val indexes = db.autocommit {
-                execute("SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'users_name_idx'") { it.getString(0) }
+                execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'users_name_idx'",
+                    params = emptyMap(),
+                    invalidates = emptyList(),
+                ) { it.getString(0) }
             }
             assertEquals(listOf("users_name_idx"), indexes)
         }
@@ -91,7 +103,11 @@ class MigrateTest {
             )
             assertFails { db.migrate(batch) }
             // The whole transaction rolled back: neither the table nor the journal survives.
-            assertFails { db.autocommit { execute("""SELECT * FROM "rollme"""") { it.getInt(0) } } }
+            assertFails {
+                db.autocommit {
+                    execute("""SELECT * FROM "rollme"""", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) }
+                }
+            }
         }
     }
 }

--- a/kormium-mysql/src/jvmTest/kotlin/TableIntegrationTest.kt
+++ b/kormium-mysql/src/jvmTest/kotlin/TableIntegrationTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import io.github.kormium.Catalog
 import io.github.kormium.Column
@@ -192,9 +194,9 @@ class TableIntegrationTest {
         assumeDockerAvailable()
         ItDatabase.newDriver(poolSize = 1).use { driver ->
             assertFailsWith<Exception> {
-                driver.autocommit { execute("SELECT * FROM table_that_does_not_exist") { rs -> rs.getInt(0) } }
+                driver.autocommit { execute("SELECT * FROM table_that_does_not_exist", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } }
             }
-            assertEquals(1, driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single())
+            assertEquals(1, driver.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } }.single())
         }
     }
 
@@ -205,7 +207,7 @@ class TableIntegrationTest {
         val driver = ItDatabase.newDriver(poolSize = 1)
         driver.close()
         assertFailsWith<DatabaseClosedException> {
-            driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }
+            driver.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } }
         }
     }
 
@@ -251,14 +253,15 @@ class TableIntegrationTest {
         ItDatabase.migrate(migrations)
         ItDatabase.migrate(migrations) // already applied -> no-op
 
-        val rows = ItDatabase.autocommit { execute("SELECT id FROM `$table`") { it.getInt(0) } }
+        val rows = ItDatabase.autocommit { execute("SELECT id FROM `$table`", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) } }
         assertEquals(listOf(1), rows)
 
-        ItDatabase.autocommit { executeUpdate("DROP TABLE `$table`") }
+        ItDatabase.autocommit { executeUpdate("DROP TABLE `$table`", params = emptyMap(), invalidates = emptyList()) }
         ItDatabase.autocommit {
             executeUpdate(
                 "DELETE FROM kormium_migrations WHERE id IN (:a, :b)",
-                mapOf("a" to "001-$suffix", "b" to "002-$suffix"),
+                params = mapOf("a" to "001-$suffix", "b" to "002-$suffix"),
+                invalidates = emptyList(),
             )
         }
     }
@@ -482,6 +485,8 @@ object ItDatabase : Database<ItCatalog> {
                     `rank` INT
                 )
                 """.trimIndent(),
+                params = emptyMap(),
+                invalidates = emptyList(),
             )
         }
     }

--- a/kormium-mysql/src/nativeTest/kotlin/NativeMySqlTest.kt
+++ b/kormium-mysql/src/nativeTest/kotlin/NativeMySqlTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import io.github.kormium.Catalog
 import io.github.kormium.Column
@@ -57,7 +59,7 @@ class NativeMySqlTest {
         driver.close()
         assertEquals(true, driver.isClosed)
         driver.close() // idempotent: must not throw
-        assertFailsWith<DatabaseClosedException> { driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } } }
+        assertFailsWith<DatabaseClosedException> { driver.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } } }
     }
 
     @Test

--- a/kormium-postgres/src/jvmTest/kotlin/EdgeCaseTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/EdgeCaseTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import io.github.kormium.Catalog
 import io.github.kormium.Column

--- a/kormium-postgres/src/jvmTest/kotlin/PgNotificationIntegrationTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/PgNotificationIntegrationTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.Catalog
 import io.github.kormium.Column
 import io.github.kormium.Entity

--- a/kormium-postgres/src/jvmTest/kotlin/PgTransactionOptionsTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/PgTransactionOptionsTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.TransactionIsolation
 import io.github.kormium.autocommit
 import io.github.kormium.transaction
@@ -20,7 +22,7 @@ class PgTransactionOptionsTest {
         // Postgres reports the level the current transaction actually runs at.
         fun levelWith(isolation: TransactionIsolation) =
             ItDatabase.transaction(isolation = isolation) {
-                execute("SHOW transaction_isolation") { it.getString(0) }.first()
+                execute("SHOW transaction_isolation", params = emptyMap(), invalidates = emptyList()) { it.getString(0) }.first()
             }
         assertEquals("serializable", levelWith(TransactionIsolation.Serializable))
         assertEquals("repeatable read", levelWith(TransactionIsolation.RepeatableRead))
@@ -31,22 +33,22 @@ class PgTransactionOptionsTest {
     fun readOnlyTransactionReportsReadOnlyAndRejectsWrites() {
         assumeDockerAvailable()
         ItDatabase.autocommit {
-            executeUpdate("""CREATE TABLE IF NOT EXISTS pg_ro_widgets ("id" int PRIMARY KEY)""")
+            executeUpdate("""CREATE TABLE IF NOT EXISTS pg_ro_widgets ("id" int PRIMARY KEY)""", params = emptyMap(), invalidates = emptyList())
         }
 
         val readOnlyFlag = ItDatabase.transaction(readOnly = true) {
-            execute("SHOW transaction_read_only") { it.getString(0) }.first()
+            execute("SHOW transaction_read_only", params = emptyMap(), invalidates = emptyList()) { it.getString(0) }.first()
         }
         assertEquals("on", readOnlyFlag)
 
         // A write inside a read-only transaction is rejected by Postgres (SQLSTATE 25006).
         assertFailsWith<Throwable> {
             ItDatabase.transaction(readOnly = true) {
-                executeUpdate("INSERT INTO pg_ro_widgets (\"id\") VALUES (1)")
+                executeUpdate("INSERT INTO pg_ro_widgets (\"id\") VALUES (1)", params = emptyMap(), invalidates = emptyList())
             }
         }
         assertEquals(0L, ItDatabase.autocommit {
-            execute("SELECT count(*) FROM pg_ro_widgets") { it.getLong(0) }.first()
+            execute("SELECT count(*) FROM pg_ro_widgets", params = emptyMap(), invalidates = emptyList()) { it.getLong(0) }.first()
         })
     }
 
@@ -54,24 +56,24 @@ class PgTransactionOptionsTest {
     fun connectionStateIsRestoredAfterAnOptionedTransaction() {
         assumeDockerAvailable()
         ItDatabase.autocommit {
-            executeUpdate("""CREATE TABLE IF NOT EXISTS pg_rw_widgets ("id" int PRIMARY KEY)""")
-            executeUpdate("DELETE FROM pg_rw_widgets")
+            executeUpdate("""CREATE TABLE IF NOT EXISTS pg_rw_widgets ("id" int PRIMARY KEY)""", params = emptyMap(), invalidates = emptyList())
+            executeUpdate("DELETE FROM pg_rw_widgets", params = emptyMap(), invalidates = emptyList())
         }
         // A read-only + serializable transaction must not leave the (pooled) connection read-only
         // or stuck at serializable for the next writer.
         ItDatabase.transaction(isolation = TransactionIsolation.Serializable, readOnly = true) {
-            execute("SELECT 1") { it.getInt(0) }
+            execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) }
         }
         ItDatabase.transaction {
-            executeUpdate("INSERT INTO pg_rw_widgets (\"id\") VALUES (1)")
+            executeUpdate("INSERT INTO pg_rw_widgets (\"id\") VALUES (1)", params = emptyMap(), invalidates = emptyList())
         }
         // The next transaction is back to the default read-committed isolation.
         val isolation = ItDatabase.transaction {
-            execute("SHOW transaction_isolation") { it.getString(0) }.first()
+            execute("SHOW transaction_isolation", params = emptyMap(), invalidates = emptyList()) { it.getString(0) }.first()
         }
         assertEquals("read committed", isolation)
         assertEquals(1L, ItDatabase.autocommit {
-            execute("SELECT count(*) FROM pg_rw_widgets") { it.getLong(0) }.first()
+            execute("SELECT count(*) FROM pg_rw_widgets", params = emptyMap(), invalidates = emptyList()) { it.getLong(0) }.first()
         })
     }
 

--- a/kormium-postgres/src/jvmTest/kotlin/QueryCoverageTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/QueryCoverageTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.Catalog
 import io.github.kormium.CheckViolationException
 import io.github.kormium.Column
@@ -56,10 +58,12 @@ class QueryCoverageTest {
             QcNotNull.execSql(qcNotNullDdl)
             QcCheck.execSql(qcCheckDdl)
             QcUpsert.execSql(qcUpsertDdl)
-            executeUpdate("CREATE TABLE IF NOT EXISTS qc_fk_parent (id uuid PRIMARY KEY)")
+            executeUpdate("CREATE TABLE IF NOT EXISTS qc_fk_parent (id uuid PRIMARY KEY)", params = emptyMap(), invalidates = emptyList())
             executeUpdate(
                 "CREATE TABLE IF NOT EXISTS qc_fk_child (" +
-                    "id uuid PRIMARY KEY, parent_id uuid REFERENCES qc_fk_parent(id))"
+                    "id uuid PRIMARY KEY, parent_id uuid REFERENCES qc_fk_parent(id))",
+                params = emptyMap(),
+                invalidates = emptyList(),
             )
         }
     }
@@ -224,7 +228,8 @@ class QueryCoverageTest {
                 // typed column mapper, and pgjdbc cannot infer a SQL type for kotlin.uuid.Uuid.
                 executeUpdate(
                     "INSERT INTO qc_notnull (id) VALUES (:id::uuid)",
-                    mapOf("id" to Uuid.random().toString()),
+                    params = mapOf("id" to Uuid.random().toString()),
+                    invalidates = emptyList(),
                 )
             }
         }
@@ -238,7 +243,8 @@ class QueryCoverageTest {
             ItDatabase.transaction {
                 executeUpdate(
                     "INSERT INTO qc_fk_child (id, parent_id) VALUES (:id::uuid, :p::uuid)",
-                    mapOf("id" to Uuid.random().toString(), "p" to Uuid.random().toString()),
+                    params = mapOf("id" to Uuid.random().toString(), "p" to Uuid.random().toString()),
+                    invalidates = emptyList(),
                 )
             }
         }

--- a/kormium-postgres/src/jvmTest/kotlin/StabilityTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/StabilityTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.autocommit
 import io.github.kormium.database.createDatabase
 import org.junit.jupiter.api.Assumptions.assumeTrue
@@ -27,7 +29,7 @@ class StabilityTest {
             val threads = (1..16).map {
                 Thread {
                     try {
-                        repeat(2_000) { check(driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single() == 1) }
+                        repeat(2_000) { check(driver.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } }.single() == 1) }
                     } catch (t: Throwable) {
                         errors += t
                     }
@@ -44,7 +46,7 @@ class StabilityTest {
     fun noConnectionLeakUnderManyOps() {
         assumeDocker()
         ItDatabase.newDriver(poolSize = 2).use { driver ->
-            repeat(2_000) { check(driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single() == 1) }
+            repeat(2_000) { check(driver.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } }.single() == 1) }
         }
     }
 
@@ -65,12 +67,12 @@ class StabilityTest {
                 password = container.password,
                 poolSize = 4,
             ).use { driver ->
-                check(driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single() == 1)
+                check(driver.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } }.single() == 1)
                 container.dockerClient.restartContainerCmd(container.containerId).exec()
                 val deadline = System.currentTimeMillis() + 60_000
                 var recovered = false
                 while (System.currentTimeMillis() < deadline && !recovered) {
-                    recovered = runCatching { driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single() == 1 }
+                    recovered = runCatching { driver.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } }.single() == 1 }
                         .getOrDefault(false)
                     if (!recovered) Thread.sleep(500)
                 }

--- a/kormium-postgres/src/jvmTest/kotlin/TableIntegrationTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/TableIntegrationTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import io.github.kormium.Catalog
 import io.github.kormium.Column
@@ -140,9 +142,9 @@ class TableIntegrationTest {
         assumeDockerAvailable()
         ItDatabase.newDriver(poolSize = 1).use { driver ->
             assertFailsWith<Exception> {
-                driver.autocommit { execute("SELECT * FROM table_that_does_not_exist") { rs -> rs.getInt(0) } }
+                driver.autocommit { execute("SELECT * FROM table_that_does_not_exist", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } }
             }
-            assertEquals(1, driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single())
+            assertEquals(1, driver.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } }.single())
         }
     }
 
@@ -153,7 +155,7 @@ class TableIntegrationTest {
         val driver = ItDatabase.newDriver(poolSize = 1)
         driver.close()
         assertFailsWith<DatabaseClosedException> {
-            driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }
+            driver.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } }
         }
     }
 
@@ -311,14 +313,15 @@ class TableIntegrationTest {
         ItDatabase.migrate(migrations) // already applied → no-op
 
         // The row inserted by 002 exists exactly once, proving each migration ran a single time.
-        val rows = ItDatabase.autocommit { execute("SELECT id FROM public.$table") { it.getInt(0) } }
+        val rows = ItDatabase.autocommit { execute("SELECT id FROM public.$table", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) } }
         assertEquals(listOf(1), rows)
 
-        ItDatabase.autocommit { executeUpdate("DROP TABLE public.$table") }
+        ItDatabase.autocommit { executeUpdate("DROP TABLE public.$table", params = emptyMap(), invalidates = emptyList()) }
         ItDatabase.autocommit {
             executeUpdate(
                 "DELETE FROM kormium_migrations WHERE id IN (:a, :b)",
-                mapOf("a" to "001-$suffix", "b" to "002-$suffix"),
+                params = mapOf("a" to "001-$suffix", "b" to "002-$suffix"),
+                invalidates = emptyList(),
             )
         }
     }
@@ -377,7 +380,7 @@ class TableIntegrationTest {
         ItDatabase.newDriver(poolSize = 4).use { driver ->
             val threads = (1..8).map {
                 Thread {
-                    repeat(50) { sum.addAndGet(driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) ?: 0 } }.single()) }
+                    repeat(50) { sum.addAndGet(driver.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) ?: 0 } }.single()) }
                 }
             }
             threads.forEach { it.start() }
@@ -608,7 +611,9 @@ object ItDatabase : Database<ItCatalog> {
                     note text,
                     rank int
                 )
-                """.trimIndent()
+                """.trimIndent(),
+                params = emptyMap(),
+                invalidates = emptyList(),
             )
         }
     }

--- a/kormium-postgres/src/nativeTest/kotlin/NativeBenchmark.kt
+++ b/kormium-postgres/src/nativeTest/kotlin/NativeBenchmark.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import io.github.kormium.Catalog
 import io.github.kormium.Column
@@ -95,7 +97,7 @@ class NativeBenchmark {
         driver.transaction {
             BenchTable.execSql("DROP TABLE IF EXISTS \"cmp_bench\"")
             BenchTable.execSql(benchDdl)
-            executeUpdate("""CREATE INDEX IF NOT EXISTS cmp_bench_name_idx ON "public"."cmp_bench" ("name")""")
+            executeUpdate("""CREATE INDEX IF NOT EXISTS cmp_bench_name_idx ON "public"."cmp_bench" ("name")""", params = emptyMap(), invalidates = emptyList())
         }
 
         val threads = 8
@@ -138,7 +140,7 @@ class NativeBenchmark {
     /** Same per-iteration state as the JVM harness: seed row, bulk rows, update targets. */
     private fun reset(driver: Database<BenchCatalog>) {
         driver.transaction {
-            executeUpdate("""TRUNCATE "public"."cmp_bench"""")
+            executeUpdate("""TRUNCATE "public"."cmp_bench"""", params = emptyMap(), invalidates = emptyList())
             BenchTable.insert(BenchRow().apply { id = benchSeedId; name = "seed"; amount = BigDecimal.fromInt(1) })
             BenchTable.insertAll(List(BULK_ROWS) { newRow("bulk") })
             BenchTable.insertAll(updateIds.map { rowId ->

--- a/kormium-postgres/src/nativeTest/kotlin/NativeTableIntegrationTest.kt
+++ b/kormium-postgres/src/nativeTest/kotlin/NativeTableIntegrationTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import io.github.kormium.Catalog
 import io.github.kormium.CheckViolationException
@@ -98,10 +100,10 @@ class NativeTableIntegrationTest {
         }
         nativeDriver(poolSize = 1).use { driver ->
             assertFailsWith<Exception> {
-                driver.autocommit { execute("SELECT * FROM table_that_does_not_exist") { rs -> rs.getInt(0) } }
+                driver.autocommit { execute("SELECT * FROM table_that_does_not_exist", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } }
             }
             // Same single connection must still be usable after the error above.
-            assertEquals(1, driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }.single())
+            assertEquals(1, driver.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } }.single())
         }
     }
 
@@ -115,7 +117,7 @@ class NativeTableIntegrationTest {
         val driver = nativeDriver(poolSize = 1)
         driver.close()
         assertFailsWith<DatabaseClosedException> {
-            driver.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) } }
+            driver.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) } }
         }
     }
 
@@ -224,7 +226,9 @@ class NativeTableIntegrationTest {
         NativeDatabase.transaction {
             executeUpdate(
                 """CREATE TABLE IF NOT EXISTS public.native_upsert (""" +
-                    """tenant uuid NOT NULL, sku text NOT NULL, qty int NOT NULL, UNIQUE (tenant, sku))"""
+                    """tenant uuid NOT NULL, sku text NOT NULL, qty int NOT NULL, UNIQUE (tenant, sku))""",
+                params = emptyMap(),
+                invalidates = emptyList(),
             )
             NativeUpsert.upsert(
                 entity = NativeUpsertRow().apply { this.tenant = tenant; this.sku = sku; qty = 1 },
@@ -259,12 +263,16 @@ class NativeTableIntegrationTest {
         NativeDatabase.transaction {
             executeUpdate(
                 """CREATE TABLE IF NOT EXISTS public.native_check (""" +
-                    """id uuid PRIMARY KEY, amount int NOT NULL CHECK (amount >= 0))"""
+                    """id uuid PRIMARY KEY, amount int NOT NULL CHECK (amount >= 0))""",
+                params = emptyMap(),
+                invalidates = emptyList(),
             )
-            executeUpdate("""CREATE TABLE IF NOT EXISTS public.native_fk_parent (id uuid PRIMARY KEY)""")
+            executeUpdate("""CREATE TABLE IF NOT EXISTS public.native_fk_parent (id uuid PRIMARY KEY)""", params = emptyMap(), invalidates = emptyList())
             executeUpdate(
                 """CREATE TABLE IF NOT EXISTS public.native_fk_child (""" +
-                    """id uuid PRIMARY KEY, parent_id uuid REFERENCES public.native_fk_parent(id))"""
+                    """id uuid PRIMARY KEY, parent_id uuid REFERENCES public.native_fk_parent(id))""",
+                params = emptyMap(),
+                invalidates = emptyList(),
             )
         }
         val check = assertFailsWith<CheckViolationException> {
@@ -277,7 +285,8 @@ class NativeTableIntegrationTest {
             NativeDatabase.transaction {
                 executeUpdate(
                     "INSERT INTO public.native_fk_child (id, parent_id) VALUES (:id::uuid, :p::uuid)",
-                    mapOf("id" to Uuid.random().toString(), "p" to Uuid.random().toString()),
+                    params = mapOf("id" to Uuid.random().toString(), "p" to Uuid.random().toString()),
+                    invalidates = emptyList(),
                 )
             }
         }
@@ -298,14 +307,16 @@ class NativeTableIntegrationTest {
         nativeDriver(poolSize = 1).use { driver ->
             driver.transaction {
                 // Pin the session zone so timestamptz prints the bare "+00" form.
-                execute("SET TIME ZONE 'UTC'")
+                executeUpdate("SET TIME ZONE 'UTC'", params = emptyMap(), invalidates = emptyList())
                 val rows = execute(
                     """
                     SELECT '2024-01-15 13:45:30.123456+00'::timestamptz,
                            '2024-01-15 13:45:30'::timestamp,
                            '2024-01-15'::date,
                            '13:45:30'::time
-                    """.trimIndent()
+                    """.trimIndent(),
+                    params = emptyMap(),
+                    invalidates = emptyList(),
                 ) { rs ->
                     assertEquals(Instant.parse("2024-01-15T13:45:30.123456Z"), rs.getInstant(0))
                     assertEquals(LocalDateTime.parse("2024-01-15T13:45:30"), rs.getLocalDateTime(1))
@@ -332,7 +343,7 @@ class NativeTableIntegrationTest {
             val futures = workers.map { worker ->
                 worker.execute(TransferMode.SAFE, { driver }) { db ->
                     var ok = 0
-                    repeat(2_000) { if (db.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) ?: 0 } }.single() == 1) ok++ }
+                    repeat(2_000) { if (db.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) ?: 0 } }.single() == 1) ok++ }
                     ok
                 }
             }
@@ -356,7 +367,7 @@ class NativeTableIntegrationTest {
         nativeDriver(poolSize = 1).use { driver ->
             repeat(10) { i ->
                 val got = driver.autocommit {
-                    execute("SELECT :a::int + :b::int", mapOf("a" to i, "b" to 100)) { rs -> rs.getInt(0) }
+                    execute("SELECT :a::int + :b::int", params = mapOf("a" to i, "b" to 100), invalidates = emptyList()) { rs -> rs.getInt(0) }
                 }.single()
                 assertEquals(i + 100, got)
             }
@@ -375,7 +386,7 @@ class NativeTableIntegrationTest {
             val futures = workers.map { worker ->
                 worker.execute(TransferMode.SAFE, { driver }) { db ->
                     var sum = 0
-                    repeat(50) { sum += db.autocommit { execute("SELECT 1") { rs -> rs.getInt(0) ?: 0 } }.single() }
+                    repeat(50) { sum += db.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { rs -> rs.getInt(0) ?: 0 } }.single() }
                     sum
                 }
             }
@@ -457,7 +468,9 @@ object NativeDatabase : Database<NativeCatalog> {
                     note text,
                     rank int
                 )
-                """.trimIndent()
+                """.trimIndent(),
+                params = emptyMap(),
+                invalidates = emptyList(),
             )
         }
     }

--- a/kormium-r2dbc/src/jvmTest/kotlin/R2dbcNotificationIntegrationTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/R2dbcNotificationIntegrationTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.Catalog
 import io.github.kormium.Column
 import io.github.kormium.Entity

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/MySqlR2dbcIntegrationTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/MySqlR2dbcIntegrationTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.r2dbc
 
 import io.github.kormium.Catalog

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcCancellationTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcCancellationTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.r2dbc
 
 import io.github.kormium.Query

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcEdgeCaseTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcEdgeCaseTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.r2dbc
 
 import io.github.kormium.Catalog
@@ -61,10 +63,12 @@ class R2dbcEdgeCaseTest {
                 ECheck.execSql(eCheckDdl)
                 EUpsert.execSql(eUpsertDdl)
                 ENotNull.execSql(eNotNullDdl)
-                executeUpdate("""CREATE TABLE IF NOT EXISTS "e_fk_parent" ("id" uuid PRIMARY KEY)""")
+                executeUpdate("""CREATE TABLE IF NOT EXISTS "e_fk_parent" ("id" uuid PRIMARY KEY)""", params = emptyMap(), invalidates = emptyList())
                 executeUpdate(
                     """CREATE TABLE IF NOT EXISTS "e_fk_child" (""" +
-                        """"id" uuid PRIMARY KEY, "parent_id" uuid REFERENCES "e_fk_parent"("id"))"""
+                        """"id" uuid PRIMARY KEY, "parent_id" uuid REFERENCES "e_fk_parent"("id"))""",
+                    params = emptyMap(),
+                    invalidates = emptyList(),
                 )
             }
         }
@@ -178,7 +182,8 @@ class R2dbcEdgeCaseTest {
                 db!!.suspendTransaction {
                     executeUpdate(
                         """INSERT INTO "e_notnull" ("id") VALUES (:id::uuid)""",
-                        mapOf("id" to Uuid.random().toString()),
+                        params = mapOf("id" to Uuid.random().toString()),
+                        invalidates = emptyList(),
                     )
                 }
             }
@@ -195,7 +200,8 @@ class R2dbcEdgeCaseTest {
                 db!!.suspendTransaction {
                     executeUpdate(
                         """INSERT INTO "e_fk_child" ("id", "parent_id") VALUES (:id::uuid, :p::uuid)""",
-                        mapOf("id" to Uuid.random().toString(), "p" to Uuid.random().toString()),
+                        params = mapOf("id" to Uuid.random().toString(), "p" to Uuid.random().toString()),
+                        invalidates = emptyList(),
                     )
                 }
             }

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcIntegrationTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcIntegrationTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.r2dbc
 
 import io.github.kormium.Catalog

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcLifecycleTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcLifecycleTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.r2dbc
 
 import io.github.kormium.DatabaseClosedException
@@ -51,8 +53,8 @@ class R2dbcLifecycleTest {
         withDb { db ->
             db.close()
             runBlocking {
-                assertFailsWith<DatabaseClosedException> { db.suspendAutocommit { execute("SELECT 1") } }
-                assertFailsWith<DatabaseClosedException> { db.suspendTransaction { execute("SELECT 1") } }
+                assertFailsWith<DatabaseClosedException> { db.suspendAutocommit { executeUpdate("SELECT 1", params = emptyMap(), invalidates = emptyList()) } }
+                assertFailsWith<DatabaseClosedException> { db.suspendTransaction { executeUpdate("SELECT 1", params = emptyMap(), invalidates = emptyList()) } }
             }
         }
     }

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcTransactionOptionsTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcTransactionOptionsTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.r2dbc
 
 import io.github.kormium.TransactionIsolation
@@ -52,21 +54,21 @@ class R2dbcTransactionOptionsTest {
         val database = db!!
         runBlocking {
             val level = database.suspendTransaction(isolation = TransactionIsolation.Serializable) {
-                execute("SHOW transaction_isolation") { it.getString(0) }.first()
+                execute("SHOW transaction_isolation", params = emptyMap(), invalidates = emptyList()) { it.getString(0) }.first()
             }
             assertEquals("serializable", level)
 
             val readOnly = database.suspendTransaction(readOnly = true) {
-                execute("SHOW transaction_read_only") { it.getString(0) }.first()
+                execute("SHOW transaction_read_only", params = emptyMap(), invalidates = emptyList()) { it.getString(0) }.first()
             }
             assertEquals("on", readOnly)
 
             database.suspendAutocommit {
-                executeUpdate("""CREATE TABLE IF NOT EXISTS r2_ro_widgets ("id" int PRIMARY KEY)""")
+                executeUpdate("""CREATE TABLE IF NOT EXISTS r2_ro_widgets ("id" int PRIMARY KEY)""", params = emptyMap(), invalidates = emptyList())
             }
             assertFailsWith<Throwable> {
                 database.suspendTransaction(readOnly = true) {
-                    executeUpdate("INSERT INTO r2_ro_widgets (\"id\") VALUES (1)")
+                    executeUpdate("INSERT INTO r2_ro_widgets (\"id\") VALUES (1)", params = emptyMap(), invalidates = emptyList())
                 }
             }
         }

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteBuilderTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteBuilderTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import io.github.kormium.BatchInsertMode
 import io.github.kormium.autocommit
@@ -17,7 +19,7 @@ class SqliteBuilderTest {
     fun builderAppliesConfigAndRunsBeforeStart() {
         val db: Database<SqCatalog> = createSqliteDatabase {
             config { batchInsertMode = BatchInsertMode.UnionNulls }
-            beforeStart { autocommit { executeUpdate(productsDdl) } }   // create the schema before the db is returned
+            beforeStart { autocommit { executeUpdate(productsDdl, params = emptyMap(), invalidates = emptyList()) } }   // create the schema before the db is returned
         }
 
         db.use {

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteCancellationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteCancellationTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.Catalog
 import io.github.kormium.Column
 import io.github.kormium.Entity

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteColumnTypeTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteColumnTypeTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.Column
 import io.github.kormium.Entity
 import io.github.kormium.Table

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteEdgeCaseTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteEdgeCaseTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.Catalog
 import io.github.kormium.Column
 import io.github.kormium.Entity

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import io.github.kormium.Catalog
 import io.github.kormium.Column
@@ -474,17 +476,20 @@ class SqliteIntegrationTest {
     @Test
     fun testForeignKeyViolationIsTyped() {
         db.transaction {
-            executeUpdate("CREATE TABLE IF NOT EXISTS fk_parent (id TEXT PRIMARY KEY)")
+            executeUpdate("CREATE TABLE IF NOT EXISTS fk_parent (id TEXT PRIMARY KEY)", params = emptyMap(), invalidates = emptyList())
             executeUpdate(
                 "CREATE TABLE IF NOT EXISTS fk_child (" +
-                    "id TEXT PRIMARY KEY, parent_id TEXT REFERENCES fk_parent(id))"
+                    "id TEXT PRIMARY KEY, parent_id TEXT REFERENCES fk_parent(id))",
+                params = emptyMap(),
+                invalidates = emptyList(),
             )
         }
         assertFailsWith<ForeignKeyViolationException> {
             db.transaction {
                 executeUpdate(
                     "INSERT INTO fk_child (id, parent_id) VALUES (:id, :p)",
-                    mapOf("id" to Uuid.random().toString(), "p" to Uuid.random().toString()),
+                    params = mapOf("id" to Uuid.random().toString(), "p" to Uuid.random().toString()),
+                    invalidates = emptyList(),
                 )
             }
         }

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteLifecycleTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteLifecycleTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.Catalog
 import io.github.kormium.DatabaseClosedException
 import io.github.kormium.autocommit
@@ -33,14 +35,14 @@ class SqliteLifecycleTest {
     fun useAfterCloseThrowsDatabaseClosed() {
         val db = createSqliteDatabase(":memory:")
         db.close()
-        assertFailsWith<DatabaseClosedException> { db.autocommit { execute("SELECT 1") } }
-        assertFailsWith<DatabaseClosedException> { db.transaction { execute("SELECT 1") } }
+        assertFailsWith<DatabaseClosedException> { db.autocommit { executeUpdate("SELECT 1", params = emptyMap(), invalidates = emptyList()) } }
+        assertFailsWith<DatabaseClosedException> { db.transaction { executeUpdate("SELECT 1", params = emptyMap(), invalidates = emptyList()) } }
     }
 
     @Test
     fun suspendUseAfterCloseThrowsDatabaseClosed() = runTest {
         val db = createSqliteDatabase(":memory:")
         db.close()
-        assertFailsWith<DatabaseClosedException> { db.suspendAutocommit { execute("SELECT 1") } }
+        assertFailsWith<DatabaseClosedException> { db.suspendAutocommit { executeUpdate("SELECT 1", params = emptyMap(), invalidates = emptyList()) } }
     }
 }

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteObserveTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteObserveTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import io.github.kormium.createSqliteDatabase
 import io.github.kormium.database.SuspendDatabase

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteQueryCoverageTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteQueryCoverageTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.Catalog
 import io.github.kormium.CheckViolationException
 import io.github.kormium.Column
@@ -289,7 +291,8 @@ class SqliteQueryCoverageTest {
                 // Insert via raw SQL so we can omit the NOT NULL "label" column entirely.
                 executeUpdate(
                     "INSERT INTO qc_notnull (id) VALUES (:id)",
-                    mapOf("id" to Uuid.random().toString()),
+                    params = mapOf("id" to Uuid.random().toString()),
+                    invalidates = emptyList(),
                 )
             }
         }
@@ -299,17 +302,20 @@ class SqliteQueryCoverageTest {
     @Test
     fun foreignKeyViolationIsTyped() {
         db.transaction {
-            executeUpdate("CREATE TABLE IF NOT EXISTS qc_fk_parent (id TEXT PRIMARY KEY)")
+            executeUpdate("CREATE TABLE IF NOT EXISTS qc_fk_parent (id TEXT PRIMARY KEY)", params = emptyMap(), invalidates = emptyList())
             executeUpdate(
                 "CREATE TABLE IF NOT EXISTS qc_fk_child (" +
-                    "id TEXT PRIMARY KEY, parent_id TEXT REFERENCES qc_fk_parent(id))"
+                    "id TEXT PRIMARY KEY, parent_id TEXT REFERENCES qc_fk_parent(id))",
+                params = emptyMap(),
+                invalidates = emptyList(),
             )
         }
         assertFailsWith<ForeignKeyViolationException> {
             db.transaction {
                 executeUpdate(
                     "INSERT INTO qc_fk_child (id, parent_id) VALUES (:id, :p)",
-                    mapOf("id" to Uuid.random().toString(), "p" to Uuid.random().toString()),
+                    params = mapOf("id" to Uuid.random().toString(), "p" to Uuid.random().toString()),
+                    invalidates = emptyList(),
                 )
             }
         }

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteQueryObserverTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteQueryObserverTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.Catalog
 import io.github.kormium.Column
 import io.github.kormium.Entity
@@ -56,7 +58,7 @@ class SqliteQueryObserverTest {
     fun observesRawExecute() {
         db.transaction { ObsItems.execSql(obsItemsDdl) }
         events.clear()
-        db.autocommit { execute("SELECT 1") }
+        db.autocommit { execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { } }
         assertTrue(events.any { it.kind == QueryKind.Select && it.sql == "SELECT 1" })
     }
 

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteResultMappingTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteResultMappingTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.Catalog
 import io.github.kormium.Column
 import io.github.kormium.Entity
@@ -33,7 +35,7 @@ class SqliteResultMappingTest {
         db.transaction {
             RmItems.execSql(rmDdlNameNullable)
             // Plant a row whose non-null `name` is actually NULL in the database.
-            executeUpdate("INSERT INTO rm_items (id, note) VALUES (:id, :note)", mapOf("id" to id.toString(), "note" to "x"))
+            executeUpdate("INSERT INTO rm_items (id, note) VALUES (:id, :note)", params = mapOf("id" to id.toString(), "note" to "x"), invalidates = emptyList())
         }
         val ex = assertFailsWith<ResultMappingException> {
             db.autocommit { RmItems.findOne { where { RmItems.id eq id } } }
@@ -52,7 +54,8 @@ class SqliteResultMappingTest {
             // Plant a non-parseable UUID in the non-null `ref` column.
             executeUpdate(
                 "INSERT INTO rm_typed (id, ref, status) VALUES (:id, :ref, :status)",
-                mapOf("id" to id.toString(), "ref" to "not-a-uuid", "status" to "ACTIVE"),
+                params = mapOf("id" to id.toString(), "ref" to "not-a-uuid", "status" to "ACTIVE"),
+                invalidates = emptyList(),
             )
         }
         val ex = assertFailsWith<ResultMappingException> { db.autocommit { RmTyped.findOne { where { RmTyped.id eq id } } } }
@@ -69,7 +72,8 @@ class SqliteResultMappingTest {
             RmTyped.execSql(rmTypedDdl)
             executeUpdate(
                 "INSERT INTO rm_typed (id, ref, status) VALUES (:id, :ref, :status)",
-                mapOf("id" to id.toString(), "ref" to Uuid.random().toString(), "status" to "BOGUS"),
+                params = mapOf("id" to id.toString(), "ref" to Uuid.random().toString(), "status" to "BOGUS"),
+                invalidates = emptyList(),
             )
         }
         val ex = assertFailsWith<ResultMappingException> { db.autocommit { RmTyped.findOne { where { RmTyped.id eq id } } } }
@@ -84,7 +88,7 @@ class SqliteResultMappingTest {
         val id = Uuid.random()
         db.transaction {
             RmItems.execSql(rmDdlNameNullable)
-            executeUpdate("INSERT INTO rm_items (id, name) VALUES (:id, :name)", mapOf("id" to id.toString(), "name" to "ok"))
+            executeUpdate("INSERT INTO rm_items (id, name) VALUES (:id, :name)", params = mapOf("id" to id.toString(), "name" to "ok"), invalidates = emptyList())
         }
         val row = db.autocommit { RmItems.findOne { where { RmItems.id eq id } } }
         assertEquals("ok", row?.name)

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteSuspendTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteSuspendTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import io.github.kormium.createSqliteDatabase
 import io.github.kormium.database.SuspendDatabase

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteTransactionOptionsTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteTransactionOptionsTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 import io.github.kormium.Catalog
 import io.github.kormium.Column
 import io.github.kormium.Entity
@@ -27,7 +29,7 @@ class SqliteTransactionOptionsTest {
     // poolSize defaults to 1, so the read-only connection is the one reused next — exactly what
     // we need to prove PRAGMA query_only is reset on release.
     private val db: Database<RoCatalog> = createSqliteDatabase(":memory:").also { d ->
-        d.transaction { executeUpdate(roWidgetsDdl) }
+        d.transaction { executeUpdate(roWidgetsDdl, params = emptyMap(), invalidates = emptyList()) }
     }
 
     @Test

--- a/readme.md
+++ b/readme.md
@@ -192,10 +192,16 @@ module details.
 
 Kormium does not own schema management — create tables with raw SQL or a migration tool.
 
+Raw SQL is gated by `@OptIn(DelicateKormiumApi::class)`, and `executeUpdate` always takes
+`params` and `invalidates` explicitly (`emptyMap()` / `emptyList()` when there's nothing to bind
+or no table to notify):
+
 ```kotlin
 db.transaction {
     executeUpdate(
         """CREATE TABLE IF NOT EXISTS "users" ("id" uuid NOT NULL, "name" text NOT NULL, "age" integer NOT NULL, PRIMARY KEY ("id"))""",
+        params = emptyMap(),
+        invalidates = emptyList(),
     )
     Users.insert(User().apply {
         id = Uuid.random()

--- a/samples/cross-instance-cache/src/commonMain/kotlin/Sample.kt
+++ b/samples/cross-instance-cache/src/commonMain/kotlin/Sample.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.samples.crossinstancecache
 
 import eu.vendeli.rethis.ReThis

--- a/samples/ktor-di/src/jvmTest/kotlin/KtorDiTest.kt
+++ b/samples/ktor-di/src/jvmTest/kotlin/KtorDiTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.samples.ktordi
 
 import io.github.kormium.database.SuspendDatabase

--- a/samples/ktor-koin/src/jvmTest/kotlin/KtorKoinTest.kt
+++ b/samples/ktor-koin/src/jvmTest/kotlin/KtorKoinTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.samples.ktorkoin
 
 import io.github.kormium.database.SuspendDatabase

--- a/samples/r2dbc/src/jvmTest/kotlin/R2dbcSampleTest.kt
+++ b/samples/r2dbc/src/jvmTest/kotlin/R2dbcSampleTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.samples.r2dbc
 
 import io.github.kormium.database.SuspendDatabase

--- a/samples/repository/src/commonMain/kotlin/Main.kt
+++ b/samples/repository/src/commonMain/kotlin/Main.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.samples.repository
 
 import io.github.kormium.Catalog

--- a/samples/repository/src/commonTest/kotlin/RepositoryTest.kt
+++ b/samples/repository/src/commonTest/kotlin/RepositoryTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.samples.repository
 
 import io.github.kormium.createSqliteDatabase

--- a/samples/sharding/src/commonMain/kotlin/Main.kt
+++ b/samples/sharding/src/commonMain/kotlin/Main.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.samples.sharding
 
 import io.github.kormium.Catalog

--- a/samples/sharding/src/commonTest/kotlin/ShardingTest.kt
+++ b/samples/sharding/src/commonTest/kotlin/ShardingTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.samples.sharding
 
 import io.github.kormium.autocommit

--- a/samples/sqlite-cache/src/commonMain/kotlin/Main.kt
+++ b/samples/sqlite-cache/src/commonMain/kotlin/Main.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.samples.sqlitecache
 
 import io.github.kormium.Catalog

--- a/samples/sqlite-cache/src/jvmTest/kotlin/SqliteCacheTest.kt
+++ b/samples/sqlite-cache/src/jvmTest/kotlin/SqliteCacheTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.samples.sqlitecache
 
 import io.github.kormium.autocommit

--- a/samples/wasm-todo/src/wasmJsMain/kotlin/io/github/kormium/sample/todo/TodoRepository.kt
+++ b/samples/wasm-todo/src/wasmJsMain/kotlin/io/github/kormium/sample/todo/TodoRepository.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
 package io.github.kormium.sample.todo
 
 import io.github.kormium.database.SuspendDatabase


### PR DESCRIPTION
## Summary
- `Scope`/`SuspendScope.execute`/`executeUpdate` no longer default `params`/`invalidates` — both must be passed explicitly on every raw-SQL call, so the parameterized path is never more effort than string concatenation and a write can no longer silently skip `kormium-observe` notification.
- The redundant `execute(sql, params, invalidates): Long` overload (a duplicate of `executeUpdate` that discarded its row count) is merged away; `executeUpdate` now returns the real `Long`.
- `RawExpression` and `Scope`/`SuspendScope.execute`/`executeUpdate`/`execSql` require `@OptIn(DelicateKormiumApi::class)` — a new `@RequiresOptIn(ERROR)` marker for the whole raw-SQL escape hatch.
- **ADR 0009** records the reasoning and partially supersedes ADR 0006 (which had earlier rejected an opt-in marker); ADR 0006 is marked superseded-in-part rather than rewritten, per the project's append-only ADR convention.
- All call sites across core, backend tests (postgres/mysql/sqlite/r2dbc/migrate), samples, benchmarks, and docs updated to match.
- Fixed a real bug found while updating tests: JDBC's `executeUpdate()` rejects any statement that returns rows ("Query returns results"), unlike the native driver where `execute`/`executeUpdate` were identical — a raw `SELECT` now correctly goes through the row-returning `execute(...)` form.

## Test plan
- [x] `compileKotlinJvm` / `compileTestKotlinJvm` clean across the whole repo
- [x] `compileTestKotlinMacosArm64` clean
- [x] `compileKotlinWasmJs` clean
- [x] `kormium-core:allTests`, `kormium-sqlite:jvmTest`/`macosArm64Test`, `kormium-migrate:jvmTest` all green
- [x] `kormium-postgres`/`kormium-mysql`/`kormium-r2dbc` jvmTest green (Docker-backed integration tests skip gracefully without Docker)
- [x] All samples' jvmTest green

🤖 Generated with [Claude Code](https://claude.com/claude-code)