### PR TITLE
Lock the public API: explicitApi() + binary-compatibility-validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,12 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      # kormium-mysql's klib ABI can only be validated where all its targets build (its one
+      # Linux-buildable target trips a BCV inference edge case on the Linux runner — see the
+      # note in kormium-mysql/build.gradle.kts). Everything else is checked in the Linux job.
+      - name: API compatibility check (kormium-mysql klib)
+        run: ./gradlew :kormium-mysql:klibApiCheck --console=plain
+
       # Compile the Android and iOS variants of every Compose-Multiplatform-enabled module.
       # sqlite3.h is vendored and iOS/macOS ship libsqlite3, so no extra system deps are needed.
       - name: Build Android + iOS targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,11 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      # Public-ABI guard (JVM + klib dumps in <module>/api/). Fails in seconds when a change
+      # alters the API surface without a reviewed `./gradlew apiDump`.
+      - name: API compatibility check
+        run: ./gradlew apiCheck --console=plain
+
       # JVM unit tests. kormium-sqlite runs against an in-memory database (no Docker); it covers
       # both the blocking and the suspend (offload) paths.
       - name: JVM tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,11 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      # Public-ABI guard (JVM + klib dumps in <module>/api/). Fails in seconds when a change
+      # Public-ABI guard (dumps in <module>/api/). On Linux this covers the JVM dumps —
+      # the klib checks run in the macOS job, the only host that builds every declared
+      # target (see the note in the root build.gradle.kts). Fails in seconds when a change
       # alters the API surface without a reviewed `./gradlew apiDump`.
-      - name: API compatibility check
+      - name: API compatibility check (JVM)
         run: ./gradlew apiCheck --console=plain
 
       # JVM unit tests. kormium-sqlite runs against an in-memory database (no Docker); it covers
@@ -234,11 +236,23 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      # kormium-mysql's klib ABI can only be validated where all its targets build (its one
-      # Linux-buildable target trips a BCV inference edge case on the Linux runner — see the
-      # note in kormium-mysql/build.gradle.kts). Everything else is checked in the Linux job.
-      - name: API compatibility check (kormium-mysql klib)
-        run: ./gradlew :kormium-mysql:klibApiCheck --console=plain
+      # The Kotlin/Native toolchain for the klib ABI checks below is a multi-hundred-MB download.
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-macos-kotlin-2.4.0
+
+      # The klib cinterops (libpq/libmariadb) resolve their headers from brew, like the
+      # publish workflow; macOS cross-compiles every declared target's klib from them.
+      - name: Install libpq + mariadb-connector-c (for the Kotlin/Native cinterops)
+        run: brew install libpq mariadb-connector-c
+
+      # Full ABI check (JVM + klib). The klib checks only run on macOS — the host profile
+      # that builds every declared target, same as publishing; see the note in the root
+      # build.gradle.kts. The Linux job's apiCheck covers the JVM dumps early and fast.
+      - name: API compatibility check (full, incl. klib)
+        run: ./gradlew apiCheck --console=plain
 
       # Compile the Android and iOS variants of every Compose-Multiplatform-enabled module.
       # sqlite3.h is vendored and iOS/macOS ship libsqlite3, so no extra system deps are needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -403,3 +403,11 @@ is validated on write. See [docs/queries.md](docs/queries.md#vector-search-pgvec
   `RETURNING` on `UPDATE`/`DELETE`, `FOR UPDATE`. Drop to `RawExpression` or `execute(...)` for
   those — both require `@OptIn(DelicateKormiumApi::class)`, and `execute`/`executeUpdate` require
   `params`/`invalidates` explicitly (`emptyMap()`/`emptyList()` when there's nothing to pass).
+
+## Changing kormium's own public API (contributors)
+
+Every published module compiles with Kotlin `explicitApi()` — new public declarations need
+explicit visibility and return types (the compiler errors until they do; prefer `internal`
+unless the symbol is meant for consumers). The public ABI is dumped per module in
+`<module>/api/` and checked by CI: after any deliberate API change run `./gradlew apiDump`
+and commit the `.api` diffs — they are the review artifact for the change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Kormium are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **API surface is now locked.** Every published module compiles in Kotlin's
+  `explicitApi()` strict mode (all public declarations carry explicit visibility and
+  return types), and [binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator)
+  dumps the JVM and klib ABI of each module into `<module>/api/`; CI fails on any surface
+  change that isn't an explicitly reviewed `./gradlew apiDump`. This change is purely
+  mechanical — the dumped ABI is byte-identical before and after. (Deliberate narrowing of
+  accidentally-public internals comes separately, as reviewable `.api` diffs.)
+
 ### Changed
 - **BREAKING: `Instant` is now `kotlin.time.Instant`.** `Column.Instant`, `InstantColumnType`
   and `ResultSet.getInstant` use the stdlib `kotlin.time.Instant` instead of

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,26 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 plugins {
     // Applied to the publishable subprojects below (not to the root itself).
     id("com.vanniktech.maven.publish") version "0.36.0" apply false
+    // Applied at the root: validates the public ABI of every published module (JVM + klib).
+    // API changes require `./gradlew apiDump` and a review of the .api diffs.
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.18.1"
+}
+
+apiValidation {
+    // Track the Kotlin/Native + js/wasm ABI too, not just the JVM one.
+    @OptIn(kotlinx.validation.ExperimentalBCVApi::class)
+    klib {
+        enabled = true
+    }
+    // Consumers, not published API surfaces. (Sample project names are their leaf names;
+    // the "r2dbc" here is samples:r2dbc — the library module is named kormium-r2dbc.)
+    ignoredProjects.addAll(
+        listOf(
+            "benchmarks", "kormium-bom",
+            "ktor-di", "ktor-koin", "crud-sqlite", "repository", "sharding",
+            "sqlite-cache", "cross-instance-cache", "r2dbc", "wasm-todo",
+        ),
+    )
 }
 
 buildscript {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -161,3 +161,18 @@ subprojects {
         }
     }
 }
+
+// BCV's klib ABI inference for host-unsupported targets does not hold up in this build:
+// on a Linux host the extracted golden dump keeps the full target list in its header
+// (incl. the Apple targets the dumps were generated with) while the fresh merge lists
+// only the Linux-buildable ones, so klibApiCheck always diffs. Validate the klib surface
+// on the host profile that can build every declared target — macOS, the same profile
+// that publishes. The JVM ABI checks run on every host; CI runs the full apiCheck
+// (JVM + klib) in its macOS job.
+allprojects {
+    tasks.matching { it.name == "klibApiCheck" }.configureEach {
+        onlyIf("klib ABI is validated on macOS, where every declared target builds") {
+            org.jetbrains.kotlin.konan.target.HostManager.hostIsMac
+        }
+    }
+}

--- a/kormium-core/api/jvm/kormium-core.api
+++ b/kormium-core/api/jvm/kormium-core.api
@@ -1,0 +1,1087 @@
+public final class io/github/kormium/AggregateKt {
+	public static final fun avg (Lio/github/kormium/Column;)Lio/github/kormium/Operand;
+	public static final fun count ()Lio/github/kormium/Operand;
+	public static final fun count (Lio/github/kormium/Column;)Lio/github/kormium/Operand;
+	public static final fun max (Lio/github/kormium/Column;)Lio/github/kormium/Operand;
+	public static final fun min (Lio/github/kormium/Column;)Lio/github/kormium/Operand;
+	public static final fun sum (Lio/github/kormium/Column;)Lio/github/kormium/Operand;
+	public static final fun sumInt (Lio/github/kormium/Column;)Lio/github/kormium/Operand;
+	public static final fun sumLong (Lio/github/kormium/Column;)Lio/github/kormium/Operand;
+	public static final fun sumShort (Lio/github/kormium/Column;)Lio/github/kormium/Operand;
+}
+
+public final class io/github/kormium/AscDescOrder : java/lang/Enum {
+	public static final field ASC Lio/github/kormium/AscDescOrder;
+	public static final field DESC Lio/github/kormium/AscDescOrder;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/kormium/AscDescOrder;
+	public static fun values ()[Lio/github/kormium/AscDescOrder;
+}
+
+public final class io/github/kormium/BatchInsertMode : java/lang/Enum {
+	public static final field GroupByAssignedFields Lio/github/kormium/BatchInsertMode;
+	public static final field Strict Lio/github/kormium/BatchInsertMode;
+	public static final field UnionNulls Lio/github/kormium/BatchInsertMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/kormium/BatchInsertMode;
+	public static fun values ()[Lio/github/kormium/BatchInsertMode;
+}
+
+public final class io/github/kormium/BooleanColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/BooleanColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Boolean;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toParam (Z)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/BytesColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/BytesColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)[B
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toParam ([B)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/CaseBuilder {
+	public final fun otherwise (Ljava/lang/Object;)V
+	public final fun whenever (Lio/github/kormium/Expression;)Lio/github/kormium/CaseBuilder$WhenStep;
+}
+
+public final class io/github/kormium/CaseBuilder$WhenStep {
+	public final fun then (Ljava/lang/Object;)V
+}
+
+public final class io/github/kormium/CaseOp : io/github/kormium/Operand {
+	public fun getColumnType ()Lio/github/kormium/ColumnType;
+	public fun read (Lio/github/kormium/resultset/ResultSet;ILio/github/kormium/TypeMapper;)Ljava/lang/Object;
+	public fun resultKey ()Ljava/lang/Object;
+	public fun toSql (Lio/github/kormium/ParamBuilder;)Ljava/lang/String;
+}
+
+public abstract interface class io/github/kormium/Catalog {
+}
+
+public final class io/github/kormium/CheckViolationException : io/github/kormium/QueryException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/CoalesceOp : io/github/kormium/Operand {
+	public fun getColumnType ()Lio/github/kormium/ColumnType;
+	public fun read (Lio/github/kormium/resultset/ResultSet;ILio/github/kormium/TypeMapper;)Ljava/lang/Object;
+	public fun resultKey ()Ljava/lang/Object;
+	public fun toSql (Lio/github/kormium/ParamBuilder;)Ljava/lang/String;
+}
+
+public abstract class io/github/kormium/Column : io/github/kormium/Expression, io/github/kormium/Operand {
+	public static final field Companion Lio/github/kormium/Column$Companion;
+	public synthetic fun <init> (Lio/github/kormium/Table;Ljava/lang/String;Ljava/lang/String;ZLio/github/kormium/ColumnType;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getColumnType ()Lio/github/kormium/ColumnType;
+	public final fun getFieldKey ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNullable ()Z
+	public fun init ()V
+	public fun read (Lio/github/kormium/resultset/ResultSet;ILio/github/kormium/TypeMapper;)Ljava/lang/Object;
+	public fun resultKey ()Ljava/lang/Object;
+	public fun toSql (Lio/github/kormium/ParamBuilder;)Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kormium/Column$Boolean : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/Column$Bytes : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/Column$Companion {
+	public final fun of (Lio/github/kormium/ColumnType;Ljava/lang/String;)Lio/github/kormium/Column$Spec;
+	public static synthetic fun of$default (Lio/github/kormium/Column$Companion;Lio/github/kormium/ColumnType;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kormium/Column$Spec;
+}
+
+public final class io/github/kormium/Column$Double : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/Column$Float : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/Column$Instant : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/Column$Int : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/Column$Json : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/Column$LocalDate : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/Column$LocalDateTime : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/Column$LocalTime : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/Column$Long : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/Column$NotNullColumn : io/github/kormium/Column {
+	public fun <init> (Lio/github/kormium/Table;Ljava/lang/String;Ljava/lang/String;Lio/github/kormium/ColumnType;)V
+	public final fun getValue (Lio/github/kormium/Entity;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public final fun setValue (Lio/github/kormium/Entity;Lkotlin/reflect/KProperty;Ljava/lang/Object;)V
+}
+
+public final class io/github/kormium/Column$NullableColumn : io/github/kormium/Column {
+	public fun <init> (Lio/github/kormium/Table;Ljava/lang/String;Ljava/lang/String;Lio/github/kormium/ColumnType;)V
+	public final fun getValue (Lio/github/kormium/Entity;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public final fun setValue (Lio/github/kormium/Entity;Lkotlin/reflect/KProperty;Ljava/lang/Object;)V
+}
+
+public final class io/github/kormium/Column$NullableSpec {
+	public final fun provideDelegate (Lio/github/kormium/Table;Lkotlin/reflect/KProperty;)Lkotlin/properties/ReadOnlyProperty;
+}
+
+public final class io/github/kormium/Column$PrimaryKeySpec {
+	public final fun provideDelegate (Lio/github/kormium/Table;Lkotlin/reflect/KProperty;)Lkotlin/properties/ReadOnlyProperty;
+}
+
+public final class io/github/kormium/Column$Short : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public class io/github/kormium/Column$Spec {
+	public fun <init> (Ljava/lang/String;Lio/github/kormium/ColumnType;)V
+	public final fun nullable ()Lio/github/kormium/Column$NullableSpec;
+	public final fun primaryKey ()Lio/github/kormium/Column$PrimaryKeySpec;
+	public final fun provideDelegate (Lio/github/kormium/Table;Lkotlin/reflect/KProperty;)Lkotlin/properties/ReadOnlyProperty;
+}
+
+public final class io/github/kormium/Column$Text : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/Column$UUID : io/github/kormium/Column$Spec {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract interface class io/github/kormium/ColumnType {
+	public fun getDescription ()Ljava/lang/String;
+	public abstract fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/ColumnType$DefaultImpls {
+	public static fun getDescription (Lio/github/kormium/ColumnType;)Ljava/lang/String;
+	public static fun toParam (Lio/github/kormium/ColumnType;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/ColumnTypeKt {
+	public static final fun convert (Lio/github/kormium/ColumnType;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lio/github/kormium/ColumnType;
+}
+
+public final class io/github/kormium/ConcurrencyConflictException : io/github/kormium/QueryException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract interface class io/github/kormium/ConnectionPool {
+	public abstract fun acquire ()Lio/github/kormium/PinnedConnection;
+	public fun acquireSuspending (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/ConnectionPool$DefaultImpls {
+	public static fun acquireSuspending (Lio/github/kormium/ConnectionPool;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/ConnectionPoolKt {
+	public static final fun runConnection (Lio/github/kormium/ConnectionPool;ZLio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun runConnection$default (Lio/github/kormium/ConnectionPool;ZLio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun runPinned (Lio/github/kormium/ConnectionPool;ZLio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun runPinned$default (Lio/github/kormium/ConnectionPool;ZLio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/DatabaseClosedException : io/github/kormium/KormiumException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/DatabaseLifecycle {
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public final fun checkOpen ()V
+	public final fun close ()V
+	public final fun isClosed ()Z
+}
+
+public abstract interface annotation class io/github/kormium/DelicateKormiumApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface class io/github/kormium/Dialect {
+	public fun advisoryLockSql (J)Ljava/lang/String;
+	public fun getReadOnlyToggle ()Lio/github/kormium/ReadOnlyToggle;
+	public fun getSupportsReturning ()Z
+	public fun getSupportsTransactionIsolation ()Z
+	public abstract fun quoteIdentifier (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun renderBind (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/String;
+	public fun renderCharLength (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderInsertDefaultValues (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderInsertOrIgnoreSuffix (Ljava/util/List;)Ljava/lang/String;
+	public abstract fun renderLimit-WZ4Q5Ns (I)Ljava/lang/String;
+	public fun renderLimitOffset-feOb9K0 (II)Ljava/lang/String;
+	public abstract fun renderOffset-WZ4Q5Ns (I)Ljava/lang/String;
+	public fun renderUpsertSuffix (Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class io/github/kormium/Dialect$DefaultImpls {
+	public static fun advisoryLockSql (Lio/github/kormium/Dialect;J)Ljava/lang/String;
+	public static fun getReadOnlyToggle (Lio/github/kormium/Dialect;)Lio/github/kormium/ReadOnlyToggle;
+	public static fun getSupportsReturning (Lio/github/kormium/Dialect;)Z
+	public static fun getSupportsTransactionIsolation (Lio/github/kormium/Dialect;)Z
+	public static fun renderCharLength (Lio/github/kormium/Dialect;Ljava/lang/String;)Ljava/lang/String;
+	public static fun renderInsertDefaultValues (Lio/github/kormium/Dialect;Ljava/lang/String;)Ljava/lang/String;
+	public static fun renderInsertOrIgnoreSuffix (Lio/github/kormium/Dialect;Ljava/util/List;)Ljava/lang/String;
+	public static fun renderLimitOffset-feOb9K0 (Lio/github/kormium/Dialect;II)Ljava/lang/String;
+	public static fun renderUpsertSuffix (Lio/github/kormium/Dialect;Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class io/github/kormium/DoubleColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/DoubleColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Double;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun toParam (D)Ljava/lang/Object;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract class io/github/kormium/Entity {
+	protected fun <init> ()V
+}
+
+public final class io/github/kormium/EntityKt {
+	public static final fun isSet (Lio/github/kormium/Entity;Lio/github/kormium/Column;)Z
+	public static final fun unset (Lio/github/kormium/Entity;Lio/github/kormium/Column;)V
+}
+
+public final class io/github/kormium/ExceptionsKt {
+	public static final fun sqlException (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)Lio/github/kormium/QueryException;
+	public static synthetic fun sqlException$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)Lio/github/kormium/QueryException;
+}
+
+public final class io/github/kormium/ExistsKt {
+	public static final fun any (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function0;)Lio/github/kormium/Expression;
+	public static final fun none (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function0;)Lio/github/kormium/Expression;
+}
+
+public final class io/github/kormium/ExistsOp : io/github/kormium/Expression {
+	public fun toSql (Lio/github/kormium/ParamBuilder;)Ljava/lang/String;
+}
+
+public abstract interface class io/github/kormium/Expression {
+	public abstract fun toSql (Lio/github/kormium/ParamBuilder;)Ljava/lang/String;
+}
+
+public final class io/github/kormium/ExpressionKt {
+	public static final fun and (Lio/github/kormium/Expression;Lio/github/kormium/Expression;)Lio/github/kormium/Expression;
+	public static final fun between (Lio/github/kormium/Operand;Lkotlin/ranges/ClosedRange;)Lio/github/kormium/Expression;
+	public static final fun case (Lio/github/kormium/ColumnType;Lkotlin/jvm/functions/Function1;)Lio/github/kormium/CaseOp;
+	public static final fun coalesce (Lio/github/kormium/CoalesceOp;Ljava/lang/Object;)Lio/github/kormium/CoalesceOp;
+	public static final fun coalesce (Lio/github/kormium/CoalesceOp;[Lio/github/kormium/Column;)Lio/github/kormium/CoalesceOp;
+	public static final fun coalesce (Lio/github/kormium/Column;Ljava/lang/Object;)Lio/github/kormium/CoalesceOp;
+	public static final fun coalesce (Lio/github/kormium/Column;[Lio/github/kormium/Column;)Lio/github/kormium/CoalesceOp;
+	public static final fun div (Lio/github/kormium/Column;Lio/github/kormium/Column;)Lio/github/kormium/NumericExpr;
+	public static final fun div (Lio/github/kormium/Column;Lio/github/kormium/NumericExpr;)Lio/github/kormium/NumericExpr;
+	public static final fun div (Lio/github/kormium/Column;Ljava/lang/Object;)Lio/github/kormium/NumericExpr;
+	public static final fun div (Lio/github/kormium/NumericExpr;Lio/github/kormium/Column;)Lio/github/kormium/NumericExpr;
+	public static final fun div (Lio/github/kormium/NumericExpr;Lio/github/kormium/NumericExpr;)Lio/github/kormium/NumericExpr;
+	public static final fun div (Lio/github/kormium/NumericExpr;Ljava/lang/Object;)Lio/github/kormium/NumericExpr;
+	public static final fun eq (Lio/github/kormium/Column$NullableColumn;Ljava/lang/Void;)Lio/github/kormium/Expression;
+	public static final fun eq (Lio/github/kormium/Expression;Lio/github/kormium/Expression;)Lio/github/kormium/Expression;
+	public static final fun eq (Lio/github/kormium/Operand;Ljava/lang/Object;)Lio/github/kormium/Expression;
+	public static final fun gt (Lio/github/kormium/Expression;Lio/github/kormium/Expression;)Lio/github/kormium/Expression;
+	public static final fun gt (Lio/github/kormium/Operand;Ljava/lang/Object;)Lio/github/kormium/Expression;
+	public static final fun gtEq (Lio/github/kormium/Expression;Lio/github/kormium/Expression;)Lio/github/kormium/Expression;
+	public static final fun gtEq (Lio/github/kormium/Operand;Ljava/lang/Object;)Lio/github/kormium/Expression;
+	public static final fun inList (Lio/github/kormium/Operand;Ljava/util/List;)Lio/github/kormium/Expression;
+	public static final fun isNotNull (Lio/github/kormium/Operand;)Lio/github/kormium/Expression;
+	public static final fun isNull (Lio/github/kormium/Operand;)Lio/github/kormium/Expression;
+	public static final fun length (Lio/github/kormium/Column;)Lio/github/kormium/NumericExpr;
+	public static final fun length (Lio/github/kormium/StringExpr;)Lio/github/kormium/NumericExpr;
+	public static final fun like (Lio/github/kormium/Operand;Lio/github/kormium/Operand;)Lio/github/kormium/Expression;
+	public static final fun like (Lio/github/kormium/Operand;Ljava/lang/String;)Lio/github/kormium/Expression;
+	public static final fun lower (Lio/github/kormium/Column;)Lio/github/kormium/StringExpr;
+	public static final fun lower (Lio/github/kormium/StringExpr;)Lio/github/kormium/StringExpr;
+	public static final fun lt (Lio/github/kormium/Expression;Lio/github/kormium/Expression;)Lio/github/kormium/Expression;
+	public static final fun lt (Lio/github/kormium/Operand;Ljava/lang/Object;)Lio/github/kormium/Expression;
+	public static final fun ltEq (Lio/github/kormium/Expression;Lio/github/kormium/Expression;)Lio/github/kormium/Expression;
+	public static final fun ltEq (Lio/github/kormium/Operand;Ljava/lang/Object;)Lio/github/kormium/Expression;
+	public static final fun ltrim (Lio/github/kormium/Column;)Lio/github/kormium/StringExpr;
+	public static final fun ltrim (Lio/github/kormium/StringExpr;)Lio/github/kormium/StringExpr;
+	public static final fun minus (Lio/github/kormium/Column;Lio/github/kormium/Column;)Lio/github/kormium/NumericExpr;
+	public static final fun minus (Lio/github/kormium/Column;Lio/github/kormium/NumericExpr;)Lio/github/kormium/NumericExpr;
+	public static final fun minus (Lio/github/kormium/Column;Ljava/lang/Object;)Lio/github/kormium/NumericExpr;
+	public static final fun minus (Lio/github/kormium/NumericExpr;Lio/github/kormium/Column;)Lio/github/kormium/NumericExpr;
+	public static final fun minus (Lio/github/kormium/NumericExpr;Lio/github/kormium/NumericExpr;)Lio/github/kormium/NumericExpr;
+	public static final fun minus (Lio/github/kormium/NumericExpr;Ljava/lang/Object;)Lio/github/kormium/NumericExpr;
+	public static final fun neq (Lio/github/kormium/Column$NullableColumn;Ljava/lang/Void;)Lio/github/kormium/Expression;
+	public static final fun neq (Lio/github/kormium/Expression;Lio/github/kormium/Expression;)Lio/github/kormium/Expression;
+	public static final fun neq (Lio/github/kormium/Operand;Ljava/lang/Object;)Lio/github/kormium/Expression;
+	public static final fun not (Lio/github/kormium/Expression;)Lio/github/kormium/Expression;
+	public static final fun or (Lio/github/kormium/Expression;Lio/github/kormium/Expression;)Lio/github/kormium/Expression;
+	public static final fun plus (Lio/github/kormium/Column;Lio/github/kormium/Column;)Lio/github/kormium/NumericExpr;
+	public static final fun plus (Lio/github/kormium/Column;Lio/github/kormium/NumericExpr;)Lio/github/kormium/NumericExpr;
+	public static final fun plus (Lio/github/kormium/Column;Ljava/lang/Object;)Lio/github/kormium/NumericExpr;
+	public static final fun plus (Lio/github/kormium/NumericExpr;Lio/github/kormium/Column;)Lio/github/kormium/NumericExpr;
+	public static final fun plus (Lio/github/kormium/NumericExpr;Lio/github/kormium/NumericExpr;)Lio/github/kormium/NumericExpr;
+	public static final fun plus (Lio/github/kormium/NumericExpr;Ljava/lang/Object;)Lio/github/kormium/NumericExpr;
+	public static final fun rem (Lio/github/kormium/Column;Lio/github/kormium/Column;)Lio/github/kormium/NumericExpr;
+	public static final fun rem (Lio/github/kormium/Column;Lio/github/kormium/NumericExpr;)Lio/github/kormium/NumericExpr;
+	public static final fun rem (Lio/github/kormium/Column;Ljava/lang/Object;)Lio/github/kormium/NumericExpr;
+	public static final fun rem (Lio/github/kormium/NumericExpr;Lio/github/kormium/Column;)Lio/github/kormium/NumericExpr;
+	public static final fun rem (Lio/github/kormium/NumericExpr;Lio/github/kormium/NumericExpr;)Lio/github/kormium/NumericExpr;
+	public static final fun rem (Lio/github/kormium/NumericExpr;Ljava/lang/Object;)Lio/github/kormium/NumericExpr;
+	public static final fun rtrim (Lio/github/kormium/Column;)Lio/github/kormium/StringExpr;
+	public static final fun rtrim (Lio/github/kormium/StringExpr;)Lio/github/kormium/StringExpr;
+	public static final fun times (Lio/github/kormium/Column;Lio/github/kormium/Column;)Lio/github/kormium/NumericExpr;
+	public static final fun times (Lio/github/kormium/Column;Lio/github/kormium/NumericExpr;)Lio/github/kormium/NumericExpr;
+	public static final fun times (Lio/github/kormium/Column;Ljava/lang/Object;)Lio/github/kormium/NumericExpr;
+	public static final fun times (Lio/github/kormium/NumericExpr;Lio/github/kormium/Column;)Lio/github/kormium/NumericExpr;
+	public static final fun times (Lio/github/kormium/NumericExpr;Lio/github/kormium/NumericExpr;)Lio/github/kormium/NumericExpr;
+	public static final fun times (Lio/github/kormium/NumericExpr;Ljava/lang/Object;)Lio/github/kormium/NumericExpr;
+	public static final fun trim (Lio/github/kormium/Column;)Lio/github/kormium/StringExpr;
+	public static final fun trim (Lio/github/kormium/StringExpr;)Lio/github/kormium/StringExpr;
+	public static final fun upper (Lio/github/kormium/Column;)Lio/github/kormium/StringExpr;
+	public static final fun upper (Lio/github/kormium/StringExpr;)Lio/github/kormium/StringExpr;
+}
+
+public final class io/github/kormium/FloatColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/FloatColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Float;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun toParam (F)Ljava/lang/Object;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/ForeignKeyViolationException : io/github/kormium/QueryException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/InstantColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/InstantColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Lkotlin/time/Instant;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toParam (Lkotlin/time/Instant;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/IntColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/IntColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Integer;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun toParam (I)Ljava/lang/Object;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/Join {
+	public final fun distinct ()Lio/github/kormium/Join;
+	public final fun groupBy ([Lio/github/kormium/Column;)Lio/github/kormium/Join;
+	public final fun having (Lio/github/kormium/Expression;)Lio/github/kormium/Join;
+	public final fun innerJoin (Lio/github/kormium/Table;)Lio/github/kormium/JoinStep;
+	public final fun leftJoin (Lio/github/kormium/Table;)Lio/github/kormium/JoinStep;
+	public final fun where (Lio/github/kormium/Expression;)Lio/github/kormium/Join;
+}
+
+public final class io/github/kormium/JoinKt {
+	public static final fun entity (Lio/github/kormium/ResultRow;Lio/github/kormium/Table;)Lio/github/kormium/Entity;
+	public static final fun innerJoin (Lio/github/kormium/Table;Lio/github/kormium/Table;)Lio/github/kormium/JoinPairStep;
+	public static final fun leftJoin (Lio/github/kormium/Table;Lio/github/kormium/Table;)Lio/github/kormium/LeftJoinPairStep;
+	public static final fun query (Lio/github/kormium/Table;)Lio/github/kormium/Join;
+}
+
+public final class io/github/kormium/JoinPair {
+	public final fun distinct ()Lio/github/kormium/Join;
+	public final fun groupBy ([Lio/github/kormium/Column;)Lio/github/kormium/Join;
+	public final fun innerJoin (Lio/github/kormium/Table;)Lio/github/kormium/JoinStep;
+	public final fun leftJoin (Lio/github/kormium/Table;)Lio/github/kormium/JoinStep;
+	public final fun where (Lio/github/kormium/Expression;)Lio/github/kormium/JoinPair;
+}
+
+public final class io/github/kormium/JoinPairStep {
+	public final fun on (Lio/github/kormium/Expression;)Lio/github/kormium/JoinPair;
+}
+
+public final class io/github/kormium/JoinStep {
+	public final fun on (Lio/github/kormium/Expression;)Lio/github/kormium/Join;
+}
+
+public final class io/github/kormium/JsonColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/JsonColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Lkotlinx/serialization/json/JsonElement;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toParam (Lkotlinx/serialization/json/JsonElement;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/KormiumBuilder {
+	public fun <init> ()V
+	public final fun beforeStart (Lkotlin/jvm/functions/Function1;)V
+	public final fun config (Lkotlin/jvm/functions/Function1;)V
+	public final fun finish (Lkotlin/jvm/functions/Function1;)Lio/github/kormium/database/Database;
+}
+
+public final class io/github/kormium/KormiumConfig {
+	public fun <init> ()V
+	public fun <init> (Lio/github/kormium/BatchInsertMode;Lio/github/kormium/QueryObserver;)V
+	public synthetic fun <init> (Lio/github/kormium/BatchInsertMode;Lio/github/kormium/QueryObserver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kormium/BatchInsertMode;
+	public final fun component2 ()Lio/github/kormium/QueryObserver;
+	public final fun copy (Lio/github/kormium/BatchInsertMode;Lio/github/kormium/QueryObserver;)Lio/github/kormium/KormiumConfig;
+	public static synthetic fun copy$default (Lio/github/kormium/KormiumConfig;Lio/github/kormium/BatchInsertMode;Lio/github/kormium/QueryObserver;ILjava/lang/Object;)Lio/github/kormium/KormiumConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBatchInsertMode ()Lio/github/kormium/BatchInsertMode;
+	public final fun getQueryObserver ()Lio/github/kormium/QueryObserver;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kormium/KormiumConfigBuilder {
+	public final fun getBatchInsertMode ()Lio/github/kormium/BatchInsertMode;
+	public final fun setBatchInsertMode (Lio/github/kormium/BatchInsertMode;)V
+}
+
+public abstract interface annotation class io/github/kormium/KormiumDsl : java/lang/annotation/Annotation {
+}
+
+public class io/github/kormium/KormiumException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/LeftJoinPair {
+	public final fun distinct ()Lio/github/kormium/Join;
+	public final fun groupBy ([Lio/github/kormium/Column;)Lio/github/kormium/Join;
+	public final fun innerJoin (Lio/github/kormium/Table;)Lio/github/kormium/JoinStep;
+	public final fun leftJoin (Lio/github/kormium/Table;)Lio/github/kormium/JoinStep;
+	public final fun where (Lio/github/kormium/Expression;)Lio/github/kormium/LeftJoinPair;
+}
+
+public final class io/github/kormium/LeftJoinPairStep {
+	public final fun on (Lio/github/kormium/Expression;)Lio/github/kormium/LeftJoinPair;
+}
+
+public final class io/github/kormium/LocalDateColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/LocalDateColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Lkotlinx/datetime/LocalDate;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toParam (Lkotlinx/datetime/LocalDate;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/LocalDateTimeColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/LocalDateTimeColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Lkotlinx/datetime/LocalDateTime;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toParam (Lkotlinx/datetime/LocalDateTime;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/LocalTimeColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/LocalTimeColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Lkotlinx/datetime/LocalTime;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toParam (Lkotlinx/datetime/LocalTime;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/LongColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/LongColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Long;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun toParam (J)Ljava/lang/Object;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/NotNullViolationException : io/github/kormium/QueryException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract interface class io/github/kormium/NotificationTransport {
+	public abstract fun publish (Ljava/util/Set;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun subscribe ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class io/github/kormium/NotificationTransportKt {
+	public static final fun connectNotifications (Lio/github/kormium/database/SuspendDatabase;Lio/github/kormium/NotificationTransport;)Lio/github/kormium/Registration;
+	public static final fun decodeTablePayload (Ljava/lang/String;)Ljava/util/Set;
+	public static final fun encodeTablePayload (Ljava/util/Set;)Ljava/lang/String;
+}
+
+public abstract interface class io/github/kormium/NumericExpr : io/github/kormium/Operand {
+}
+
+public final class io/github/kormium/NumericExpr$DefaultImpls {
+	public static fun read (Lio/github/kormium/NumericExpr;Lio/github/kormium/resultset/ResultSet;ILio/github/kormium/TypeMapper;)Ljava/lang/Object;
+}
+
+public abstract interface class io/github/kormium/Operand : io/github/kormium/Selectable {
+	public abstract fun getColumnType ()Lio/github/kormium/ColumnType;
+	public fun read (Lio/github/kormium/resultset/ResultSet;ILio/github/kormium/TypeMapper;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/Operand$DefaultImpls {
+	public static fun read (Lio/github/kormium/Operand;Lio/github/kormium/resultset/ResultSet;ILio/github/kormium/TypeMapper;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/OrderByDsl {
+	public final fun ASC (Lio/github/kormium/Selectable;)V
+	public final fun DESC (Lio/github/kormium/Selectable;)V
+}
+
+public final class io/github/kormium/ParamBuilder {
+	public static final field Companion Lio/github/kormium/ParamBuilder$Companion;
+	public fun <init> (Lio/github/kormium/Dialect;Lio/github/kormium/TypeMapper;Z)V
+	public synthetic fun <init> (Lio/github/kormium/Dialect;Lio/github/kormium/TypeMapper;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kormium/Dialect;Lio/github/kormium/TypeMapper;ZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun bind (Ljava/lang/Object;)Ljava/lang/String;
+	public final fun getDialect ()Lio/github/kormium/Dialect;
+	public final fun getParams ()Ljava/util/Map;
+	public final fun getQualifyColumns ()Z
+}
+
+public final class io/github/kormium/ParamBuilder$Companion {
+}
+
+public abstract interface class io/github/kormium/PinnedConnection {
+	public abstract fun begin (Lio/github/kormium/TransactionIsolation;Z)V
+	public static synthetic fun begin$default (Lio/github/kormium/PinnedConnection;Lio/github/kormium/TransactionIsolation;ZILjava/lang/Object;)V
+	public abstract fun commit ()V
+	public abstract fun getExecutor ()Lio/github/kormium/SqlExecutor;
+	public abstract fun release ()V
+	public abstract fun rollback ()V
+}
+
+public final class io/github/kormium/PinnedConnection$DefaultImpls {
+	public static synthetic fun begin$default (Lio/github/kormium/PinnedConnection;Lio/github/kormium/TransactionIsolation;ZILjava/lang/Object;)V
+}
+
+public final class io/github/kormium/Query {
+	public synthetic fun <init> (Lio/github/kormium/Expression;IILjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kormium/Expression;IILjava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kormium/Expression;
+	public final fun component2-pVg5ArA ()I
+	public final fun component3-pVg5ArA ()I
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy-gd2BlFg (Lio/github/kormium/Expression;IILjava/util/Map;)Lio/github/kormium/Query;
+	public static synthetic fun copy-gd2BlFg$default (Lio/github/kormium/Query;Lio/github/kormium/Expression;IILjava/util/Map;ILjava/lang/Object;)Lio/github/kormium/Query;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLimit-pVg5ArA ()I
+	public final fun getOffset-pVg5ArA ()I
+	public final fun getOrderBy ()Ljava/util/Map;
+	public final fun getWhereExpression ()Lio/github/kormium/Expression;
+	public fun hashCode ()I
+	public final fun toSql (Lio/github/kormium/ParamBuilder;)Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public final fun toWhereSql (Lio/github/kormium/ParamBuilder;)Ljava/lang/String;
+}
+
+public final class io/github/kormium/QueryBuilder {
+	public fun <init> ()V
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getOffset ()Ljava/lang/Integer;
+	public final fun getOrderBy ()Lio/github/kormium/OrderByDsl;
+	public final fun setLimit (Ljava/lang/Integer;)V
+	public final fun setOffset (Ljava/lang/Integer;)V
+	public final fun where (Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class io/github/kormium/QueryEvent {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kormium/QueryKind;JLjava/lang/Long;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public final fun getBackend ()Ljava/lang/String;
+	public final fun getDurationNanos ()J
+	public final fun getError ()Ljava/lang/Throwable;
+	public final fun getKind ()Lio/github/kormium/QueryKind;
+	public final fun getRowCount ()Ljava/lang/Long;
+	public final fun getSql ()Ljava/lang/String;
+	public final fun getSqlState ()Ljava/lang/String;
+	public final fun getSucceeded ()Z
+}
+
+public class io/github/kormium/QueryException : io/github/kormium/KormiumException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getSqlState ()Ljava/lang/String;
+}
+
+public final class io/github/kormium/QueryKind : java/lang/Enum {
+	public static final field Companion Lio/github/kormium/QueryKind$Companion;
+	public static final field Delete Lio/github/kormium/QueryKind;
+	public static final field Insert Lio/github/kormium/QueryKind;
+	public static final field Other Lio/github/kormium/QueryKind;
+	public static final field Select Lio/github/kormium/QueryKind;
+	public static final field Update Lio/github/kormium/QueryKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/kormium/QueryKind;
+	public static fun values ()[Lio/github/kormium/QueryKind;
+}
+
+public final class io/github/kormium/QueryKind$Companion {
+	public final fun of (Ljava/lang/String;)Lio/github/kormium/QueryKind;
+}
+
+public abstract interface class io/github/kormium/QueryObserver {
+	public abstract fun onQuery (Lio/github/kormium/QueryEvent;)V
+}
+
+public final class io/github/kormium/RawExpression : io/github/kormium/Expression {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getExpression ()Ljava/lang/String;
+	public fun toSql (Lio/github/kormium/ParamBuilder;)Ljava/lang/String;
+}
+
+public final class io/github/kormium/ReadOnlyToggle {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/kormium/ReadOnlyToggle;
+	public static synthetic fun copy$default (Lio/github/kormium/ReadOnlyToggle;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kormium/ReadOnlyToggle;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnter ()Ljava/lang/String;
+	public final fun getExit ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/github/kormium/Registration {
+	public abstract fun remove ()V
+}
+
+public final class io/github/kormium/RenderScope {
+	public final fun all (Lio/github/kormium/Table;)Lio/github/kormium/RenderedSql;
+	public final fun count (Lio/github/kormium/Table;Lio/github/kormium/Query;)Lio/github/kormium/RenderedSql;
+	public final fun count (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;)Lio/github/kormium/RenderedSql;
+	public static synthetic fun count$default (Lio/github/kormium/RenderScope;Lio/github/kormium/Table;Lio/github/kormium/Query;ILjava/lang/Object;)Lio/github/kormium/RenderedSql;
+	public final fun deleteWhere (Lio/github/kormium/Table;Lio/github/kormium/Query;)Lio/github/kormium/RenderedSql;
+	public final fun deleteWhere (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;)Lio/github/kormium/RenderedSql;
+	public final fun find (Lio/github/kormium/Table;Lio/github/kormium/Query;)Lio/github/kormium/RenderedSql;
+	public final fun find (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;)Lio/github/kormium/RenderedSql;
+	public final fun findOne (Lio/github/kormium/Table;Lio/github/kormium/Query;)Lio/github/kormium/RenderedSql;
+	public final fun findOne (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;)Lio/github/kormium/RenderedSql;
+	public final fun getDialect ()Lio/github/kormium/Dialect;
+	public final fun getTypeMapper ()Lio/github/kormium/TypeMapper;
+	public final fun insert (Lio/github/kormium/Table;Lio/github/kormium/Entity;Z)Lio/github/kormium/RenderedSql;
+	public static synthetic fun insert$default (Lio/github/kormium/RenderScope;Lio/github/kormium/Table;Lio/github/kormium/Entity;ZILjava/lang/Object;)Lio/github/kormium/RenderedSql;
+	public final fun insertAll (Lio/github/kormium/Table;Ljava/util/List;ZLio/github/kormium/BatchInsertMode;)Ljava/util/List;
+	public static synthetic fun insertAll$default (Lio/github/kormium/RenderScope;Lio/github/kormium/Table;Ljava/util/List;ZLio/github/kormium/BatchInsertMode;ILjava/lang/Object;)Ljava/util/List;
+	public final fun insertOrIgnore (Lio/github/kormium/Table;Lio/github/kormium/Entity;Lio/github/kormium/Column;)Lio/github/kormium/RenderedSql;
+	public final fun insertOrIgnore (Lio/github/kormium/Table;Lio/github/kormium/Entity;Ljava/util/List;)Lio/github/kormium/RenderedSql;
+	public final fun select (Lio/github/kormium/Join;[Lio/github/kormium/Selectable;)Lio/github/kormium/RenderedSql;
+	public final fun select (Lio/github/kormium/JoinPair;[Lio/github/kormium/Selectable;)Lio/github/kormium/RenderedSql;
+	public final fun select (Lio/github/kormium/LeftJoinPair;[Lio/github/kormium/Selectable;)Lio/github/kormium/RenderedSql;
+	public final fun update (Lio/github/kormium/Table;Lio/github/kormium/Entity;Lio/github/kormium/Query;)Lio/github/kormium/RenderedSql;
+	public final fun update (Lio/github/kormium/Table;Lio/github/kormium/Entity;Lkotlin/jvm/functions/Function1;)Lio/github/kormium/RenderedSql;
+	public final fun update (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;)Lio/github/kormium/RenderedSql;
+	public final fun upsert (Lio/github/kormium/Table;Lio/github/kormium/Entity;Lio/github/kormium/Column;Lio/github/kormium/Entity;Z)Lio/github/kormium/RenderedSql;
+	public final fun upsert (Lio/github/kormium/Table;Lio/github/kormium/Entity;Ljava/util/List;Lio/github/kormium/Entity;Z)Lio/github/kormium/RenderedSql;
+	public static synthetic fun upsert$default (Lio/github/kormium/RenderScope;Lio/github/kormium/Table;Lio/github/kormium/Entity;Lio/github/kormium/Column;Lio/github/kormium/Entity;ZILjava/lang/Object;)Lio/github/kormium/RenderedSql;
+	public static synthetic fun upsert$default (Lio/github/kormium/RenderScope;Lio/github/kormium/Table;Lio/github/kormium/Entity;Ljava/util/List;Lio/github/kormium/Entity;ZILjava/lang/Object;)Lio/github/kormium/RenderedSql;
+}
+
+public final class io/github/kormium/RenderSqlKt {
+	public static final fun renderSql (Lio/github/kormium/Catalog;Lio/github/kormium/Dialect;Lio/github/kormium/TypeMapper;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun renderSql (Lio/github/kormium/database/Database;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun renderSql$default (Lio/github/kormium/Catalog;Lio/github/kormium/Dialect;Lio/github/kormium/TypeMapper;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/RenderedSql {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public final fun getParams ()Ljava/util/Map;
+	public final fun getSql ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kormium/ResultMappingException : io/github/kormium/KormiumException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/ResultRow {
+	public final fun get (Lio/github/kormium/Selectable;)Ljava/lang/Object;
+	public final fun getOrNull (Lio/github/kormium/Selectable;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/Scope {
+	public final fun all (Lio/github/kormium/Table;)Ljava/util/List;
+	public final fun count (Lio/github/kormium/Table;Lio/github/kormium/Query;)J
+	public final fun count (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;)J
+	public static synthetic fun count$default (Lio/github/kormium/Scope;Lio/github/kormium/Table;Lio/github/kormium/Query;ILjava/lang/Object;)J
+	public final fun deleteWhere (Lio/github/kormium/Table;Lio/github/kormium/Query;)J
+	public final fun deleteWhere (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;)J
+	public final fun execSql (Lio/github/kormium/Table;Ljava/lang/String;)V
+	public final fun execute (Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public final fun executeUpdate (Ljava/lang/String;Ljava/util/Map;Ljava/util/List;)J
+	public final fun find (Lio/github/kormium/JoinPair;)Ljava/util/List;
+	public final fun find (Lio/github/kormium/LeftJoinPair;)Ljava/util/List;
+	public final fun find (Lio/github/kormium/Table;Lio/github/kormium/Query;)Ljava/util/List;
+	public final fun find (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public final fun findOne (Lio/github/kormium/Table;Lio/github/kormium/Query;)Lio/github/kormium/Entity;
+	public final fun findOne (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;)Lio/github/kormium/Entity;
+	public final fun insert (Lio/github/kormium/Table;Lio/github/kormium/Entity;Z)Lio/github/kormium/Entity;
+	public static synthetic fun insert$default (Lio/github/kormium/Scope;Lio/github/kormium/Table;Lio/github/kormium/Entity;ZILjava/lang/Object;)Lio/github/kormium/Entity;
+	public final fun insertAll (Lio/github/kormium/Table;Ljava/util/List;ZLio/github/kormium/BatchInsertMode;)Ljava/util/List;
+	public static synthetic fun insertAll$default (Lio/github/kormium/Scope;Lio/github/kormium/Table;Ljava/util/List;ZLio/github/kormium/BatchInsertMode;ILjava/lang/Object;)Ljava/util/List;
+	public final fun insertOrIgnore (Lio/github/kormium/Table;Lio/github/kormium/Entity;Lio/github/kormium/Column;)J
+	public final fun insertOrIgnore (Lio/github/kormium/Table;Lio/github/kormium/Entity;Ljava/util/List;)J
+	public final fun savepoint (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun select (Lio/github/kormium/Join;[Lio/github/kormium/Selectable;)Ljava/util/List;
+	public final fun select (Lio/github/kormium/Join;[Lio/github/kormium/Selectable;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public final fun select (Lio/github/kormium/JoinPair;[Lio/github/kormium/Selectable;)Ljava/util/List;
+	public final fun select (Lio/github/kormium/JoinPair;[Lio/github/kormium/Selectable;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public final fun select (Lio/github/kormium/LeftJoinPair;[Lio/github/kormium/Selectable;)Ljava/util/List;
+	public final fun select (Lio/github/kormium/LeftJoinPair;[Lio/github/kormium/Selectable;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public final fun update (Lio/github/kormium/Table;Lio/github/kormium/Entity;Lio/github/kormium/Query;)J
+	public final fun update (Lio/github/kormium/Table;Lio/github/kormium/Entity;Lkotlin/jvm/functions/Function1;)J
+	public final fun update (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;)J
+	public final fun upsert (Lio/github/kormium/Table;Lio/github/kormium/Entity;Lio/github/kormium/Column;Lio/github/kormium/Entity;Z)Lio/github/kormium/Entity;
+	public final fun upsert (Lio/github/kormium/Table;Lio/github/kormium/Entity;Ljava/util/List;Lio/github/kormium/Entity;Z)Lio/github/kormium/Entity;
+	public static synthetic fun upsert$default (Lio/github/kormium/Scope;Lio/github/kormium/Table;Lio/github/kormium/Entity;Lio/github/kormium/Column;Lio/github/kormium/Entity;ZILjava/lang/Object;)Lio/github/kormium/Entity;
+	public static synthetic fun upsert$default (Lio/github/kormium/Scope;Lio/github/kormium/Table;Lio/github/kormium/Entity;Ljava/util/List;Lio/github/kormium/Entity;ZILjava/lang/Object;)Lio/github/kormium/Entity;
+}
+
+public final class io/github/kormium/ScopeKt {
+	public static final fun autocommit (Lio/github/kormium/database/Database;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun transaction (Lio/github/kormium/database/Database;Lio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun transaction$default (Lio/github/kormium/database/Database;Lio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/github/kormium/Selectable : io/github/kormium/Expression {
+	public abstract fun read (Lio/github/kormium/resultset/ResultSet;ILio/github/kormium/TypeMapper;)Ljava/lang/Object;
+	public abstract fun resultKey ()Ljava/lang/Object;
+}
+
+public final class io/github/kormium/ShortColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/ShortColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Short;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toParam (S)Ljava/lang/Object;
+}
+
+public abstract interface class io/github/kormium/SqlExecutor {
+	public abstract fun execute (Ljava/lang/String;Lio/github/kormium/SqlParameterSource;)J
+	public abstract fun execute (Ljava/lang/String;Lio/github/kormium/SqlParameterSource;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public abstract fun execute (Ljava/lang/String;Ljava/util/Map;)J
+	public abstract fun execute (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public static synthetic fun execute$default (Lio/github/kormium/SqlExecutor;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)J
+	public static synthetic fun execute$default (Lio/github/kormium/SqlExecutor;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/util/List;
+	public abstract fun executeUpdate (Ljava/lang/String;Ljava/util/Map;)J
+	public static synthetic fun executeUpdate$default (Lio/github/kormium/SqlExecutor;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)J
+	public abstract fun getDialect ()Lio/github/kormium/Dialect;
+	public abstract fun getTypeMapper ()Lio/github/kormium/TypeMapper;
+}
+
+public final class io/github/kormium/SqlExecutor$DefaultImpls {
+	public static synthetic fun execute$default (Lio/github/kormium/SqlExecutor;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)J
+	public static synthetic fun execute$default (Lio/github/kormium/SqlExecutor;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun executeUpdate$default (Lio/github/kormium/SqlExecutor;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)J
+}
+
+public abstract interface class io/github/kormium/SqlParameterSource {
+	public static final field Companion Lio/github/kormium/SqlParameterSource$Companion;
+	public fun getParameterNames ()[Ljava/lang/String;
+	public fun getSqlType-OGnWXxg (Ljava/lang/String;)I
+	public fun getTypeName (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun getValue (Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun hasValue (Ljava/lang/String;)Z
+}
+
+public final class io/github/kormium/SqlParameterSource$Companion {
+	public final fun getTYPE_UNKNOWN-pVg5ArA ()I
+}
+
+public final class io/github/kormium/SqlParameterSource$DefaultImpls {
+	public static fun getParameterNames (Lio/github/kormium/SqlParameterSource;)[Ljava/lang/String;
+	public static fun getSqlType-OGnWXxg (Lio/github/kormium/SqlParameterSource;Ljava/lang/String;)I
+	public static fun getTypeName (Lio/github/kormium/SqlParameterSource;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class io/github/kormium/StandardDialect : io/github/kormium/Dialect {
+	public static final field INSTANCE Lio/github/kormium/StandardDialect;
+	public fun advisoryLockSql (J)Ljava/lang/String;
+	public fun getReadOnlyToggle ()Lio/github/kormium/ReadOnlyToggle;
+	public fun getSupportsReturning ()Z
+	public fun getSupportsTransactionIsolation ()Z
+	public fun quoteIdentifier (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderBind (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/String;
+	public fun renderCharLength (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderInsertDefaultValues (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderInsertOrIgnoreSuffix (Ljava/util/List;)Ljava/lang/String;
+	public fun renderLimit-WZ4Q5Ns (I)Ljava/lang/String;
+	public fun renderLimitOffset-feOb9K0 (II)Ljava/lang/String;
+	public fun renderOffset-WZ4Q5Ns (I)Ljava/lang/String;
+	public fun renderUpsertSuffix (Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class io/github/kormium/StandardTypeMapper : io/github/kormium/TypeMapper {
+	public static final field INSTANCE Lio/github/kormium/StandardTypeMapper;
+	public fun toParameter (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/github/kormium/StringExpr : io/github/kormium/Operand {
+	public fun getColumnType ()Lio/github/kormium/ColumnType;
+}
+
+public final class io/github/kormium/StringExpr$DefaultImpls {
+	public static fun getColumnType (Lio/github/kormium/StringExpr;)Lio/github/kormium/ColumnType;
+	public static fun read (Lio/github/kormium/StringExpr;Lio/github/kormium/resultset/ResultSet;ILio/github/kormium/TypeMapper;)Ljava/lang/String;
+}
+
+public final class io/github/kormium/SuspendScope {
+	public final fun all (Lio/github/kormium/Table;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun count (Lio/github/kormium/Table;Lio/github/kormium/Query;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun count (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun count$default (Lio/github/kormium/SuspendScope;Lio/github/kormium/Table;Lio/github/kormium/Query;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteWhere (Lio/github/kormium/Table;Lio/github/kormium/Query;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteWhere (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun execSql (Lio/github/kormium/Table;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun execute (Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun executeUpdate (Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun find (Lio/github/kormium/JoinPair;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun find (Lio/github/kormium/LeftJoinPair;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun find (Lio/github/kormium/Table;Lio/github/kormium/Query;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun find (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun findOne (Lio/github/kormium/Table;Lio/github/kormium/Query;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun findOne (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun insert (Lio/github/kormium/Table;Lio/github/kormium/Entity;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun insert$default (Lio/github/kormium/SuspendScope;Lio/github/kormium/Table;Lio/github/kormium/Entity;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun insertAll (Lio/github/kormium/Table;Ljava/util/List;ZLio/github/kormium/BatchInsertMode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun insertAll$default (Lio/github/kormium/SuspendScope;Lio/github/kormium/Table;Ljava/util/List;ZLio/github/kormium/BatchInsertMode;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun insertOrIgnore (Lio/github/kormium/Table;Lio/github/kormium/Entity;Lio/github/kormium/Column;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun insertOrIgnore (Lio/github/kormium/Table;Lio/github/kormium/Entity;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun savepoint (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun select (Lio/github/kormium/Join;[Lio/github/kormium/Selectable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun select (Lio/github/kormium/Join;[Lio/github/kormium/Selectable;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun select (Lio/github/kormium/JoinPair;[Lio/github/kormium/Selectable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun select (Lio/github/kormium/JoinPair;[Lio/github/kormium/Selectable;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun select (Lio/github/kormium/LeftJoinPair;[Lio/github/kormium/Selectable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun select (Lio/github/kormium/LeftJoinPair;[Lio/github/kormium/Selectable;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun update (Lio/github/kormium/Table;Lio/github/kormium/Entity;Lio/github/kormium/Query;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun update (Lio/github/kormium/Table;Lio/github/kormium/Entity;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun update (Lio/github/kormium/Table;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun upsert (Lio/github/kormium/Table;Lio/github/kormium/Entity;Lio/github/kormium/Column;Lio/github/kormium/Entity;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun upsert (Lio/github/kormium/Table;Lio/github/kormium/Entity;Ljava/util/List;Lio/github/kormium/Entity;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun upsert$default (Lio/github/kormium/SuspendScope;Lio/github/kormium/Table;Lio/github/kormium/Entity;Lio/github/kormium/Column;Lio/github/kormium/Entity;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun upsert$default (Lio/github/kormium/SuspendScope;Lio/github/kormium/Table;Lio/github/kormium/Entity;Ljava/util/List;Lio/github/kormium/Entity;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/SuspendScopeKt {
+	public static final fun suspendAutocommit (Lio/github/kormium/database/SuspendDatabase;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun suspendTransaction (Lio/github/kormium/database/SuspendDatabase;Lio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun suspendTransaction$default (Lio/github/kormium/database/SuspendDatabase;Lio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/github/kormium/SuspendSqlExecutor {
+	public abstract fun execute (Ljava/lang/String;Lio/github/kormium/SqlParameterSource;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun execute (Ljava/lang/String;Lio/github/kormium/SqlParameterSource;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun execute (Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun execute (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun execute$default (Lio/github/kormium/SuspendSqlExecutor;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun execute$default (Lio/github/kormium/SuspendSqlExecutor;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun executeUpdate (Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun executeUpdate$default (Lio/github/kormium/SuspendSqlExecutor;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getDialect ()Lio/github/kormium/Dialect;
+	public abstract fun getTypeMapper ()Lio/github/kormium/TypeMapper;
+}
+
+public final class io/github/kormium/SuspendSqlExecutor$DefaultImpls {
+	public static synthetic fun execute$default (Lio/github/kormium/SuspendSqlExecutor;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun execute$default (Lio/github/kormium/SuspendSqlExecutor;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun executeUpdate$default (Lio/github/kormium/SuspendSqlExecutor;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract class io/github/kormium/Table {
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public final fun getFactory ()Lkotlin/jvm/functions/Function0;
+	public final fun getFieldDisplayNames ()Ljava/util/Map;
+	public final fun getPrimaryKey ()Ljava/util/List;
+	public final fun getTableName ()Ljava/lang/String;
+}
+
+public final class io/github/kormium/TextColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/TextColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/String;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toParam (Ljava/lang/String;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/TransactionIsolation : java/lang/Enum {
+	public static final field ReadCommitted Lio/github/kormium/TransactionIsolation;
+	public static final field ReadUncommitted Lio/github/kormium/TransactionIsolation;
+	public static final field RepeatableRead Lio/github/kormium/TransactionIsolation;
+	public static final field Serializable Lio/github/kormium/TransactionIsolation;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getSql ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/kormium/TransactionIsolation;
+	public static fun values ()[Lio/github/kormium/TransactionIsolation;
+}
+
+public abstract interface class io/github/kormium/TypeMapper {
+	public abstract fun toParameter (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/UniqueViolationException : io/github/kormium/QueryException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kormium/UpdateBuilder {
+	public fun <init> ()V
+	public final fun set (Lio/github/kormium/Column;Lio/github/kormium/Expression;)V
+	public final fun set (Lio/github/kormium/Column;Ljava/lang/Object;)V
+	public final fun where (Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class io/github/kormium/UuidColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/UuidColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Lkotlin/uuid/Uuid;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toParam (Lkotlin/uuid/Uuid;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/Value : io/github/kormium/Expression {
+	public fun <init> (Ljava/lang/Object;)V
+	public fun toSql (Lio/github/kormium/ParamBuilder;)Ljava/lang/String;
+}
+
+public abstract interface class io/github/kormium/WriteListener {
+	public abstract fun onCommit (Ljava/util/Set;)V
+}
+
+public class io/github/kormium/WriteListeners {
+	public fun <init> ()V
+	public fun add (Lio/github/kormium/WriteListener;)Lio/github/kormium/Registration;
+	public final fun fire (Ljava/util/Set;)V
+	public final fun isActive ()Z
+	public final fun publishCommit (Ljava/util/Set;)V
+	public fun setCommitPublish (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/github/kormium/WriteListeners$Disabled : io/github/kormium/WriteListeners {
+	public static final field INSTANCE Lio/github/kormium/WriteListeners$Disabled;
+	public fun add (Lio/github/kormium/WriteListener;)Lio/github/kormium/Registration;
+	public fun setCommitPublish (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class io/github/kormium/database/Database : java/lang/AutoCloseable {
+	public abstract fun close ()V
+	public fun getConfig ()Lio/github/kormium/KormiumConfig;
+	public fun getDialect ()Lio/github/kormium/Dialect;
+	public fun getWriteListeners ()Lio/github/kormium/WriteListeners;
+	public fun isClosed ()Z
+	public abstract fun usePinned (ZLio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun usePinned$default (Lio/github/kormium/database/Database;ZLio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/database/Database$DefaultImpls {
+	public static fun getConfig (Lio/github/kormium/database/Database;)Lio/github/kormium/KormiumConfig;
+	public static fun getDialect (Lio/github/kormium/database/Database;)Lio/github/kormium/Dialect;
+	public static fun getWriteListeners (Lio/github/kormium/database/Database;)Lio/github/kormium/WriteListeners;
+	public static fun isClosed (Lio/github/kormium/database/Database;)Z
+	public static synthetic fun usePinned$default (Lio/github/kormium/database/Database;ZLio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/github/kormium/database/SuspendDatabase : java/lang/AutoCloseable {
+	public abstract fun close ()V
+	public fun getConfig ()Lio/github/kormium/KormiumConfig;
+	public fun getDialect ()Lio/github/kormium/Dialect;
+	public fun getWriteListeners ()Lio/github/kormium/WriteListeners;
+	public fun isClosed ()Z
+	public abstract fun useConnection (ZLio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun useConnection$default (Lio/github/kormium/database/SuspendDatabase;ZLio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/database/SuspendDatabase$DefaultImpls {
+	public static fun getConfig (Lio/github/kormium/database/SuspendDatabase;)Lio/github/kormium/KormiumConfig;
+	public static fun getDialect (Lio/github/kormium/database/SuspendDatabase;)Lio/github/kormium/Dialect;
+	public static fun getWriteListeners (Lio/github/kormium/database/SuspendDatabase;)Lio/github/kormium/WriteListeners;
+	public static fun isClosed (Lio/github/kormium/database/SuspendDatabase;)Z
+	public static synthetic fun useConnection$default (Lio/github/kormium/database/SuspendDatabase;ZLio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/github/kormium/resultset/ResultSet {
+	public abstract fun getBoolean (I)Ljava/lang/Boolean;
+	public abstract fun getBytes (I)[B
+	public abstract fun getColumns ()[Ljava/lang/String;
+	public abstract fun getDate (I)Lkotlinx/datetime/LocalDate;
+	public abstract fun getDouble (I)Ljava/lang/Double;
+	public abstract fun getFloat (I)Ljava/lang/Float;
+	public abstract fun getInstant (I)Lkotlin/time/Instant;
+	public abstract fun getInt (I)Ljava/lang/Integer;
+	public abstract fun getLocalDateTime (I)Lkotlinx/datetime/LocalDateTime;
+	public abstract fun getLong (I)Ljava/lang/Long;
+	public abstract fun getShort (I)Ljava/lang/Short;
+	public abstract fun getString (I)Ljava/lang/String;
+	public abstract fun getTime (I)Lkotlinx/datetime/LocalTime;
+	public abstract fun next ()Z
+}
+
+public final class io/github/kormium/sql/ExtensionsKt {
+	public static final fun getJson (Lio/github/kormium/resultset/ResultSet;I)Lkotlinx/serialization/json/JsonElement;
+	public static final fun getUUID (Lio/github/kormium/resultset/ResultSet;I)Lkotlin/uuid/Uuid;
+}
+

--- a/kormium-core/api/kormium-core.klib.api
+++ b/kormium-core/api/kormium-core.klib.api
@@ -1,0 +1,940 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64, macosArm64, macosX64, mingwX64, wasmJs, wasmWasi]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-core>
+open annotation class io.github.kormium/DelicateKormiumApi : kotlin/Annotation { // io.github.kormium/DelicateKormiumApi|null[0]
+    constructor <init>() // io.github.kormium/DelicateKormiumApi.<init>|<init>(){}[0]
+}
+
+open annotation class io.github.kormium/KormiumDsl : kotlin/Annotation { // io.github.kormium/KormiumDsl|null[0]
+    constructor <init>() // io.github.kormium/KormiumDsl.<init>|<init>(){}[0]
+}
+
+final enum class io.github.kormium/AscDescOrder : kotlin/Enum<io.github.kormium/AscDescOrder> { // io.github.kormium/AscDescOrder|null[0]
+    enum entry ASC // io.github.kormium/AscDescOrder.ASC|null[0]
+    enum entry DESC // io.github.kormium/AscDescOrder.DESC|null[0]
+
+    final val entries // io.github.kormium/AscDescOrder.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<io.github.kormium/AscDescOrder> // io.github.kormium/AscDescOrder.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): io.github.kormium/AscDescOrder // io.github.kormium/AscDescOrder.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<io.github.kormium/AscDescOrder> // io.github.kormium/AscDescOrder.values|values#static(){}[0]
+}
+
+final enum class io.github.kormium/BatchInsertMode : kotlin/Enum<io.github.kormium/BatchInsertMode> { // io.github.kormium/BatchInsertMode|null[0]
+    enum entry GroupByAssignedFields // io.github.kormium/BatchInsertMode.GroupByAssignedFields|null[0]
+    enum entry Strict // io.github.kormium/BatchInsertMode.Strict|null[0]
+    enum entry UnionNulls // io.github.kormium/BatchInsertMode.UnionNulls|null[0]
+
+    final val entries // io.github.kormium/BatchInsertMode.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<io.github.kormium/BatchInsertMode> // io.github.kormium/BatchInsertMode.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): io.github.kormium/BatchInsertMode // io.github.kormium/BatchInsertMode.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<io.github.kormium/BatchInsertMode> // io.github.kormium/BatchInsertMode.values|values#static(){}[0]
+}
+
+final enum class io.github.kormium/QueryKind : kotlin/Enum<io.github.kormium/QueryKind> { // io.github.kormium/QueryKind|null[0]
+    enum entry Delete // io.github.kormium/QueryKind.Delete|null[0]
+    enum entry Insert // io.github.kormium/QueryKind.Insert|null[0]
+    enum entry Other // io.github.kormium/QueryKind.Other|null[0]
+    enum entry Select // io.github.kormium/QueryKind.Select|null[0]
+    enum entry Update // io.github.kormium/QueryKind.Update|null[0]
+
+    final val entries // io.github.kormium/QueryKind.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<io.github.kormium/QueryKind> // io.github.kormium/QueryKind.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): io.github.kormium/QueryKind // io.github.kormium/QueryKind.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<io.github.kormium/QueryKind> // io.github.kormium/QueryKind.values|values#static(){}[0]
+
+    final object Companion { // io.github.kormium/QueryKind.Companion|null[0]
+        final fun of(kotlin/String): io.github.kormium/QueryKind // io.github.kormium/QueryKind.Companion.of|of(kotlin.String){}[0]
+    }
+}
+
+final enum class io.github.kormium/TransactionIsolation : kotlin/Enum<io.github.kormium/TransactionIsolation> { // io.github.kormium/TransactionIsolation|null[0]
+    enum entry ReadCommitted // io.github.kormium/TransactionIsolation.ReadCommitted|null[0]
+    enum entry ReadUncommitted // io.github.kormium/TransactionIsolation.ReadUncommitted|null[0]
+    enum entry RepeatableRead // io.github.kormium/TransactionIsolation.RepeatableRead|null[0]
+    enum entry Serializable // io.github.kormium/TransactionIsolation.Serializable|null[0]
+
+    final val entries // io.github.kormium/TransactionIsolation.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<io.github.kormium/TransactionIsolation> // io.github.kormium/TransactionIsolation.entries.<get-entries>|<get-entries>#static(){}[0]
+    final val sql // io.github.kormium/TransactionIsolation.sql|{}sql[0]
+        final fun <get-sql>(): kotlin/String // io.github.kormium/TransactionIsolation.sql.<get-sql>|<get-sql>(){}[0]
+
+    final fun valueOf(kotlin/String): io.github.kormium/TransactionIsolation // io.github.kormium/TransactionIsolation.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<io.github.kormium/TransactionIsolation> // io.github.kormium/TransactionIsolation.values|values#static(){}[0]
+}
+
+abstract fun interface io.github.kormium/QueryObserver { // io.github.kormium/QueryObserver|null[0]
+    abstract fun onQuery(io.github.kormium/QueryEvent) // io.github.kormium/QueryObserver.onQuery|onQuery(io.github.kormium.QueryEvent){}[0]
+}
+
+abstract fun interface io.github.kormium/Registration { // io.github.kormium/Registration|null[0]
+    abstract fun remove() // io.github.kormium/Registration.remove|remove(){}[0]
+}
+
+abstract fun interface io.github.kormium/WriteListener { // io.github.kormium/WriteListener|null[0]
+    abstract fun onCommit(kotlin.collections/Set<kotlin/String>) // io.github.kormium/WriteListener.onCommit|onCommit(kotlin.collections.Set<kotlin.String>){}[0]
+}
+
+abstract interface <#A: kotlin/Any?> io.github.kormium/ColumnType { // io.github.kormium/ColumnType|null[0]
+    open val description // io.github.kormium/ColumnType.description|{}description[0]
+        open fun <get-description>(): kotlin/String // io.github.kormium/ColumnType.description.<get-description>|<get-description>(){}[0]
+
+    abstract fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): #A? // io.github.kormium/ColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+    open fun toParam(#A): kotlin/Any? // io.github.kormium/ColumnType.toParam|toParam(1:0){}[0]
+}
+
+abstract interface <#A: kotlin/Any?> io.github.kormium/NumericExpr : io.github.kormium/Operand<#A> // io.github.kormium/NumericExpr|null[0]
+
+abstract interface <#A: kotlin/Any?> io.github.kormium/Operand : io.github.kormium/Selectable<#A> { // io.github.kormium/Operand|null[0]
+    abstract val columnType // io.github.kormium/Operand.columnType|{}columnType[0]
+        abstract fun <get-columnType>(): io.github.kormium/ColumnType<#A> // io.github.kormium/Operand.columnType.<get-columnType>|<get-columnType>(){}[0]
+
+    open fun read(io.github.kormium.resultset/ResultSet, kotlin/Int, io.github.kormium/TypeMapper): #A? // io.github.kormium/Operand.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int;io.github.kormium.TypeMapper){}[0]
+}
+
+abstract interface <#A: kotlin/Any?> io.github.kormium/Selectable : io.github.kormium/Expression { // io.github.kormium/Selectable|null[0]
+    abstract fun read(io.github.kormium.resultset/ResultSet, kotlin/Int, io.github.kormium/TypeMapper): #A? // io.github.kormium/Selectable.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int;io.github.kormium.TypeMapper){}[0]
+    abstract fun resultKey(): kotlin/Any // io.github.kormium/Selectable.resultKey|resultKey(){}[0]
+}
+
+abstract interface <#A: out io.github.kormium/Catalog> io.github.kormium.database/Database : kotlin/AutoCloseable { // io.github.kormium.database/Database|null[0]
+    open val config // io.github.kormium.database/Database.config|{}config[0]
+        open fun <get-config>(): io.github.kormium/KormiumConfig // io.github.kormium.database/Database.config.<get-config>|<get-config>(){}[0]
+    open val dialect // io.github.kormium.database/Database.dialect|{}dialect[0]
+        open fun <get-dialect>(): io.github.kormium/Dialect // io.github.kormium.database/Database.dialect.<get-dialect>|<get-dialect>(){}[0]
+    open val isClosed // io.github.kormium.database/Database.isClosed|{}isClosed[0]
+        open fun <get-isClosed>(): kotlin/Boolean // io.github.kormium.database/Database.isClosed.<get-isClosed>|<get-isClosed>(){}[0]
+    open val writeListeners // io.github.kormium.database/Database.writeListeners|{}writeListeners[0]
+        open fun <get-writeListeners>(): io.github.kormium/WriteListeners // io.github.kormium.database/Database.writeListeners.<get-writeListeners>|<get-writeListeners>(){}[0]
+
+    abstract fun <#A1: kotlin/Any?> usePinned(kotlin/Boolean, io.github.kormium/TransactionIsolation? = ..., kotlin/Boolean = ..., kotlin/Function1<io.github.kormium/SqlExecutor, #A1>): #A1 // io.github.kormium.database/Database.usePinned|usePinned(kotlin.Boolean;io.github.kormium.TransactionIsolation?;kotlin.Boolean;kotlin.Function1<io.github.kormium.SqlExecutor,0:0>){0§<kotlin.Any?>}[0]
+    abstract fun close() // io.github.kormium.database/Database.close|close(){}[0]
+}
+
+abstract interface <#A: out io.github.kormium/Catalog> io.github.kormium.database/SuspendDatabase : kotlin/AutoCloseable { // io.github.kormium.database/SuspendDatabase|null[0]
+    open val config // io.github.kormium.database/SuspendDatabase.config|{}config[0]
+        open fun <get-config>(): io.github.kormium/KormiumConfig // io.github.kormium.database/SuspendDatabase.config.<get-config>|<get-config>(){}[0]
+    open val dialect // io.github.kormium.database/SuspendDatabase.dialect|{}dialect[0]
+        open fun <get-dialect>(): io.github.kormium/Dialect // io.github.kormium.database/SuspendDatabase.dialect.<get-dialect>|<get-dialect>(){}[0]
+    open val isClosed // io.github.kormium.database/SuspendDatabase.isClosed|{}isClosed[0]
+        open fun <get-isClosed>(): kotlin/Boolean // io.github.kormium.database/SuspendDatabase.isClosed.<get-isClosed>|<get-isClosed>(){}[0]
+    open val writeListeners // io.github.kormium.database/SuspendDatabase.writeListeners|{}writeListeners[0]
+        open fun <get-writeListeners>(): io.github.kormium/WriteListeners // io.github.kormium.database/SuspendDatabase.writeListeners.<get-writeListeners>|<get-writeListeners>(){}[0]
+
+    abstract fun close() // io.github.kormium.database/SuspendDatabase.close|close(){}[0]
+    abstract suspend fun <#A1: kotlin/Any?> useConnection(kotlin/Boolean, io.github.kormium/TransactionIsolation? = ..., kotlin/Boolean = ..., kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendSqlExecutor, #A1>): #A1 // io.github.kormium.database/SuspendDatabase.useConnection|useConnection(kotlin.Boolean;io.github.kormium.TransactionIsolation?;kotlin.Boolean;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendSqlExecutor,0:0>){0§<kotlin.Any?>}[0]
+}
+
+abstract interface io.github.kormium.resultset/ResultSet { // io.github.kormium.resultset/ResultSet|null[0]
+    abstract val columns // io.github.kormium.resultset/ResultSet.columns|{}columns[0]
+        abstract fun <get-columns>(): kotlin/Array<kotlin/String> // io.github.kormium.resultset/ResultSet.columns.<get-columns>|<get-columns>(){}[0]
+
+    abstract fun getBoolean(kotlin/Int): kotlin/Boolean? // io.github.kormium.resultset/ResultSet.getBoolean|getBoolean(kotlin.Int){}[0]
+    abstract fun getBytes(kotlin/Int): kotlin/ByteArray? // io.github.kormium.resultset/ResultSet.getBytes|getBytes(kotlin.Int){}[0]
+    abstract fun getDate(kotlin/Int): kotlinx.datetime/LocalDate? // io.github.kormium.resultset/ResultSet.getDate|getDate(kotlin.Int){}[0]
+    abstract fun getDouble(kotlin/Int): kotlin/Double? // io.github.kormium.resultset/ResultSet.getDouble|getDouble(kotlin.Int){}[0]
+    abstract fun getFloat(kotlin/Int): kotlin/Float? // io.github.kormium.resultset/ResultSet.getFloat|getFloat(kotlin.Int){}[0]
+    abstract fun getInstant(kotlin/Int): kotlin.time/Instant? // io.github.kormium.resultset/ResultSet.getInstant|getInstant(kotlin.Int){}[0]
+    abstract fun getInt(kotlin/Int): kotlin/Int? // io.github.kormium.resultset/ResultSet.getInt|getInt(kotlin.Int){}[0]
+    abstract fun getLocalDateTime(kotlin/Int): kotlinx.datetime/LocalDateTime? // io.github.kormium.resultset/ResultSet.getLocalDateTime|getLocalDateTime(kotlin.Int){}[0]
+    abstract fun getLong(kotlin/Int): kotlin/Long? // io.github.kormium.resultset/ResultSet.getLong|getLong(kotlin.Int){}[0]
+    abstract fun getShort(kotlin/Int): kotlin/Short? // io.github.kormium.resultset/ResultSet.getShort|getShort(kotlin.Int){}[0]
+    abstract fun getString(kotlin/Int): kotlin/String? // io.github.kormium.resultset/ResultSet.getString|getString(kotlin.Int){}[0]
+    abstract fun getTime(kotlin/Int): kotlinx.datetime/LocalTime? // io.github.kormium.resultset/ResultSet.getTime|getTime(kotlin.Int){}[0]
+    abstract fun next(): kotlin/Boolean // io.github.kormium.resultset/ResultSet.next|next(){}[0]
+}
+
+abstract interface io.github.kormium/Catalog // io.github.kormium/Catalog|null[0]
+
+abstract interface io.github.kormium/ConnectionPool { // io.github.kormium/ConnectionPool|null[0]
+    abstract fun acquire(): io.github.kormium/PinnedConnection // io.github.kormium/ConnectionPool.acquire|acquire(){}[0]
+    open suspend fun acquireSuspending(): io.github.kormium/PinnedConnection // io.github.kormium/ConnectionPool.acquireSuspending|acquireSuspending(){}[0]
+}
+
+abstract interface io.github.kormium/Dialect { // io.github.kormium/Dialect|null[0]
+    open val readOnlyToggle // io.github.kormium/Dialect.readOnlyToggle|{}readOnlyToggle[0]
+        open fun <get-readOnlyToggle>(): io.github.kormium/ReadOnlyToggle? // io.github.kormium/Dialect.readOnlyToggle.<get-readOnlyToggle>|<get-readOnlyToggle>(){}[0]
+    open val supportsReturning // io.github.kormium/Dialect.supportsReturning|{}supportsReturning[0]
+        open fun <get-supportsReturning>(): kotlin/Boolean // io.github.kormium/Dialect.supportsReturning.<get-supportsReturning>|<get-supportsReturning>(){}[0]
+    open val supportsTransactionIsolation // io.github.kormium/Dialect.supportsTransactionIsolation|{}supportsTransactionIsolation[0]
+        open fun <get-supportsTransactionIsolation>(): kotlin/Boolean // io.github.kormium/Dialect.supportsTransactionIsolation.<get-supportsTransactionIsolation>|<get-supportsTransactionIsolation>(){}[0]
+
+    abstract fun quoteIdentifier(kotlin/String): kotlin/String // io.github.kormium/Dialect.quoteIdentifier|quoteIdentifier(kotlin.String){}[0]
+    abstract fun renderBind(kotlin/String, kotlin/Any?): kotlin/String // io.github.kormium/Dialect.renderBind|renderBind(kotlin.String;kotlin.Any?){}[0]
+    abstract fun renderLimit(kotlin/UInt): kotlin/String // io.github.kormium/Dialect.renderLimit|renderLimit(kotlin.UInt){}[0]
+    abstract fun renderOffset(kotlin/UInt): kotlin/String // io.github.kormium/Dialect.renderOffset|renderOffset(kotlin.UInt){}[0]
+    open fun advisoryLockSql(kotlin/Long): kotlin/String? // io.github.kormium/Dialect.advisoryLockSql|advisoryLockSql(kotlin.Long){}[0]
+    open fun renderCharLength(kotlin/String): kotlin/String // io.github.kormium/Dialect.renderCharLength|renderCharLength(kotlin.String){}[0]
+    open fun renderInsertDefaultValues(kotlin/String): kotlin/String // io.github.kormium/Dialect.renderInsertDefaultValues|renderInsertDefaultValues(kotlin.String){}[0]
+    open fun renderInsertOrIgnoreSuffix(kotlin.collections/List<kotlin/String>): kotlin/String // io.github.kormium/Dialect.renderInsertOrIgnoreSuffix|renderInsertOrIgnoreSuffix(kotlin.collections.List<kotlin.String>){}[0]
+    open fun renderLimitOffset(kotlin/UInt, kotlin/UInt): kotlin/String // io.github.kormium/Dialect.renderLimitOffset|renderLimitOffset(kotlin.UInt;kotlin.UInt){}[0]
+    open fun renderUpsertSuffix(kotlin.collections/List<kotlin/String>, kotlin/String): kotlin/String // io.github.kormium/Dialect.renderUpsertSuffix|renderUpsertSuffix(kotlin.collections.List<kotlin.String>;kotlin.String){}[0]
+}
+
+abstract interface io.github.kormium/Expression { // io.github.kormium/Expression|null[0]
+    abstract fun toSql(io.github.kormium/ParamBuilder): kotlin/String // io.github.kormium/Expression.toSql|toSql(io.github.kormium.ParamBuilder){}[0]
+}
+
+abstract interface io.github.kormium/NotificationTransport { // io.github.kormium/NotificationTransport|null[0]
+    abstract fun subscribe(): kotlinx.coroutines.flow/Flow<kotlin.collections/Set<kotlin/String>> // io.github.kormium/NotificationTransport.subscribe|subscribe(){}[0]
+    abstract suspend fun publish(kotlin.collections/Set<kotlin/String>) // io.github.kormium/NotificationTransport.publish|publish(kotlin.collections.Set<kotlin.String>){}[0]
+}
+
+abstract interface io.github.kormium/PinnedConnection { // io.github.kormium/PinnedConnection|null[0]
+    abstract val executor // io.github.kormium/PinnedConnection.executor|{}executor[0]
+        abstract fun <get-executor>(): io.github.kormium/SqlExecutor // io.github.kormium/PinnedConnection.executor.<get-executor>|<get-executor>(){}[0]
+
+    abstract fun begin(io.github.kormium/TransactionIsolation? = ..., kotlin/Boolean = ...) // io.github.kormium/PinnedConnection.begin|begin(io.github.kormium.TransactionIsolation?;kotlin.Boolean){}[0]
+    abstract fun commit() // io.github.kormium/PinnedConnection.commit|commit(){}[0]
+    abstract fun release() // io.github.kormium/PinnedConnection.release|release(){}[0]
+    abstract fun rollback() // io.github.kormium/PinnedConnection.rollback|rollback(){}[0]
+}
+
+abstract interface io.github.kormium/SqlExecutor { // io.github.kormium/SqlExecutor|null[0]
+    abstract val dialect // io.github.kormium/SqlExecutor.dialect|{}dialect[0]
+        abstract fun <get-dialect>(): io.github.kormium/Dialect // io.github.kormium/SqlExecutor.dialect.<get-dialect>|<get-dialect>(){}[0]
+    abstract val typeMapper // io.github.kormium/SqlExecutor.typeMapper|{}typeMapper[0]
+        abstract fun <get-typeMapper>(): io.github.kormium/TypeMapper // io.github.kormium/SqlExecutor.typeMapper.<get-typeMapper>|<get-typeMapper>(){}[0]
+
+    abstract fun <#A1: kotlin/Any?> execute(kotlin/String, io.github.kormium/SqlParameterSource, kotlin/Function1<io.github.kormium.resultset/ResultSet, #A1>): kotlin.collections/List<#A1> // io.github.kormium/SqlExecutor.execute|execute(kotlin.String;io.github.kormium.SqlParameterSource;kotlin.Function1<io.github.kormium.resultset.ResultSet,0:0>){0§<kotlin.Any?>}[0]
+    abstract fun <#A1: kotlin/Any?> execute(kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/Any?> = ..., kotlin/Function1<io.github.kormium.resultset/ResultSet, #A1>): kotlin.collections/List<#A1> // io.github.kormium/SqlExecutor.execute|execute(kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.Any?>;kotlin.Function1<io.github.kormium.resultset.ResultSet,0:0>){0§<kotlin.Any?>}[0]
+    abstract fun execute(kotlin/String, io.github.kormium/SqlParameterSource): kotlin/Long // io.github.kormium/SqlExecutor.execute|execute(kotlin.String;io.github.kormium.SqlParameterSource){}[0]
+    abstract fun execute(kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/Any?> = ...): kotlin/Long // io.github.kormium/SqlExecutor.execute|execute(kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.Any?>){}[0]
+    abstract fun executeUpdate(kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/Any?> = ...): kotlin/Long // io.github.kormium/SqlExecutor.executeUpdate|executeUpdate(kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.Any?>){}[0]
+}
+
+abstract interface io.github.kormium/SqlParameterSource { // io.github.kormium/SqlParameterSource|null[0]
+    open val parameterNames // io.github.kormium/SqlParameterSource.parameterNames|{}parameterNames[0]
+        open fun <get-parameterNames>(): kotlin/Array<kotlin/String>? // io.github.kormium/SqlParameterSource.parameterNames.<get-parameterNames>|<get-parameterNames>(){}[0]
+
+    abstract fun getValue(kotlin/String): kotlin/Any? // io.github.kormium/SqlParameterSource.getValue|getValue(kotlin.String){}[0]
+    abstract fun hasValue(kotlin/String): kotlin/Boolean // io.github.kormium/SqlParameterSource.hasValue|hasValue(kotlin.String){}[0]
+    open fun getSqlType(kotlin/String): kotlin/UInt // io.github.kormium/SqlParameterSource.getSqlType|getSqlType(kotlin.String){}[0]
+    open fun getTypeName(kotlin/String?): kotlin/String? // io.github.kormium/SqlParameterSource.getTypeName|getTypeName(kotlin.String?){}[0]
+
+    final object Companion { // io.github.kormium/SqlParameterSource.Companion|null[0]
+        final val TYPE_UNKNOWN // io.github.kormium/SqlParameterSource.Companion.TYPE_UNKNOWN|{}TYPE_UNKNOWN[0]
+            final fun <get-TYPE_UNKNOWN>(): kotlin/UInt // io.github.kormium/SqlParameterSource.Companion.TYPE_UNKNOWN.<get-TYPE_UNKNOWN>|<get-TYPE_UNKNOWN>(){}[0]
+    }
+}
+
+abstract interface io.github.kormium/StringExpr : io.github.kormium/Operand<kotlin/String> { // io.github.kormium/StringExpr|null[0]
+    open val columnType // io.github.kormium/StringExpr.columnType|{}columnType[0]
+        open fun <get-columnType>(): io.github.kormium/ColumnType<kotlin/String> // io.github.kormium/StringExpr.columnType.<get-columnType>|<get-columnType>(){}[0]
+}
+
+abstract interface io.github.kormium/SuspendSqlExecutor { // io.github.kormium/SuspendSqlExecutor|null[0]
+    abstract val dialect // io.github.kormium/SuspendSqlExecutor.dialect|{}dialect[0]
+        abstract fun <get-dialect>(): io.github.kormium/Dialect // io.github.kormium/SuspendSqlExecutor.dialect.<get-dialect>|<get-dialect>(){}[0]
+    abstract val typeMapper // io.github.kormium/SuspendSqlExecutor.typeMapper|{}typeMapper[0]
+        abstract fun <get-typeMapper>(): io.github.kormium/TypeMapper // io.github.kormium/SuspendSqlExecutor.typeMapper.<get-typeMapper>|<get-typeMapper>(){}[0]
+
+    abstract suspend fun <#A1: kotlin/Any?> execute(kotlin/String, io.github.kormium/SqlParameterSource, kotlin/Function1<io.github.kormium.resultset/ResultSet, #A1>): kotlin.collections/List<#A1> // io.github.kormium/SuspendSqlExecutor.execute|execute(kotlin.String;io.github.kormium.SqlParameterSource;kotlin.Function1<io.github.kormium.resultset.ResultSet,0:0>){0§<kotlin.Any?>}[0]
+    abstract suspend fun <#A1: kotlin/Any?> execute(kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/Any?> = ..., kotlin/Function1<io.github.kormium.resultset/ResultSet, #A1>): kotlin.collections/List<#A1> // io.github.kormium/SuspendSqlExecutor.execute|execute(kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.Any?>;kotlin.Function1<io.github.kormium.resultset.ResultSet,0:0>){0§<kotlin.Any?>}[0]
+    abstract suspend fun execute(kotlin/String, io.github.kormium/SqlParameterSource): kotlin/Long // io.github.kormium/SuspendSqlExecutor.execute|execute(kotlin.String;io.github.kormium.SqlParameterSource){}[0]
+    abstract suspend fun execute(kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/Any?> = ...): kotlin/Long // io.github.kormium/SuspendSqlExecutor.execute|execute(kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.Any?>){}[0]
+    abstract suspend fun executeUpdate(kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/Any?> = ...): kotlin/Long // io.github.kormium/SuspendSqlExecutor.executeUpdate|executeUpdate(kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.Any?>){}[0]
+}
+
+abstract interface io.github.kormium/TypeMapper { // io.github.kormium/TypeMapper|null[0]
+    abstract fun toParameter(kotlin/Any?): kotlin/Any? // io.github.kormium/TypeMapper.toParameter|toParameter(kotlin.Any?){}[0]
+}
+
+abstract class <#A: io.github.kormium/Catalog, #B: io.github.kormium/Entity> io.github.kormium/Table { // io.github.kormium/Table|null[0]
+    constructor <init>(kotlin/String, kotlin/Function0<#B>) // io.github.kormium/Table.<init>|<init>(kotlin.String;kotlin.Function0<1:1>){}[0]
+
+    final val factory // io.github.kormium/Table.factory|{}factory[0]
+        final fun <get-factory>(): kotlin/Function0<#B> // io.github.kormium/Table.factory.<get-factory>|<get-factory>(){}[0]
+    final val primaryKey // io.github.kormium/Table.primaryKey|{}primaryKey[0]
+        final fun <get-primaryKey>(): kotlin.collections/List<io.github.kormium/Column<*, *, #B>> // io.github.kormium/Table.primaryKey.<get-primaryKey>|<get-primaryKey>(){}[0]
+    final val tableName // io.github.kormium/Table.tableName|{}tableName[0]
+        final fun <get-tableName>(): kotlin/String // io.github.kormium/Table.tableName.<get-tableName>|<get-tableName>(){}[0]
+
+    final fun getFieldDisplayNames(): kotlin.collections/Map<kotlin/String, io.github.kormium/Column<*, *, *>> // io.github.kormium/Table.getFieldDisplayNames|getFieldDisplayNames(){}[0]
+}
+
+abstract class io.github.kormium/Entity { // io.github.kormium/Entity|null[0]
+    constructor <init>() // io.github.kormium/Entity.<init>|<init>(){}[0]
+}
+
+final class <#A: io.github.kormium/Catalog, #B: io.github.kormium/Entity, #C: io.github.kormium/Entity> io.github.kormium/JoinPair { // io.github.kormium/JoinPair|null[0]
+    final fun distinct(): io.github.kormium/Join<#A> // io.github.kormium/JoinPair.distinct|distinct(){}[0]
+    final fun groupBy(kotlin/Array<out io.github.kormium/Column<*, *, *>>...): io.github.kormium/Join<#A> // io.github.kormium/JoinPair.groupBy|groupBy(kotlin.Array<out|io.github.kormium.Column<*,*,*>>...){}[0]
+    final fun innerJoin(io.github.kormium/Table<#A, *>): io.github.kormium/JoinStep<#A> // io.github.kormium/JoinPair.innerJoin|innerJoin(io.github.kormium.Table<1:0,*>){}[0]
+    final fun leftJoin(io.github.kormium/Table<#A, *>): io.github.kormium/JoinStep<#A> // io.github.kormium/JoinPair.leftJoin|leftJoin(io.github.kormium.Table<1:0,*>){}[0]
+    final fun where(io.github.kormium/Expression): io.github.kormium/JoinPair<#A, #B, #C> // io.github.kormium/JoinPair.where|where(io.github.kormium.Expression){}[0]
+}
+
+final class <#A: io.github.kormium/Catalog, #B: io.github.kormium/Entity, #C: io.github.kormium/Entity> io.github.kormium/JoinPairStep { // io.github.kormium/JoinPairStep|null[0]
+    final fun on(io.github.kormium/Expression): io.github.kormium/JoinPair<#A, #B, #C> // io.github.kormium/JoinPairStep.on|on(io.github.kormium.Expression){}[0]
+}
+
+final class <#A: io.github.kormium/Catalog, #B: io.github.kormium/Entity, #C: io.github.kormium/Entity> io.github.kormium/LeftJoinPair { // io.github.kormium/LeftJoinPair|null[0]
+    final fun distinct(): io.github.kormium/Join<#A> // io.github.kormium/LeftJoinPair.distinct|distinct(){}[0]
+    final fun groupBy(kotlin/Array<out io.github.kormium/Column<*, *, *>>...): io.github.kormium/Join<#A> // io.github.kormium/LeftJoinPair.groupBy|groupBy(kotlin.Array<out|io.github.kormium.Column<*,*,*>>...){}[0]
+    final fun innerJoin(io.github.kormium/Table<#A, *>): io.github.kormium/JoinStep<#A> // io.github.kormium/LeftJoinPair.innerJoin|innerJoin(io.github.kormium.Table<1:0,*>){}[0]
+    final fun leftJoin(io.github.kormium/Table<#A, *>): io.github.kormium/JoinStep<#A> // io.github.kormium/LeftJoinPair.leftJoin|leftJoin(io.github.kormium.Table<1:0,*>){}[0]
+    final fun where(io.github.kormium/Expression): io.github.kormium/LeftJoinPair<#A, #B, #C> // io.github.kormium/LeftJoinPair.where|where(io.github.kormium.Expression){}[0]
+}
+
+final class <#A: io.github.kormium/Catalog, #B: io.github.kormium/Entity, #C: io.github.kormium/Entity> io.github.kormium/LeftJoinPairStep { // io.github.kormium/LeftJoinPairStep|null[0]
+    final fun on(io.github.kormium/Expression): io.github.kormium/LeftJoinPair<#A, #B, #C> // io.github.kormium/LeftJoinPairStep.on|on(io.github.kormium.Expression){}[0]
+}
+
+final class <#A: io.github.kormium/Catalog> io.github.kormium/Join { // io.github.kormium/Join|null[0]
+    final fun distinct(): io.github.kormium/Join<#A> // io.github.kormium/Join.distinct|distinct(){}[0]
+    final fun groupBy(kotlin/Array<out io.github.kormium/Column<*, *, *>>...): io.github.kormium/Join<#A> // io.github.kormium/Join.groupBy|groupBy(kotlin.Array<out|io.github.kormium.Column<*,*,*>>...){}[0]
+    final fun having(io.github.kormium/Expression): io.github.kormium/Join<#A> // io.github.kormium/Join.having|having(io.github.kormium.Expression){}[0]
+    final fun innerJoin(io.github.kormium/Table<#A, *>): io.github.kormium/JoinStep<#A> // io.github.kormium/Join.innerJoin|innerJoin(io.github.kormium.Table<1:0,*>){}[0]
+    final fun leftJoin(io.github.kormium/Table<#A, *>): io.github.kormium/JoinStep<#A> // io.github.kormium/Join.leftJoin|leftJoin(io.github.kormium.Table<1:0,*>){}[0]
+    final fun where(io.github.kormium/Expression): io.github.kormium/Join<#A> // io.github.kormium/Join.where|where(io.github.kormium.Expression){}[0]
+}
+
+final class <#A: io.github.kormium/Catalog> io.github.kormium/JoinStep { // io.github.kormium/JoinStep|null[0]
+    final fun on(io.github.kormium/Expression): io.github.kormium/Join<#A> // io.github.kormium/JoinStep.on|on(io.github.kormium.Expression){}[0]
+}
+
+final class <#A: io.github.kormium/Catalog> io.github.kormium/RenderScope { // io.github.kormium/RenderScope|null[0]
+    final val dialect // io.github.kormium/RenderScope.dialect|{}dialect[0]
+        final fun <get-dialect>(): io.github.kormium/Dialect // io.github.kormium/RenderScope.dialect.<get-dialect>|<get-dialect>(){}[0]
+    final val typeMapper // io.github.kormium/RenderScope.typeMapper|{}typeMapper[0]
+        final fun <get-typeMapper>(): io.github.kormium/TypeMapper // io.github.kormium/RenderScope.typeMapper.<get-typeMapper>|<get-typeMapper>(){}[0]
+
+    final fun (io.github.kormium/Join<#A>).select(kotlin/Array<out io.github.kormium/Selectable<*>>...): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.select|select@io.github.kormium.Join<1:0>(kotlin.Array<out|io.github.kormium.Selectable<*>>...){}[0]
+    final fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity> (io.github.kormium/JoinPair<#A, #A1, #B1>).select(kotlin/Array<out io.github.kormium/Selectable<*>>...): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.select|select@io.github.kormium.JoinPair<1:0,0:0,0:1>(kotlin.Array<out|io.github.kormium.Selectable<*>>...){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity> (io.github.kormium/LeftJoinPair<#A, #A1, #B1>).select(kotlin/Array<out io.github.kormium/Selectable<*>>...): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.select|select@io.github.kormium.LeftJoinPair<1:0,0:0,0:1>(kotlin.Array<out|io.github.kormium.Selectable<*>>...){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).all(): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.all|all@io.github.kormium.Table<1:0,0:0>(){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).count(io.github.kormium/Query = ...): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.count|count@io.github.kormium.Table<1:0,0:0>(io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).count(kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.count|count@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).deleteWhere(io.github.kormium/Query): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.deleteWhere|deleteWhere@io.github.kormium.Table<1:0,0:0>(io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).deleteWhere(kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.deleteWhere|deleteWhere@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).find(io.github.kormium/Query): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.find|find@io.github.kormium.Table<1:0,0:0>(io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).find(kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.find|find@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).findOne(io.github.kormium/Query): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.findOne|findOne@io.github.kormium.Table<1:0,0:0>(io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).findOne(kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.findOne|findOne@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).insert(#A1, kotlin/Boolean = ...): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.insert|insert@io.github.kormium.Table<1:0,0:0>(0:0;kotlin.Boolean){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).insertAll(kotlin.collections/List<#A1>, kotlin/Boolean = ..., io.github.kormium/BatchInsertMode = ...): kotlin.collections/List<io.github.kormium/RenderedSql> // io.github.kormium/RenderScope.insertAll|insertAll@io.github.kormium.Table<1:0,0:0>(kotlin.collections.List<0:0>;kotlin.Boolean;io.github.kormium.BatchInsertMode){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).insertOrIgnore(#A1, io.github.kormium/Column<*, *, #A1>): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.insertOrIgnore|insertOrIgnore@io.github.kormium.Table<1:0,0:0>(0:0;io.github.kormium.Column<*,*,0:0>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).insertOrIgnore(#A1, kotlin.collections/List<io.github.kormium/Column<*, *, #A1>>): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.insertOrIgnore|insertOrIgnore@io.github.kormium.Table<1:0,0:0>(0:0;kotlin.collections.List<io.github.kormium.Column<*,*,0:0>>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).update(#A1, io.github.kormium/Query): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.update|update@io.github.kormium.Table<1:0,0:0>(0:0;io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).update(#A1, kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.update|update@io.github.kormium.Table<1:0,0:0>(0:0;kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).update(kotlin/Function1<io.github.kormium/UpdateBuilder, kotlin/Unit>): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.update|update@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.UpdateBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).upsert(#A1, io.github.kormium/Column<*, *, #A1>, #A1, kotlin/Boolean = ...): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.upsert|upsert@io.github.kormium.Table<1:0,0:0>(0:0;io.github.kormium.Column<*,*,0:0>;0:0;kotlin.Boolean){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).upsert(#A1, kotlin.collections/List<io.github.kormium/Column<*, *, #A1>>, #A1, kotlin/Boolean = ...): io.github.kormium/RenderedSql // io.github.kormium/RenderScope.upsert|upsert@io.github.kormium.Table<1:0,0:0>(0:0;kotlin.collections.List<io.github.kormium.Column<*,*,0:0>>;0:0;kotlin.Boolean){0§<io.github.kormium.Entity>}[0]
+}
+
+final class <#A: io.github.kormium/Catalog> io.github.kormium/Scope { // io.github.kormium/Scope|null[0]
+    final fun (io.github.kormium/Join<#A>).select(kotlin/Array<out io.github.kormium/Selectable<*>>...): kotlin.collections/List<io.github.kormium/ResultRow> // io.github.kormium/Scope.select|select@io.github.kormium.Join<1:0>(kotlin.Array<out|io.github.kormium.Selectable<*>>...){}[0]
+    final fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity, #C1: kotlin/Any?> (io.github.kormium/JoinPair<#A, #A1, #B1>).select(kotlin/Array<out io.github.kormium/Selectable<*>>..., kotlin/Function1<io.github.kormium/ResultRow, #C1>): kotlin.collections/List<#C1> // io.github.kormium/Scope.select|select@io.github.kormium.JoinPair<1:0,0:0,0:1>(kotlin.Array<out|io.github.kormium.Selectable<*>>...;kotlin.Function1<io.github.kormium.ResultRow,0:2>){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>;2§<kotlin.Any?>}[0]
+    final fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity, #C1: kotlin/Any?> (io.github.kormium/LeftJoinPair<#A, #A1, #B1>).select(kotlin/Array<out io.github.kormium/Selectable<*>>..., kotlin/Function1<io.github.kormium/ResultRow, #C1>): kotlin.collections/List<#C1> // io.github.kormium/Scope.select|select@io.github.kormium.LeftJoinPair<1:0,0:0,0:1>(kotlin.Array<out|io.github.kormium.Selectable<*>>...;kotlin.Function1<io.github.kormium.ResultRow,0:2>){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>;2§<kotlin.Any?>}[0]
+    final fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity> (io.github.kormium/JoinPair<#A, #A1, #B1>).find(): kotlin.collections/List<kotlin/Pair<#A1, #B1>> // io.github.kormium/Scope.find|find@io.github.kormium.JoinPair<1:0,0:0,0:1>(){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity> (io.github.kormium/JoinPair<#A, #A1, #B1>).select(kotlin/Array<out io.github.kormium/Selectable<*>>...): kotlin.collections/List<io.github.kormium/ResultRow> // io.github.kormium/Scope.select|select@io.github.kormium.JoinPair<1:0,0:0,0:1>(kotlin.Array<out|io.github.kormium.Selectable<*>>...){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity> (io.github.kormium/LeftJoinPair<#A, #A1, #B1>).find(): kotlin.collections/List<kotlin/Pair<#A1, #B1?>> // io.github.kormium/Scope.find|find@io.github.kormium.LeftJoinPair<1:0,0:0,0:1>(){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity> (io.github.kormium/LeftJoinPair<#A, #A1, #B1>).select(kotlin/Array<out io.github.kormium/Selectable<*>>...): kotlin.collections/List<io.github.kormium/ResultRow> // io.github.kormium/Scope.select|select@io.github.kormium.LeftJoinPair<1:0,0:0,0:1>(kotlin.Array<out|io.github.kormium.Selectable<*>>...){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).all(): kotlin.collections/List<#A1> // io.github.kormium/Scope.all|all@io.github.kormium.Table<1:0,0:0>(){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).count(io.github.kormium/Query = ...): kotlin/Long // io.github.kormium/Scope.count|count@io.github.kormium.Table<1:0,0:0>(io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).count(kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): kotlin/Long // io.github.kormium/Scope.count|count@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).deleteWhere(io.github.kormium/Query): kotlin/Long // io.github.kormium/Scope.deleteWhere|deleteWhere@io.github.kormium.Table<1:0,0:0>(io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).deleteWhere(kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): kotlin/Long // io.github.kormium/Scope.deleteWhere|deleteWhere@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).execSql(kotlin/String) // io.github.kormium/Scope.execSql|execSql@io.github.kormium.Table<1:0,0:0>(kotlin.String){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).find(io.github.kormium/Query): kotlin.collections/List<#A1> // io.github.kormium/Scope.find|find@io.github.kormium.Table<1:0,0:0>(io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).find(kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): kotlin.collections/List<#A1> // io.github.kormium/Scope.find|find@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).findOne(io.github.kormium/Query): #A1? // io.github.kormium/Scope.findOne|findOne@io.github.kormium.Table<1:0,0:0>(io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).findOne(kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): #A1? // io.github.kormium/Scope.findOne|findOne@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).insert(#A1, kotlin/Boolean = ...): #A1 // io.github.kormium/Scope.insert|insert@io.github.kormium.Table<1:0,0:0>(0:0;kotlin.Boolean){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).insertAll(kotlin.collections/List<#A1>, kotlin/Boolean = ..., io.github.kormium/BatchInsertMode = ...): kotlin.collections/List<#A1> // io.github.kormium/Scope.insertAll|insertAll@io.github.kormium.Table<1:0,0:0>(kotlin.collections.List<0:0>;kotlin.Boolean;io.github.kormium.BatchInsertMode){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).insertOrIgnore(#A1, io.github.kormium/Column<*, *, #A1>): kotlin/Long // io.github.kormium/Scope.insertOrIgnore|insertOrIgnore@io.github.kormium.Table<1:0,0:0>(0:0;io.github.kormium.Column<*,*,0:0>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).insertOrIgnore(#A1, kotlin.collections/List<io.github.kormium/Column<*, *, #A1>>): kotlin/Long // io.github.kormium/Scope.insertOrIgnore|insertOrIgnore@io.github.kormium.Table<1:0,0:0>(0:0;kotlin.collections.List<io.github.kormium.Column<*,*,0:0>>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).update(#A1, io.github.kormium/Query): kotlin/Long // io.github.kormium/Scope.update|update@io.github.kormium.Table<1:0,0:0>(0:0;io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).update(#A1, kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): kotlin/Long // io.github.kormium/Scope.update|update@io.github.kormium.Table<1:0,0:0>(0:0;kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).update(kotlin/Function1<io.github.kormium/UpdateBuilder, kotlin/Unit>): kotlin/Long // io.github.kormium/Scope.update|update@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.UpdateBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).upsert(#A1, io.github.kormium/Column<*, *, #A1>, #A1, kotlin/Boolean = ...): #A1 // io.github.kormium/Scope.upsert|upsert@io.github.kormium.Table<1:0,0:0>(0:0;io.github.kormium.Column<*,*,0:0>;0:0;kotlin.Boolean){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).upsert(#A1, kotlin.collections/List<io.github.kormium/Column<*, *, #A1>>, #A1, kotlin/Boolean = ...): #A1 // io.github.kormium/Scope.upsert|upsert@io.github.kormium.Table<1:0,0:0>(0:0;kotlin.collections.List<io.github.kormium.Column<*,*,0:0>>;0:0;kotlin.Boolean){0§<io.github.kormium.Entity>}[0]
+    final fun <#A1: kotlin/Any?> (io.github.kormium/Join<#A>).select(kotlin/Array<out io.github.kormium/Selectable<*>>..., kotlin/Function1<io.github.kormium/ResultRow, #A1>): kotlin.collections/List<#A1> // io.github.kormium/Scope.select|select@io.github.kormium.Join<1:0>(kotlin.Array<out|io.github.kormium.Selectable<*>>...;kotlin.Function1<io.github.kormium.ResultRow,0:0>){0§<kotlin.Any?>}[0]
+    final fun <#A1: kotlin/Any?> execute(kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/Any?>, kotlin.collections/List<io.github.kormium/Table<#A, *>>, kotlin/Function1<io.github.kormium.resultset/ResultSet, #A1>): kotlin.collections/List<#A1> // io.github.kormium/Scope.execute|execute(kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.Any?>;kotlin.collections.List<io.github.kormium.Table<1:0,*>>;kotlin.Function1<io.github.kormium.resultset.ResultSet,0:0>){0§<kotlin.Any?>}[0]
+    final fun <#A1: kotlin/Any?> savepoint(kotlin/Function1<io.github.kormium/Scope<#A>, #A1>): #A1 // io.github.kormium/Scope.savepoint|savepoint(kotlin.Function1<io.github.kormium.Scope<1:0>,0:0>){0§<kotlin.Any?>}[0]
+    final fun executeUpdate(kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/Any?>, kotlin.collections/List<io.github.kormium/Table<#A, *>>): kotlin/Long // io.github.kormium/Scope.executeUpdate|executeUpdate(kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.Any?>;kotlin.collections.List<io.github.kormium.Table<1:0,*>>){}[0]
+}
+
+final class <#A: io.github.kormium/Catalog> io.github.kormium/SuspendScope { // io.github.kormium/SuspendScope|null[0]
+    final suspend fun (io.github.kormium/Join<#A>).select(kotlin/Array<out io.github.kormium/Selectable<*>>...): kotlin.collections/List<io.github.kormium/ResultRow> // io.github.kormium/SuspendScope.select|select@io.github.kormium.Join<1:0>(kotlin.Array<out|io.github.kormium.Selectable<*>>...){}[0]
+    final suspend fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity, #C1: kotlin/Any?> (io.github.kormium/JoinPair<#A, #A1, #B1>).select(kotlin/Array<out io.github.kormium/Selectable<*>>..., kotlin/Function1<io.github.kormium/ResultRow, #C1>): kotlin.collections/List<#C1> // io.github.kormium/SuspendScope.select|select@io.github.kormium.JoinPair<1:0,0:0,0:1>(kotlin.Array<out|io.github.kormium.Selectable<*>>...;kotlin.Function1<io.github.kormium.ResultRow,0:2>){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>;2§<kotlin.Any?>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity, #C1: kotlin/Any?> (io.github.kormium/LeftJoinPair<#A, #A1, #B1>).select(kotlin/Array<out io.github.kormium/Selectable<*>>..., kotlin/Function1<io.github.kormium/ResultRow, #C1>): kotlin.collections/List<#C1> // io.github.kormium/SuspendScope.select|select@io.github.kormium.LeftJoinPair<1:0,0:0,0:1>(kotlin.Array<out|io.github.kormium.Selectable<*>>...;kotlin.Function1<io.github.kormium.ResultRow,0:2>){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>;2§<kotlin.Any?>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity> (io.github.kormium/JoinPair<#A, #A1, #B1>).find(): kotlin.collections/List<kotlin/Pair<#A1, #B1>> // io.github.kormium/SuspendScope.find|find@io.github.kormium.JoinPair<1:0,0:0,0:1>(){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity> (io.github.kormium/JoinPair<#A, #A1, #B1>).select(kotlin/Array<out io.github.kormium/Selectable<*>>...): kotlin.collections/List<io.github.kormium/ResultRow> // io.github.kormium/SuspendScope.select|select@io.github.kormium.JoinPair<1:0,0:0,0:1>(kotlin.Array<out|io.github.kormium.Selectable<*>>...){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity> (io.github.kormium/LeftJoinPair<#A, #A1, #B1>).find(): kotlin.collections/List<kotlin/Pair<#A1, #B1?>> // io.github.kormium/SuspendScope.find|find@io.github.kormium.LeftJoinPair<1:0,0:0,0:1>(){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity, #B1: io.github.kormium/Entity> (io.github.kormium/LeftJoinPair<#A, #A1, #B1>).select(kotlin/Array<out io.github.kormium/Selectable<*>>...): kotlin.collections/List<io.github.kormium/ResultRow> // io.github.kormium/SuspendScope.select|select@io.github.kormium.LeftJoinPair<1:0,0:0,0:1>(kotlin.Array<out|io.github.kormium.Selectable<*>>...){0§<io.github.kormium.Entity>;1§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).all(): kotlin.collections/List<#A1> // io.github.kormium/SuspendScope.all|all@io.github.kormium.Table<1:0,0:0>(){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).count(io.github.kormium/Query = ...): kotlin/Long // io.github.kormium/SuspendScope.count|count@io.github.kormium.Table<1:0,0:0>(io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).count(kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): kotlin/Long // io.github.kormium/SuspendScope.count|count@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).deleteWhere(io.github.kormium/Query): kotlin/Long // io.github.kormium/SuspendScope.deleteWhere|deleteWhere@io.github.kormium.Table<1:0,0:0>(io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).deleteWhere(kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): kotlin/Long // io.github.kormium/SuspendScope.deleteWhere|deleteWhere@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).execSql(kotlin/String) // io.github.kormium/SuspendScope.execSql|execSql@io.github.kormium.Table<1:0,0:0>(kotlin.String){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).find(io.github.kormium/Query): kotlin.collections/List<#A1> // io.github.kormium/SuspendScope.find|find@io.github.kormium.Table<1:0,0:0>(io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).find(kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): kotlin.collections/List<#A1> // io.github.kormium/SuspendScope.find|find@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).findOne(io.github.kormium/Query): #A1? // io.github.kormium/SuspendScope.findOne|findOne@io.github.kormium.Table<1:0,0:0>(io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).findOne(kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): #A1? // io.github.kormium/SuspendScope.findOne|findOne@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).insert(#A1, kotlin/Boolean = ...): #A1 // io.github.kormium/SuspendScope.insert|insert@io.github.kormium.Table<1:0,0:0>(0:0;kotlin.Boolean){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).insertAll(kotlin.collections/List<#A1>, kotlin/Boolean = ..., io.github.kormium/BatchInsertMode = ...): kotlin.collections/List<#A1> // io.github.kormium/SuspendScope.insertAll|insertAll@io.github.kormium.Table<1:0,0:0>(kotlin.collections.List<0:0>;kotlin.Boolean;io.github.kormium.BatchInsertMode){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).insertOrIgnore(#A1, io.github.kormium/Column<*, *, #A1>): kotlin/Long // io.github.kormium/SuspendScope.insertOrIgnore|insertOrIgnore@io.github.kormium.Table<1:0,0:0>(0:0;io.github.kormium.Column<*,*,0:0>){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).insertOrIgnore(#A1, kotlin.collections/List<io.github.kormium/Column<*, *, #A1>>): kotlin/Long // io.github.kormium/SuspendScope.insertOrIgnore|insertOrIgnore@io.github.kormium.Table<1:0,0:0>(0:0;kotlin.collections.List<io.github.kormium.Column<*,*,0:0>>){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).update(#A1, io.github.kormium/Query): kotlin/Long // io.github.kormium/SuspendScope.update|update@io.github.kormium.Table<1:0,0:0>(0:0;io.github.kormium.Query){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).update(#A1, kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit>): kotlin/Long // io.github.kormium/SuspendScope.update|update@io.github.kormium.Table<1:0,0:0>(0:0;kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).update(kotlin/Function1<io.github.kormium/UpdateBuilder, kotlin/Unit>): kotlin/Long // io.github.kormium/SuspendScope.update|update@io.github.kormium.Table<1:0,0:0>(kotlin.Function1<io.github.kormium.UpdateBuilder,kotlin.Unit>){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).upsert(#A1, io.github.kormium/Column<*, *, #A1>, #A1, kotlin/Boolean = ...): #A1 // io.github.kormium/SuspendScope.upsert|upsert@io.github.kormium.Table<1:0,0:0>(0:0;io.github.kormium.Column<*,*,0:0>;0:0;kotlin.Boolean){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: io.github.kormium/Entity> (io.github.kormium/Table<#A, #A1>).upsert(#A1, kotlin.collections/List<io.github.kormium/Column<*, *, #A1>>, #A1, kotlin/Boolean = ...): #A1 // io.github.kormium/SuspendScope.upsert|upsert@io.github.kormium.Table<1:0,0:0>(0:0;kotlin.collections.List<io.github.kormium.Column<*,*,0:0>>;0:0;kotlin.Boolean){0§<io.github.kormium.Entity>}[0]
+    final suspend fun <#A1: kotlin/Any?> (io.github.kormium/Join<#A>).select(kotlin/Array<out io.github.kormium/Selectable<*>>..., kotlin/Function1<io.github.kormium/ResultRow, #A1>): kotlin.collections/List<#A1> // io.github.kormium/SuspendScope.select|select@io.github.kormium.Join<1:0>(kotlin.Array<out|io.github.kormium.Selectable<*>>...;kotlin.Function1<io.github.kormium.ResultRow,0:0>){0§<kotlin.Any?>}[0]
+    final suspend fun <#A1: kotlin/Any?> execute(kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/Any?>, kotlin.collections/List<io.github.kormium/Table<#A, *>>, kotlin/Function1<io.github.kormium.resultset/ResultSet, #A1>): kotlin.collections/List<#A1> // io.github.kormium/SuspendScope.execute|execute(kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.Any?>;kotlin.collections.List<io.github.kormium.Table<1:0,*>>;kotlin.Function1<io.github.kormium.resultset.ResultSet,0:0>){0§<kotlin.Any?>}[0]
+    final suspend fun <#A1: kotlin/Any?> savepoint(kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #A1>): #A1 // io.github.kormium/SuspendScope.savepoint|savepoint(kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<1:0>,0:0>){0§<kotlin.Any?>}[0]
+    final suspend fun executeUpdate(kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/Any?>, kotlin.collections/List<io.github.kormium/Table<#A, *>>): kotlin/Long // io.github.kormium/SuspendScope.executeUpdate|executeUpdate(kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.Any?>;kotlin.collections.List<io.github.kormium.Table<1:0,*>>){}[0]
+}
+
+final class <#A: kotlin/Any?> io.github.kormium/CaseBuilder { // io.github.kormium/CaseBuilder|null[0]
+    final fun otherwise(#A) // io.github.kormium/CaseBuilder.otherwise|otherwise(1:0){}[0]
+    final fun whenever(io.github.kormium/Expression): io.github.kormium/CaseBuilder.WhenStep<#A> // io.github.kormium/CaseBuilder.whenever|whenever(io.github.kormium.Expression){}[0]
+
+    final inner class WhenStep { // io.github.kormium/CaseBuilder.WhenStep|null[0]
+        final fun then(#A) // io.github.kormium/CaseBuilder.WhenStep.then|then(2:0){}[0]
+    }
+}
+
+final class <#A: kotlin/Any?> io.github.kormium/CaseOp : io.github.kormium/Operand<#A> { // io.github.kormium/CaseOp|null[0]
+    final val columnType // io.github.kormium/CaseOp.columnType|{}columnType[0]
+        final fun <get-columnType>(): io.github.kormium/ColumnType<#A> // io.github.kormium/CaseOp.columnType.<get-columnType>|<get-columnType>(){}[0]
+
+    final fun resultKey(): kotlin/Any // io.github.kormium/CaseOp.resultKey|resultKey(){}[0]
+    final fun toSql(io.github.kormium/ParamBuilder): kotlin/String // io.github.kormium/CaseOp.toSql|toSql(io.github.kormium.ParamBuilder){}[0]
+}
+
+final class <#A: kotlin/Any?> io.github.kormium/CoalesceOp : io.github.kormium/Operand<#A> { // io.github.kormium/CoalesceOp|null[0]
+    final val columnType // io.github.kormium/CoalesceOp.columnType|{}columnType[0]
+        final fun <get-columnType>(): io.github.kormium/ColumnType<#A> // io.github.kormium/CoalesceOp.columnType.<get-columnType>|<get-columnType>(){}[0]
+
+    final fun resultKey(): kotlin/Any // io.github.kormium/CoalesceOp.resultKey|resultKey(){}[0]
+    final fun toSql(io.github.kormium/ParamBuilder): kotlin/String // io.github.kormium/CoalesceOp.toSql|toSql(io.github.kormium.ParamBuilder){}[0]
+}
+
+final class io.github.kormium/CheckViolationException : io.github.kormium/QueryException { // io.github.kormium/CheckViolationException|null[0]
+    constructor <init>(kotlin/String, kotlin/String?, kotlin/Throwable? = ...) // io.github.kormium/CheckViolationException.<init>|<init>(kotlin.String;kotlin.String?;kotlin.Throwable?){}[0]
+}
+
+final class io.github.kormium/ConcurrencyConflictException : io.github.kormium/QueryException { // io.github.kormium/ConcurrencyConflictException|null[0]
+    constructor <init>(kotlin/String, kotlin/String?, kotlin/Throwable? = ...) // io.github.kormium/ConcurrencyConflictException.<init>|<init>(kotlin.String;kotlin.String?;kotlin.Throwable?){}[0]
+}
+
+final class io.github.kormium/DatabaseClosedException : io.github.kormium/KormiumException { // io.github.kormium/DatabaseClosedException|null[0]
+    constructor <init>(kotlin/String = ...) // io.github.kormium/DatabaseClosedException.<init>|<init>(kotlin.String){}[0]
+}
+
+final class io.github.kormium/DatabaseLifecycle { // io.github.kormium/DatabaseLifecycle|null[0]
+    constructor <init>(kotlin/Function0<kotlin/Unit>) // io.github.kormium/DatabaseLifecycle.<init>|<init>(kotlin.Function0<kotlin.Unit>){}[0]
+
+    final val isClosed // io.github.kormium/DatabaseLifecycle.isClosed|{}isClosed[0]
+        final fun <get-isClosed>(): kotlin/Boolean // io.github.kormium/DatabaseLifecycle.isClosed.<get-isClosed>|<get-isClosed>(){}[0]
+
+    final fun checkOpen() // io.github.kormium/DatabaseLifecycle.checkOpen|checkOpen(){}[0]
+    final fun close() // io.github.kormium/DatabaseLifecycle.close|close(){}[0]
+}
+
+final class io.github.kormium/ExistsOp : io.github.kormium/Expression { // io.github.kormium/ExistsOp|null[0]
+    final fun toSql(io.github.kormium/ParamBuilder): kotlin/String // io.github.kormium/ExistsOp.toSql|toSql(io.github.kormium.ParamBuilder){}[0]
+}
+
+final class io.github.kormium/ForeignKeyViolationException : io.github.kormium/QueryException { // io.github.kormium/ForeignKeyViolationException|null[0]
+    constructor <init>(kotlin/String, kotlin/String?, kotlin/Throwable? = ...) // io.github.kormium/ForeignKeyViolationException.<init>|<init>(kotlin.String;kotlin.String?;kotlin.Throwable?){}[0]
+}
+
+final class io.github.kormium/KormiumBuilder { // io.github.kormium/KormiumBuilder|null[0]
+    constructor <init>() // io.github.kormium/KormiumBuilder.<init>|<init>(){}[0]
+
+    final fun <#A1: io.github.kormium.database/Database<kotlin/Nothing>> finish(kotlin/Function1<io.github.kormium/KormiumConfig, #A1>): #A1 // io.github.kormium/KormiumBuilder.finish|finish(kotlin.Function1<io.github.kormium.KormiumConfig,0:0>){0§<io.github.kormium.database.Database<kotlin.Nothing>>}[0]
+    final fun beforeStart(kotlin/Function1<io.github.kormium.database/Database<kotlin/Nothing>, kotlin/Unit>) // io.github.kormium/KormiumBuilder.beforeStart|beforeStart(kotlin.Function1<io.github.kormium.database.Database<kotlin.Nothing>,kotlin.Unit>){}[0]
+    final fun config(kotlin/Function1<io.github.kormium/KormiumConfigBuilder, kotlin/Unit>) // io.github.kormium/KormiumBuilder.config|config(kotlin.Function1<io.github.kormium.KormiumConfigBuilder,kotlin.Unit>){}[0]
+}
+
+final class io.github.kormium/KormiumConfig { // io.github.kormium/KormiumConfig|null[0]
+    constructor <init>(io.github.kormium/BatchInsertMode = ..., io.github.kormium/QueryObserver? = ...) // io.github.kormium/KormiumConfig.<init>|<init>(io.github.kormium.BatchInsertMode;io.github.kormium.QueryObserver?){}[0]
+
+    final val batchInsertMode // io.github.kormium/KormiumConfig.batchInsertMode|{}batchInsertMode[0]
+        final fun <get-batchInsertMode>(): io.github.kormium/BatchInsertMode // io.github.kormium/KormiumConfig.batchInsertMode.<get-batchInsertMode>|<get-batchInsertMode>(){}[0]
+    final val queryObserver // io.github.kormium/KormiumConfig.queryObserver|{}queryObserver[0]
+        final fun <get-queryObserver>(): io.github.kormium/QueryObserver? // io.github.kormium/KormiumConfig.queryObserver.<get-queryObserver>|<get-queryObserver>(){}[0]
+
+    final fun component1(): io.github.kormium/BatchInsertMode // io.github.kormium/KormiumConfig.component1|component1(){}[0]
+    final fun component2(): io.github.kormium/QueryObserver? // io.github.kormium/KormiumConfig.component2|component2(){}[0]
+    final fun copy(io.github.kormium/BatchInsertMode = ..., io.github.kormium/QueryObserver? = ...): io.github.kormium/KormiumConfig // io.github.kormium/KormiumConfig.copy|copy(io.github.kormium.BatchInsertMode;io.github.kormium.QueryObserver?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // io.github.kormium/KormiumConfig.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // io.github.kormium/KormiumConfig.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // io.github.kormium/KormiumConfig.toString|toString(){}[0]
+}
+
+final class io.github.kormium/KormiumConfigBuilder { // io.github.kormium/KormiumConfigBuilder|null[0]
+    final var batchInsertMode // io.github.kormium/KormiumConfigBuilder.batchInsertMode|{}batchInsertMode[0]
+        final fun <get-batchInsertMode>(): io.github.kormium/BatchInsertMode // io.github.kormium/KormiumConfigBuilder.batchInsertMode.<get-batchInsertMode>|<get-batchInsertMode>(){}[0]
+        final fun <set-batchInsertMode>(io.github.kormium/BatchInsertMode) // io.github.kormium/KormiumConfigBuilder.batchInsertMode.<set-batchInsertMode>|<set-batchInsertMode>(io.github.kormium.BatchInsertMode){}[0]
+}
+
+final class io.github.kormium/NotNullViolationException : io.github.kormium/QueryException { // io.github.kormium/NotNullViolationException|null[0]
+    constructor <init>(kotlin/String, kotlin/String?, kotlin/Throwable? = ...) // io.github.kormium/NotNullViolationException.<init>|<init>(kotlin.String;kotlin.String?;kotlin.Throwable?){}[0]
+}
+
+final class io.github.kormium/OrderByDsl { // io.github.kormium/OrderByDsl|null[0]
+    final fun ASC(io.github.kormium/Selectable<*>) // io.github.kormium/OrderByDsl.ASC|ASC(io.github.kormium.Selectable<*>){}[0]
+    final fun DESC(io.github.kormium/Selectable<*>) // io.github.kormium/OrderByDsl.DESC|DESC(io.github.kormium.Selectable<*>){}[0]
+}
+
+final class io.github.kormium/ParamBuilder { // io.github.kormium/ParamBuilder|null[0]
+    constructor <init>(io.github.kormium/Dialect, io.github.kormium/TypeMapper, kotlin/Boolean = ...) // io.github.kormium/ParamBuilder.<init>|<init>(io.github.kormium.Dialect;io.github.kormium.TypeMapper;kotlin.Boolean){}[0]
+
+    final val dialect // io.github.kormium/ParamBuilder.dialect|{}dialect[0]
+        final fun <get-dialect>(): io.github.kormium/Dialect // io.github.kormium/ParamBuilder.dialect.<get-dialect>|<get-dialect>(){}[0]
+    final val params // io.github.kormium/ParamBuilder.params|{}params[0]
+        final fun <get-params>(): kotlin.collections/Map<kotlin/String, kotlin/Any?> // io.github.kormium/ParamBuilder.params.<get-params>|<get-params>(){}[0]
+
+    final var qualifyColumns // io.github.kormium/ParamBuilder.qualifyColumns|{}qualifyColumns[0]
+        final fun <get-qualifyColumns>(): kotlin/Boolean // io.github.kormium/ParamBuilder.qualifyColumns.<get-qualifyColumns>|<get-qualifyColumns>(){}[0]
+
+    final fun bind(kotlin/Any?): kotlin/String // io.github.kormium/ParamBuilder.bind|bind(kotlin.Any?){}[0]
+
+    final object Companion // io.github.kormium/ParamBuilder.Companion|null[0]
+}
+
+final class io.github.kormium/Query { // io.github.kormium/Query|null[0]
+    constructor <init>(io.github.kormium/Expression? = ..., kotlin/UInt = ..., kotlin/UInt = ..., kotlin.collections/Map<io.github.kormium/Selectable<*>, io.github.kormium/AscDescOrder>? = ...) // io.github.kormium/Query.<init>|<init>(io.github.kormium.Expression?;kotlin.UInt;kotlin.UInt;kotlin.collections.Map<io.github.kormium.Selectable<*>,io.github.kormium.AscDescOrder>?){}[0]
+
+    final val limit // io.github.kormium/Query.limit|{}limit[0]
+        final fun <get-limit>(): kotlin/UInt // io.github.kormium/Query.limit.<get-limit>|<get-limit>(){}[0]
+    final val offset // io.github.kormium/Query.offset|{}offset[0]
+        final fun <get-offset>(): kotlin/UInt // io.github.kormium/Query.offset.<get-offset>|<get-offset>(){}[0]
+    final val orderBy // io.github.kormium/Query.orderBy|{}orderBy[0]
+        final fun <get-orderBy>(): kotlin.collections/Map<io.github.kormium/Selectable<*>, io.github.kormium/AscDescOrder>? // io.github.kormium/Query.orderBy.<get-orderBy>|<get-orderBy>(){}[0]
+    final val whereExpression // io.github.kormium/Query.whereExpression|{}whereExpression[0]
+        final fun <get-whereExpression>(): io.github.kormium/Expression? // io.github.kormium/Query.whereExpression.<get-whereExpression>|<get-whereExpression>(){}[0]
+
+    final fun component1(): io.github.kormium/Expression? // io.github.kormium/Query.component1|component1(){}[0]
+    final fun component2(): kotlin/UInt // io.github.kormium/Query.component2|component2(){}[0]
+    final fun component3(): kotlin/UInt // io.github.kormium/Query.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/Map<io.github.kormium/Selectable<*>, io.github.kormium/AscDescOrder>? // io.github.kormium/Query.component4|component4(){}[0]
+    final fun copy(io.github.kormium/Expression? = ..., kotlin/UInt = ..., kotlin/UInt = ..., kotlin.collections/Map<io.github.kormium/Selectable<*>, io.github.kormium/AscDescOrder>? = ...): io.github.kormium/Query // io.github.kormium/Query.copy|copy(io.github.kormium.Expression?;kotlin.UInt;kotlin.UInt;kotlin.collections.Map<io.github.kormium.Selectable<*>,io.github.kormium.AscDescOrder>?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // io.github.kormium/Query.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // io.github.kormium/Query.hashCode|hashCode(){}[0]
+    final fun toSql(io.github.kormium/ParamBuilder): kotlin/String // io.github.kormium/Query.toSql|toSql(io.github.kormium.ParamBuilder){}[0]
+    final fun toString(): kotlin/String // io.github.kormium/Query.toString|toString(){}[0]
+    final fun toWhereSql(io.github.kormium/ParamBuilder): kotlin/String // io.github.kormium/Query.toWhereSql|toWhereSql(io.github.kormium.ParamBuilder){}[0]
+}
+
+final class io.github.kormium/QueryBuilder { // io.github.kormium/QueryBuilder|null[0]
+    constructor <init>() // io.github.kormium/QueryBuilder.<init>|<init>(){}[0]
+
+    final val orderBy // io.github.kormium/QueryBuilder.orderBy|{}orderBy[0]
+        final fun <get-orderBy>(): io.github.kormium/OrderByDsl // io.github.kormium/QueryBuilder.orderBy.<get-orderBy>|<get-orderBy>(){}[0]
+
+    final var limit // io.github.kormium/QueryBuilder.limit|{}limit[0]
+        final fun <get-limit>(): kotlin/Int? // io.github.kormium/QueryBuilder.limit.<get-limit>|<get-limit>(){}[0]
+        final fun <set-limit>(kotlin/Int?) // io.github.kormium/QueryBuilder.limit.<set-limit>|<set-limit>(kotlin.Int?){}[0]
+    final var offset // io.github.kormium/QueryBuilder.offset|{}offset[0]
+        final fun <get-offset>(): kotlin/Int? // io.github.kormium/QueryBuilder.offset.<get-offset>|<get-offset>(){}[0]
+        final fun <set-offset>(kotlin/Int?) // io.github.kormium/QueryBuilder.offset.<set-offset>|<set-offset>(kotlin.Int?){}[0]
+
+    final fun where(kotlin/Function0<io.github.kormium/Expression>) // io.github.kormium/QueryBuilder.where|where(kotlin.Function0<io.github.kormium.Expression>){}[0]
+}
+
+final class io.github.kormium/QueryEvent { // io.github.kormium/QueryEvent|null[0]
+    constructor <init>(kotlin/String, kotlin/String, io.github.kormium/QueryKind, kotlin/Long, kotlin/Long?, kotlin/Throwable?, kotlin/String?) // io.github.kormium/QueryEvent.<init>|<init>(kotlin.String;kotlin.String;io.github.kormium.QueryKind;kotlin.Long;kotlin.Long?;kotlin.Throwable?;kotlin.String?){}[0]
+
+    final val backend // io.github.kormium/QueryEvent.backend|{}backend[0]
+        final fun <get-backend>(): kotlin/String // io.github.kormium/QueryEvent.backend.<get-backend>|<get-backend>(){}[0]
+    final val durationNanos // io.github.kormium/QueryEvent.durationNanos|{}durationNanos[0]
+        final fun <get-durationNanos>(): kotlin/Long // io.github.kormium/QueryEvent.durationNanos.<get-durationNanos>|<get-durationNanos>(){}[0]
+    final val error // io.github.kormium/QueryEvent.error|{}error[0]
+        final fun <get-error>(): kotlin/Throwable? // io.github.kormium/QueryEvent.error.<get-error>|<get-error>(){}[0]
+    final val kind // io.github.kormium/QueryEvent.kind|{}kind[0]
+        final fun <get-kind>(): io.github.kormium/QueryKind // io.github.kormium/QueryEvent.kind.<get-kind>|<get-kind>(){}[0]
+    final val rowCount // io.github.kormium/QueryEvent.rowCount|{}rowCount[0]
+        final fun <get-rowCount>(): kotlin/Long? // io.github.kormium/QueryEvent.rowCount.<get-rowCount>|<get-rowCount>(){}[0]
+    final val sql // io.github.kormium/QueryEvent.sql|{}sql[0]
+        final fun <get-sql>(): kotlin/String // io.github.kormium/QueryEvent.sql.<get-sql>|<get-sql>(){}[0]
+    final val sqlState // io.github.kormium/QueryEvent.sqlState|{}sqlState[0]
+        final fun <get-sqlState>(): kotlin/String? // io.github.kormium/QueryEvent.sqlState.<get-sqlState>|<get-sqlState>(){}[0]
+    final val succeeded // io.github.kormium/QueryEvent.succeeded|{}succeeded[0]
+        final fun <get-succeeded>(): kotlin/Boolean // io.github.kormium/QueryEvent.succeeded.<get-succeeded>|<get-succeeded>(){}[0]
+}
+
+final class io.github.kormium/RawExpression : io.github.kormium/Expression { // io.github.kormium/RawExpression|null[0]
+    constructor <init>(kotlin/String) // io.github.kormium/RawExpression.<init>|<init>(kotlin.String){}[0]
+
+    final val expression // io.github.kormium/RawExpression.expression|{}expression[0]
+        final fun <get-expression>(): kotlin/String // io.github.kormium/RawExpression.expression.<get-expression>|<get-expression>(){}[0]
+
+    final fun toSql(io.github.kormium/ParamBuilder): kotlin/String // io.github.kormium/RawExpression.toSql|toSql(io.github.kormium.ParamBuilder){}[0]
+}
+
+final class io.github.kormium/ReadOnlyToggle { // io.github.kormium/ReadOnlyToggle|null[0]
+    constructor <init>(kotlin/String, kotlin/String) // io.github.kormium/ReadOnlyToggle.<init>|<init>(kotlin.String;kotlin.String){}[0]
+
+    final val enter // io.github.kormium/ReadOnlyToggle.enter|{}enter[0]
+        final fun <get-enter>(): kotlin/String // io.github.kormium/ReadOnlyToggle.enter.<get-enter>|<get-enter>(){}[0]
+    final val exit // io.github.kormium/ReadOnlyToggle.exit|{}exit[0]
+        final fun <get-exit>(): kotlin/String // io.github.kormium/ReadOnlyToggle.exit.<get-exit>|<get-exit>(){}[0]
+
+    final fun component1(): kotlin/String // io.github.kormium/ReadOnlyToggle.component1|component1(){}[0]
+    final fun component2(): kotlin/String // io.github.kormium/ReadOnlyToggle.component2|component2(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ...): io.github.kormium/ReadOnlyToggle // io.github.kormium/ReadOnlyToggle.copy|copy(kotlin.String;kotlin.String){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // io.github.kormium/ReadOnlyToggle.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // io.github.kormium/ReadOnlyToggle.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // io.github.kormium/ReadOnlyToggle.toString|toString(){}[0]
+}
+
+final class io.github.kormium/RenderedSql { // io.github.kormium/RenderedSql|null[0]
+    constructor <init>(kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/Any?>) // io.github.kormium/RenderedSql.<init>|<init>(kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.Any?>){}[0]
+
+    final val params // io.github.kormium/RenderedSql.params|{}params[0]
+        final fun <get-params>(): kotlin.collections/Map<kotlin/String, kotlin/Any?> // io.github.kormium/RenderedSql.params.<get-params>|<get-params>(){}[0]
+    final val sql // io.github.kormium/RenderedSql.sql|{}sql[0]
+        final fun <get-sql>(): kotlin/String // io.github.kormium/RenderedSql.sql.<get-sql>|<get-sql>(){}[0]
+
+    final fun toString(): kotlin/String // io.github.kormium/RenderedSql.toString|toString(){}[0]
+}
+
+final class io.github.kormium/ResultMappingException : io.github.kormium/KormiumException { // io.github.kormium/ResultMappingException|null[0]
+    constructor <init>(kotlin/String, kotlin/Throwable? = ...) // io.github.kormium/ResultMappingException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
+}
+
+final class io.github.kormium/ResultRow { // io.github.kormium/ResultRow|null[0]
+    final fun <#A1: kotlin/Any?> get(io.github.kormium/Selectable<#A1>): #A1 // io.github.kormium/ResultRow.get|get(io.github.kormium.Selectable<0:0>){0§<kotlin.Any?>}[0]
+    final fun <#A1: kotlin/Any?> getOrNull(io.github.kormium/Selectable<#A1>): #A1? // io.github.kormium/ResultRow.getOrNull|getOrNull(io.github.kormium.Selectable<0:0>){0§<kotlin.Any?>}[0]
+}
+
+final class io.github.kormium/UniqueViolationException : io.github.kormium/QueryException { // io.github.kormium/UniqueViolationException|null[0]
+    constructor <init>(kotlin/String, kotlin/String?, kotlin/Throwable? = ...) // io.github.kormium/UniqueViolationException.<init>|<init>(kotlin.String;kotlin.String?;kotlin.Throwable?){}[0]
+}
+
+final class io.github.kormium/UpdateBuilder { // io.github.kormium/UpdateBuilder|null[0]
+    constructor <init>() // io.github.kormium/UpdateBuilder.<init>|<init>(){}[0]
+
+    final fun <#A1: kotlin/Any?> (io.github.kormium/Column<#A1, *, *>).set(#A1) // io.github.kormium/UpdateBuilder.set|set@io.github.kormium.Column<0:0,*,*>(0:0){0§<kotlin.Any?>}[0]
+    final fun <#A1: kotlin/Any?> (io.github.kormium/Column<#A1, *, *>).set(io.github.kormium/Expression) // io.github.kormium/UpdateBuilder.set|set@io.github.kormium.Column<0:0,*,*>(io.github.kormium.Expression){0§<kotlin.Any?>}[0]
+    final fun where(kotlin/Function0<io.github.kormium/Expression>) // io.github.kormium/UpdateBuilder.where|where(kotlin.Function0<io.github.kormium.Expression>){}[0]
+}
+
+final class io.github.kormium/Value : io.github.kormium/Expression { // io.github.kormium/Value|null[0]
+    constructor <init>(kotlin/Any?) // io.github.kormium/Value.<init>|<init>(kotlin.Any?){}[0]
+
+    final fun toSql(io.github.kormium/ParamBuilder): kotlin/String // io.github.kormium/Value.toSql|toSql(io.github.kormium.ParamBuilder){}[0]
+}
+
+open class io.github.kormium/KormiumException : kotlin/Exception { // io.github.kormium/KormiumException|null[0]
+    constructor <init>(kotlin/String, kotlin/Throwable? = ...) // io.github.kormium/KormiumException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
+}
+
+open class io.github.kormium/QueryException : io.github.kormium/KormiumException { // io.github.kormium/QueryException|null[0]
+    constructor <init>(kotlin/String, kotlin/String? = ..., kotlin/Throwable? = ...) // io.github.kormium/QueryException.<init>|<init>(kotlin.String;kotlin.String?;kotlin.Throwable?){}[0]
+
+    final val sqlState // io.github.kormium/QueryException.sqlState|{}sqlState[0]
+        final fun <get-sqlState>(): kotlin/String? // io.github.kormium/QueryException.sqlState.<get-sqlState>|<get-sqlState>(){}[0]
+}
+
+open class io.github.kormium/WriteListeners { // io.github.kormium/WriteListeners|null[0]
+    constructor <init>() // io.github.kormium/WriteListeners.<init>|<init>(){}[0]
+
+    final val isActive // io.github.kormium/WriteListeners.isActive|{}isActive[0]
+        final fun <get-isActive>(): kotlin/Boolean // io.github.kormium/WriteListeners.isActive.<get-isActive>|<get-isActive>(){}[0]
+
+    final fun fire(kotlin.collections/Set<kotlin/String>) // io.github.kormium/WriteListeners.fire|fire(kotlin.collections.Set<kotlin.String>){}[0]
+    final fun publishCommit(kotlin.collections/Set<kotlin/String>) // io.github.kormium/WriteListeners.publishCommit|publishCommit(kotlin.collections.Set<kotlin.String>){}[0]
+    open fun add(io.github.kormium/WriteListener): io.github.kormium/Registration // io.github.kormium/WriteListeners.add|add(io.github.kormium.WriteListener){}[0]
+    open fun setCommitPublish(kotlin/Function1<kotlin.collections/Set<kotlin/String>, kotlin/Unit>?) // io.github.kormium/WriteListeners.setCommitPublish|setCommitPublish(kotlin.Function1<kotlin.collections.Set<kotlin.String>,kotlin.Unit>?){}[0]
+
+    final object Disabled : io.github.kormium/WriteListeners { // io.github.kormium/WriteListeners.Disabled|null[0]
+        final fun add(io.github.kormium/WriteListener): io.github.kormium/Registration // io.github.kormium/WriteListeners.Disabled.add|add(io.github.kormium.WriteListener){}[0]
+        final fun setCommitPublish(kotlin/Function1<kotlin.collections/Set<kotlin/String>, kotlin/Unit>?) // io.github.kormium/WriteListeners.Disabled.setCommitPublish|setCommitPublish(kotlin.Function1<kotlin.collections.Set<kotlin.String>,kotlin.Unit>?){}[0]
+    }
+}
+
+sealed class <#A: kotlin/Any?, #B: io.github.kormium/Table<*, #C>, #C: io.github.kormium/Entity> io.github.kormium/Column : io.github.kormium/Expression, io.github.kormium/Operand<#A> { // io.github.kormium/Column|null[0]
+    final val fieldKey // io.github.kormium/Column.fieldKey|{}fieldKey[0]
+        final fun <get-fieldKey>(): kotlin/String // io.github.kormium/Column.fieldKey.<get-fieldKey>|<get-fieldKey>(){}[0]
+    final val name // io.github.kormium/Column.name|{}name[0]
+        final fun <get-name>(): kotlin/String // io.github.kormium/Column.name.<get-name>|<get-name>(){}[0]
+    final val nullable // io.github.kormium/Column.nullable|{}nullable[0]
+        final fun <get-nullable>(): kotlin/Boolean // io.github.kormium/Column.nullable.<get-nullable>|<get-nullable>(){}[0]
+    open val columnType // io.github.kormium/Column.columnType|{}columnType[0]
+        open fun <get-columnType>(): io.github.kormium/ColumnType<#A> // io.github.kormium/Column.columnType.<get-columnType>|<get-columnType>(){}[0]
+
+    open fun init() // io.github.kormium/Column.init|init(){}[0]
+    open fun resultKey(): kotlin/Any // io.github.kormium/Column.resultKey|resultKey(){}[0]
+    open fun toSql(io.github.kormium/ParamBuilder): kotlin/String // io.github.kormium/Column.toSql|toSql(io.github.kormium.ParamBuilder){}[0]
+    open fun toString(): kotlin/String // io.github.kormium/Column.toString|toString(){}[0]
+
+    final class <#A1: kotlin/Any?, #B1: io.github.kormium/Table<*, #C1>, #C1: io.github.kormium/Entity> NotNullColumn : io.github.kormium/Column<#A1, #B1, #C1> { // io.github.kormium/Column.NotNullColumn|null[0]
+        constructor <init>(#B1, kotlin/String, kotlin/String, io.github.kormium/ColumnType<#A1>) // io.github.kormium/Column.NotNullColumn.<init>|<init>(1:1;kotlin.String;kotlin.String;io.github.kormium.ColumnType<1:0>){}[0]
+
+        final fun getValue(#C1, kotlin.reflect/KProperty<*>): #A1 // io.github.kormium/Column.NotNullColumn.getValue|getValue(1:2;kotlin.reflect.KProperty<*>){}[0]
+        final fun setValue(#C1, kotlin.reflect/KProperty<*>, #A1) // io.github.kormium/Column.NotNullColumn.setValue|setValue(1:2;kotlin.reflect.KProperty<*>;1:0){}[0]
+    }
+
+    final class <#A1: kotlin/Any?, #B1: io.github.kormium/Table<*, #C1>, #C1: io.github.kormium/Entity> NullableColumn : io.github.kormium/Column<#A1, #B1, #C1> { // io.github.kormium/Column.NullableColumn|null[0]
+        constructor <init>(#B1, kotlin/String, kotlin/String, io.github.kormium/ColumnType<#A1>) // io.github.kormium/Column.NullableColumn.<init>|<init>(1:1;kotlin.String;kotlin.String;io.github.kormium.ColumnType<1:0>){}[0]
+
+        final fun getValue(#C1, kotlin.reflect/KProperty<*>): #A1? // io.github.kormium/Column.NullableColumn.getValue|getValue(1:2;kotlin.reflect.KProperty<*>){}[0]
+        final fun setValue(#C1, kotlin.reflect/KProperty<*>, #A1?) // io.github.kormium/Column.NullableColumn.setValue|setValue(1:2;kotlin.reflect.KProperty<*>;1:0?){}[0]
+    }
+
+    final class <#A1: kotlin/Any?> NullableSpec { // io.github.kormium/Column.NullableSpec|null[0]
+        final fun <#A2: io.github.kormium/Table<*, #B2>, #B2: io.github.kormium/Entity> provideDelegate(#A2, kotlin.reflect/KProperty<*>): kotlin.properties/ReadOnlyProperty<#A2, io.github.kormium/Column.NullableColumn<#A1, #A2, #B2>> // io.github.kormium/Column.NullableSpec.provideDelegate|provideDelegate(0:0;kotlin.reflect.KProperty<*>){0§<io.github.kormium.Table<*,0:1>>;1§<io.github.kormium.Entity>}[0]
+    }
+
+    final class <#A1: kotlin/Any?> PrimaryKeySpec { // io.github.kormium/Column.PrimaryKeySpec|null[0]
+        final fun <#A2: io.github.kormium/Table<*, #B2>, #B2: io.github.kormium/Entity> provideDelegate(#A2, kotlin.reflect/KProperty<*>): kotlin.properties/ReadOnlyProperty<#A2, io.github.kormium/Column.NotNullColumn<#A1, #A2, #B2>> // io.github.kormium/Column.PrimaryKeySpec.provideDelegate|provideDelegate(0:0;kotlin.reflect.KProperty<*>){0§<io.github.kormium.Table<*,0:1>>;1§<io.github.kormium.Entity>}[0]
+    }
+
+    final class Boolean : io.github.kormium/Column.Spec<kotlin/Boolean> { // io.github.kormium/Column.Boolean|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.Boolean.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    final class Bytes : io.github.kormium/Column.Spec<kotlin/ByteArray> { // io.github.kormium/Column.Bytes|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.Bytes.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    final class Double : io.github.kormium/Column.Spec<kotlin/Double> { // io.github.kormium/Column.Double|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.Double.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    final class Float : io.github.kormium/Column.Spec<kotlin/Float> { // io.github.kormium/Column.Float|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.Float.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    final class Instant : io.github.kormium/Column.Spec<kotlin.time/Instant> { // io.github.kormium/Column.Instant|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.Instant.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    final class Int : io.github.kormium/Column.Spec<kotlin/Int> { // io.github.kormium/Column.Int|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.Int.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    final class Json : io.github.kormium/Column.Spec<kotlinx.serialization.json/JsonElement> { // io.github.kormium/Column.Json|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.Json.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    final class LocalDate : io.github.kormium/Column.Spec<kotlinx.datetime/LocalDate> { // io.github.kormium/Column.LocalDate|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.LocalDate.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    final class LocalDateTime : io.github.kormium/Column.Spec<kotlinx.datetime/LocalDateTime> { // io.github.kormium/Column.LocalDateTime|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.LocalDateTime.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    final class LocalTime : io.github.kormium/Column.Spec<kotlinx.datetime/LocalTime> { // io.github.kormium/Column.LocalTime|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.LocalTime.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    final class Long : io.github.kormium/Column.Spec<kotlin/Long> { // io.github.kormium/Column.Long|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.Long.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    final class Short : io.github.kormium/Column.Spec<kotlin/Short> { // io.github.kormium/Column.Short|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.Short.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    final class Text : io.github.kormium/Column.Spec<kotlin/String> { // io.github.kormium/Column.Text|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.Text.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    final class UUID : io.github.kormium/Column.Spec<kotlin.uuid/Uuid> { // io.github.kormium/Column.UUID|null[0]
+        constructor <init>(kotlin/String? = ...) // io.github.kormium/Column.UUID.<init>|<init>(kotlin.String?){}[0]
+    }
+
+    open class <#A1: kotlin/Any?> Spec { // io.github.kormium/Column.Spec|null[0]
+        constructor <init>(kotlin/String?, io.github.kormium/ColumnType<#A1>) // io.github.kormium/Column.Spec.<init>|<init>(kotlin.String?;io.github.kormium.ColumnType<1:0>){}[0]
+
+        final fun <#A2: io.github.kormium/Table<*, #B2>, #B2: io.github.kormium/Entity> provideDelegate(#A2, kotlin.reflect/KProperty<*>): kotlin.properties/ReadOnlyProperty<#A2, io.github.kormium/Column.NotNullColumn<#A1, #A2, #B2>> // io.github.kormium/Column.Spec.provideDelegate|provideDelegate(0:0;kotlin.reflect.KProperty<*>){0§<io.github.kormium.Table<*,0:1>>;1§<io.github.kormium.Entity>}[0]
+        final fun nullable(): io.github.kormium/Column.NullableSpec<#A1> // io.github.kormium/Column.Spec.nullable|nullable(){}[0]
+        final fun primaryKey(): io.github.kormium/Column.PrimaryKeySpec<#A1> // io.github.kormium/Column.Spec.primaryKey|primaryKey(){}[0]
+    }
+
+    final object Companion { // io.github.kormium/Column.Companion|null[0]
+        final fun <#A2: kotlin/Any?> of(io.github.kormium/ColumnType<#A2>, kotlin/String? = ...): io.github.kormium/Column.Spec<#A2> // io.github.kormium/Column.Companion.of|of(io.github.kormium.ColumnType<0:0>;kotlin.String?){0§<kotlin.Any?>}[0]
+        final inline fun <#A2: reified kotlin/Any?> json(kotlin/String? = ...): io.github.kormium/Column.Spec<#A2> // io.github.kormium/Column.Companion.json|json(kotlin.String?){0§<kotlin.Any?>}[0]
+        final inline fun <#A2: reified kotlin/Enum<#A2>> enum(kotlin/String? = ...): io.github.kormium/Column.Spec<#A2> // io.github.kormium/Column.Companion.enum|enum(kotlin.String?){0§<kotlin.Enum<0:0>>}[0]
+    }
+}
+
+final object io.github.kormium/BooleanColumnType : io.github.kormium/ColumnType<kotlin/Boolean> { // io.github.kormium/BooleanColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlin/Boolean? // io.github.kormium/BooleanColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final object io.github.kormium/BytesColumnType : io.github.kormium/ColumnType<kotlin/ByteArray> { // io.github.kormium/BytesColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlin/ByteArray? // io.github.kormium/BytesColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final object io.github.kormium/DoubleColumnType : io.github.kormium/ColumnType<kotlin/Double> { // io.github.kormium/DoubleColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlin/Double? // io.github.kormium/DoubleColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final object io.github.kormium/FloatColumnType : io.github.kormium/ColumnType<kotlin/Float> { // io.github.kormium/FloatColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlin/Float? // io.github.kormium/FloatColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final object io.github.kormium/InstantColumnType : io.github.kormium/ColumnType<kotlin.time/Instant> { // io.github.kormium/InstantColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlin.time/Instant? // io.github.kormium/InstantColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final object io.github.kormium/IntColumnType : io.github.kormium/ColumnType<kotlin/Int> { // io.github.kormium/IntColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlin/Int? // io.github.kormium/IntColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final object io.github.kormium/JsonColumnType : io.github.kormium/ColumnType<kotlinx.serialization.json/JsonElement> { // io.github.kormium/JsonColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlinx.serialization.json/JsonElement? // io.github.kormium/JsonColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final object io.github.kormium/LocalDateColumnType : io.github.kormium/ColumnType<kotlinx.datetime/LocalDate> { // io.github.kormium/LocalDateColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlinx.datetime/LocalDate? // io.github.kormium/LocalDateColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final object io.github.kormium/LocalDateTimeColumnType : io.github.kormium/ColumnType<kotlinx.datetime/LocalDateTime> { // io.github.kormium/LocalDateTimeColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlinx.datetime/LocalDateTime? // io.github.kormium/LocalDateTimeColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final object io.github.kormium/LocalTimeColumnType : io.github.kormium/ColumnType<kotlinx.datetime/LocalTime> { // io.github.kormium/LocalTimeColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlinx.datetime/LocalTime? // io.github.kormium/LocalTimeColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final object io.github.kormium/LongColumnType : io.github.kormium/ColumnType<kotlin/Long> { // io.github.kormium/LongColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlin/Long? // io.github.kormium/LongColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final object io.github.kormium/ShortColumnType : io.github.kormium/ColumnType<kotlin/Short> { // io.github.kormium/ShortColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlin/Short? // io.github.kormium/ShortColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final object io.github.kormium/StandardDialect : io.github.kormium/Dialect { // io.github.kormium/StandardDialect|null[0]
+    final fun quoteIdentifier(kotlin/String): kotlin/String // io.github.kormium/StandardDialect.quoteIdentifier|quoteIdentifier(kotlin.String){}[0]
+    final fun renderBind(kotlin/String, kotlin/Any?): kotlin/String // io.github.kormium/StandardDialect.renderBind|renderBind(kotlin.String;kotlin.Any?){}[0]
+    final fun renderLimit(kotlin/UInt): kotlin/String // io.github.kormium/StandardDialect.renderLimit|renderLimit(kotlin.UInt){}[0]
+    final fun renderOffset(kotlin/UInt): kotlin/String // io.github.kormium/StandardDialect.renderOffset|renderOffset(kotlin.UInt){}[0]
+}
+
+final object io.github.kormium/StandardTypeMapper : io.github.kormium/TypeMapper { // io.github.kormium/StandardTypeMapper|null[0]
+    final fun toParameter(kotlin/Any?): kotlin/Any? // io.github.kormium/StandardTypeMapper.toParameter|toParameter(kotlin.Any?){}[0]
+}
+
+final object io.github.kormium/TextColumnType : io.github.kormium/ColumnType<kotlin/String> { // io.github.kormium/TextColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlin/String? // io.github.kormium/TextColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final object io.github.kormium/UuidColumnType : io.github.kormium/ColumnType<kotlin.uuid/Uuid> { // io.github.kormium/UuidColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): kotlin.uuid/Uuid? // io.github.kormium/UuidColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+}
+
+final fun (io.github.kormium.resultset/ResultSet).io.github.kormium.sql/getJson(kotlin/Int): kotlinx.serialization.json/JsonElement? // io.github.kormium.sql/getJson|getJson@io.github.kormium.resultset.ResultSet(kotlin.Int){}[0]
+final fun (io.github.kormium.resultset/ResultSet).io.github.kormium.sql/getUUID(kotlin/Int): kotlin.uuid/Uuid? // io.github.kormium.sql/getUUID|getUUID@io.github.kormium.resultset.ResultSet(kotlin.Int){}[0]
+final fun (io.github.kormium/Column.NullableColumn<*, *, *>).io.github.kormium/eq(kotlin/Nothing?): io.github.kormium/Expression // io.github.kormium/eq|eq@io.github.kormium.Column.NullableColumn<*,*,*>(kotlin.Nothing?){}[0]
+final fun (io.github.kormium/Column.NullableColumn<*, *, *>).io.github.kormium/neq(kotlin/Nothing?): io.github.kormium/Expression // io.github.kormium/neq|neq@io.github.kormium.Column.NullableColumn<*,*,*>(kotlin.Nothing?){}[0]
+final fun (io.github.kormium/Column<*, *, *>).io.github.kormium/avg(): io.github.kormium/Operand<kotlin/Double> // io.github.kormium/avg|avg@io.github.kormium.Column<*,*,*>(){}[0]
+final fun (io.github.kormium/Column<*, *, *>).io.github.kormium/count(): io.github.kormium/Operand<kotlin/Long> // io.github.kormium/count|count@io.github.kormium.Column<*,*,*>(){}[0]
+final fun (io.github.kormium/Column<kotlin/Int, *, *>).io.github.kormium/sum(): io.github.kormium/Operand<kotlin/Long> // io.github.kormium/sum|sum@io.github.kormium.Column<kotlin.Int,*,*>(){}[0]
+final fun (io.github.kormium/Column<kotlin/Long, *, *>).io.github.kormium/sum(): io.github.kormium/Operand<kotlin/Long> // io.github.kormium/sum|sum@io.github.kormium.Column<kotlin.Long,*,*>(){}[0]
+final fun (io.github.kormium/Column<kotlin/Short, *, *>).io.github.kormium/sum(): io.github.kormium/Operand<kotlin/Long> // io.github.kormium/sum|sum@io.github.kormium.Column<kotlin.Short,*,*>(){}[0]
+final fun (io.github.kormium/Column<kotlin/String, *, *>).io.github.kormium/length(): io.github.kormium/NumericExpr<kotlin/Int> // io.github.kormium/length|length@io.github.kormium.Column<kotlin.String,*,*>(){}[0]
+final fun (io.github.kormium/Column<kotlin/String, *, *>).io.github.kormium/lower(): io.github.kormium/StringExpr // io.github.kormium/lower|lower@io.github.kormium.Column<kotlin.String,*,*>(){}[0]
+final fun (io.github.kormium/Column<kotlin/String, *, *>).io.github.kormium/ltrim(): io.github.kormium/StringExpr // io.github.kormium/ltrim|ltrim@io.github.kormium.Column<kotlin.String,*,*>(){}[0]
+final fun (io.github.kormium/Column<kotlin/String, *, *>).io.github.kormium/rtrim(): io.github.kormium/StringExpr // io.github.kormium/rtrim|rtrim@io.github.kormium.Column<kotlin.String,*,*>(){}[0]
+final fun (io.github.kormium/Column<kotlin/String, *, *>).io.github.kormium/trim(): io.github.kormium/StringExpr // io.github.kormium/trim|trim@io.github.kormium.Column<kotlin.String,*,*>(){}[0]
+final fun (io.github.kormium/Column<kotlin/String, *, *>).io.github.kormium/upper(): io.github.kormium/StringExpr // io.github.kormium/upper|upper@io.github.kormium.Column<kotlin.String,*,*>(){}[0]
+final fun (io.github.kormium/Operand<*>).io.github.kormium/isNotNull(): io.github.kormium/Expression // io.github.kormium/isNotNull|isNotNull@io.github.kormium.Operand<*>(){}[0]
+final fun (io.github.kormium/Operand<*>).io.github.kormium/isNull(): io.github.kormium/Expression // io.github.kormium/isNull|isNull@io.github.kormium.Operand<*>(){}[0]
+final fun (io.github.kormium/Operand<kotlin/String>).io.github.kormium/like(io.github.kormium/Operand<kotlin/String>): io.github.kormium/Expression // io.github.kormium/like|like@io.github.kormium.Operand<kotlin.String>(io.github.kormium.Operand<kotlin.String>){}[0]
+final fun (io.github.kormium/Operand<kotlin/String>).io.github.kormium/like(kotlin/String): io.github.kormium/Expression // io.github.kormium/like|like@io.github.kormium.Operand<kotlin.String>(kotlin.String){}[0]
+final fun (io.github.kormium/StringExpr).io.github.kormium/length(): io.github.kormium/NumericExpr<kotlin/Int> // io.github.kormium/length|length@io.github.kormium.StringExpr(){}[0]
+final fun (io.github.kormium/StringExpr).io.github.kormium/lower(): io.github.kormium/StringExpr // io.github.kormium/lower|lower@io.github.kormium.StringExpr(){}[0]
+final fun (io.github.kormium/StringExpr).io.github.kormium/ltrim(): io.github.kormium/StringExpr // io.github.kormium/ltrim|ltrim@io.github.kormium.StringExpr(){}[0]
+final fun (io.github.kormium/StringExpr).io.github.kormium/rtrim(): io.github.kormium/StringExpr // io.github.kormium/rtrim|rtrim@io.github.kormium.StringExpr(){}[0]
+final fun (io.github.kormium/StringExpr).io.github.kormium/trim(): io.github.kormium/StringExpr // io.github.kormium/trim|trim@io.github.kormium.StringExpr(){}[0]
+final fun (io.github.kormium/StringExpr).io.github.kormium/upper(): io.github.kormium/StringExpr // io.github.kormium/upper|upper@io.github.kormium.StringExpr(){}[0]
+final fun <#A: io.github.kormium/Catalog, #B: io.github.kormium/Entity, #C: io.github.kormium/Entity> (io.github.kormium/Table<#A, #B>).io.github.kormium/innerJoin(io.github.kormium/Table<#A, #C>): io.github.kormium/JoinPairStep<#A, #B, #C> // io.github.kormium/innerJoin|innerJoin@io.github.kormium.Table<0:0,0:1>(io.github.kormium.Table<0:0,0:2>){0§<io.github.kormium.Catalog>;1§<io.github.kormium.Entity>;2§<io.github.kormium.Entity>}[0]
+final fun <#A: io.github.kormium/Catalog, #B: io.github.kormium/Entity, #C: io.github.kormium/Entity> (io.github.kormium/Table<#A, #B>).io.github.kormium/leftJoin(io.github.kormium/Table<#A, #C>): io.github.kormium/LeftJoinPairStep<#A, #B, #C> // io.github.kormium/leftJoin|leftJoin@io.github.kormium.Table<0:0,0:1>(io.github.kormium.Table<0:0,0:2>){0§<io.github.kormium.Catalog>;1§<io.github.kormium.Entity>;2§<io.github.kormium.Entity>}[0]
+final fun <#A: io.github.kormium/Catalog, #B: kotlin/Any?> (io.github.kormium.database/Database<#A>).io.github.kormium/autocommit(kotlin/Function1<io.github.kormium/Scope<#A>, #B>): #B // io.github.kormium/autocommit|autocommit@io.github.kormium.database.Database<0:0>(kotlin.Function1<io.github.kormium.Scope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final fun <#A: io.github.kormium/Catalog, #B: kotlin/Any?> (io.github.kormium.database/Database<#A>).io.github.kormium/renderSql(kotlin/Function1<io.github.kormium/RenderScope<#A>, #B>): #B // io.github.kormium/renderSql|renderSql@io.github.kormium.database.Database<0:0>(kotlin.Function1<io.github.kormium.RenderScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final fun <#A: io.github.kormium/Catalog, #B: kotlin/Any?> (io.github.kormium.database/Database<#A>).io.github.kormium/transaction(io.github.kormium/TransactionIsolation? = ..., kotlin/Boolean = ..., kotlin/Function1<io.github.kormium/Scope<#A>, #B>): #B // io.github.kormium/transaction|transaction@io.github.kormium.database.Database<0:0>(io.github.kormium.TransactionIsolation?;kotlin.Boolean;kotlin.Function1<io.github.kormium.Scope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final fun <#A: io.github.kormium/Catalog, #B: kotlin/Any?> io.github.kormium/renderSql(#A, io.github.kormium/Dialect = ..., io.github.kormium/TypeMapper = ..., kotlin/Function1<io.github.kormium/RenderScope<#A>, #B>): #B // io.github.kormium/renderSql|renderSql(0:0;io.github.kormium.Dialect;io.github.kormium.TypeMapper;kotlin.Function1<io.github.kormium.RenderScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final fun <#A: io.github.kormium/Catalog> (io.github.kormium.database/SuspendDatabase<#A>).io.github.kormium/connectNotifications(io.github.kormium/NotificationTransport): io.github.kormium/Registration // io.github.kormium/connectNotifications|connectNotifications@io.github.kormium.database.SuspendDatabase<0:0>(io.github.kormium.NotificationTransport){0§<io.github.kormium.Catalog>}[0]
+final fun <#A: io.github.kormium/Catalog> (io.github.kormium/Table<#A, *>).io.github.kormium/query(): io.github.kormium/Join<#A> // io.github.kormium/query|query@io.github.kormium.Table<0:0,*>(){0§<io.github.kormium.Catalog>}[0]
+final fun <#A: io.github.kormium/Entity> (#A).io.github.kormium/isSet(io.github.kormium/Column<*, *, #A>): kotlin/Boolean // io.github.kormium/isSet|isSet@0:0(io.github.kormium.Column<*,*,0:0>){0§<io.github.kormium.Entity>}[0]
+final fun <#A: io.github.kormium/Entity> (#A).io.github.kormium/unset(io.github.kormium/Column<*, *, #A>) // io.github.kormium/unset|unset@0:0(io.github.kormium.Column<*,*,0:0>){0§<io.github.kormium.Entity>}[0]
+final fun <#A: io.github.kormium/Entity> (io.github.kormium/ResultRow).io.github.kormium/entity(io.github.kormium/Table<*, #A>): #A // io.github.kormium/entity|entity@io.github.kormium.ResultRow(io.github.kormium.Table<*,0:0>){0§<io.github.kormium.Entity>}[0]
+final fun <#A: io.github.kormium/Entity> (io.github.kormium/Table<*, #A>).io.github.kormium/any(kotlin/Function0<io.github.kormium/Expression>): io.github.kormium/Expression // io.github.kormium/any|any@io.github.kormium.Table<*,0:0>(kotlin.Function0<io.github.kormium.Expression>){0§<io.github.kormium.Entity>}[0]
+final fun <#A: io.github.kormium/Entity> (io.github.kormium/Table<*, #A>).io.github.kormium/none(kotlin/Function0<io.github.kormium/Expression>): io.github.kormium/Expression // io.github.kormium/none|none@io.github.kormium.Table<*,0:0>(kotlin.Function0<io.github.kormium.Expression>){0§<io.github.kormium.Entity>}[0]
+final fun <#A: io.github.kormium/Expression, #B: io.github.kormium/Expression> (#A).io.github.kormium/and(#B): io.github.kormium/Expression // io.github.kormium/and|and@0:0(0:1){0§<io.github.kormium.Expression>;1§<io.github.kormium.Expression>}[0]
+final fun <#A: io.github.kormium/Expression, #B: io.github.kormium/Expression> (#A).io.github.kormium/eq(#B): io.github.kormium/Expression // io.github.kormium/eq|eq@0:0(0:1){0§<io.github.kormium.Expression>;1§<io.github.kormium.Expression>}[0]
+final fun <#A: io.github.kormium/Expression, #B: io.github.kormium/Expression> (#A).io.github.kormium/gt(#B): io.github.kormium/Expression // io.github.kormium/gt|gt@0:0(0:1){0§<io.github.kormium.Expression>;1§<io.github.kormium.Expression>}[0]
+final fun <#A: io.github.kormium/Expression, #B: io.github.kormium/Expression> (#A).io.github.kormium/gtEq(#B): io.github.kormium/Expression // io.github.kormium/gtEq|gtEq@0:0(0:1){0§<io.github.kormium.Expression>;1§<io.github.kormium.Expression>}[0]
+final fun <#A: io.github.kormium/Expression, #B: io.github.kormium/Expression> (#A).io.github.kormium/lt(#B): io.github.kormium/Expression // io.github.kormium/lt|lt@0:0(0:1){0§<io.github.kormium.Expression>;1§<io.github.kormium.Expression>}[0]
+final fun <#A: io.github.kormium/Expression, #B: io.github.kormium/Expression> (#A).io.github.kormium/ltEq(#B): io.github.kormium/Expression // io.github.kormium/ltEq|ltEq@0:0(0:1){0§<io.github.kormium.Expression>;1§<io.github.kormium.Expression>}[0]
+final fun <#A: io.github.kormium/Expression, #B: io.github.kormium/Expression> (#A).io.github.kormium/neq(#B): io.github.kormium/Expression // io.github.kormium/neq|neq@0:0(0:1){0§<io.github.kormium.Expression>;1§<io.github.kormium.Expression>}[0]
+final fun <#A: io.github.kormium/Expression, #B: io.github.kormium/Expression> (#A).io.github.kormium/or(#B): io.github.kormium/Expression // io.github.kormium/or|or@0:0(0:1){0§<io.github.kormium.Expression>;1§<io.github.kormium.Expression>}[0]
+final fun <#A: kotlin/Any?, #B: kotlin/Any?> (io.github.kormium/ColumnType<#B>).io.github.kormium/convert(kotlin/Function1<#A, #B>, kotlin/Function1<#B, #A>): io.github.kormium/ColumnType<#A> // io.github.kormium/convert|convert@io.github.kormium.ColumnType<0:1>(kotlin.Function1<0:0,0:1>;kotlin.Function1<0:1,0:0>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/CoalesceOp<#A>).io.github.kormium/coalesce(#A): io.github.kormium/CoalesceOp<#A> // io.github.kormium/coalesce|coalesce@io.github.kormium.CoalesceOp<0:0>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/CoalesceOp<#A>).io.github.kormium/coalesce(kotlin/Array<out io.github.kormium/Column<#A, *, *>>...): io.github.kormium/CoalesceOp<#A> // io.github.kormium/coalesce|coalesce@io.github.kormium.CoalesceOp<0:0>(kotlin.Array<out|io.github.kormium.Column<0:0,*,*>>...){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/coalesce(#A): io.github.kormium/CoalesceOp<#A> // io.github.kormium/coalesce|coalesce@io.github.kormium.Column<0:0,*,*>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/coalesce(kotlin/Array<out io.github.kormium/Column<#A, *, *>>...): io.github.kormium/CoalesceOp<#A> // io.github.kormium/coalesce|coalesce@io.github.kormium.Column<0:0,*,*>(kotlin.Array<out|io.github.kormium.Column<0:0,*,*>>...){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/div(#A): io.github.kormium/NumericExpr<#A> // io.github.kormium/div|div@io.github.kormium.Column<0:0,*,*>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/div(io.github.kormium/Column<#A, *, *>): io.github.kormium/NumericExpr<#A> // io.github.kormium/div|div@io.github.kormium.Column<0:0,*,*>(io.github.kormium.Column<0:0,*,*>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/div(io.github.kormium/NumericExpr<#A>): io.github.kormium/NumericExpr<#A> // io.github.kormium/div|div@io.github.kormium.Column<0:0,*,*>(io.github.kormium.NumericExpr<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/max(): io.github.kormium/Operand<#A> // io.github.kormium/max|max@io.github.kormium.Column<0:0,*,*>(){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/min(): io.github.kormium/Operand<#A> // io.github.kormium/min|min@io.github.kormium.Column<0:0,*,*>(){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/minus(#A): io.github.kormium/NumericExpr<#A> // io.github.kormium/minus|minus@io.github.kormium.Column<0:0,*,*>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/minus(io.github.kormium/Column<#A, *, *>): io.github.kormium/NumericExpr<#A> // io.github.kormium/minus|minus@io.github.kormium.Column<0:0,*,*>(io.github.kormium.Column<0:0,*,*>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/minus(io.github.kormium/NumericExpr<#A>): io.github.kormium/NumericExpr<#A> // io.github.kormium/minus|minus@io.github.kormium.Column<0:0,*,*>(io.github.kormium.NumericExpr<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/plus(#A): io.github.kormium/NumericExpr<#A> // io.github.kormium/plus|plus@io.github.kormium.Column<0:0,*,*>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/plus(io.github.kormium/Column<#A, *, *>): io.github.kormium/NumericExpr<#A> // io.github.kormium/plus|plus@io.github.kormium.Column<0:0,*,*>(io.github.kormium.Column<0:0,*,*>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/plus(io.github.kormium/NumericExpr<#A>): io.github.kormium/NumericExpr<#A> // io.github.kormium/plus|plus@io.github.kormium.Column<0:0,*,*>(io.github.kormium.NumericExpr<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/rem(#A): io.github.kormium/NumericExpr<#A> // io.github.kormium/rem|rem@io.github.kormium.Column<0:0,*,*>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/rem(io.github.kormium/Column<#A, *, *>): io.github.kormium/NumericExpr<#A> // io.github.kormium/rem|rem@io.github.kormium.Column<0:0,*,*>(io.github.kormium.Column<0:0,*,*>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/rem(io.github.kormium/NumericExpr<#A>): io.github.kormium/NumericExpr<#A> // io.github.kormium/rem|rem@io.github.kormium.Column<0:0,*,*>(io.github.kormium.NumericExpr<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/sum(): io.github.kormium/Operand<#A> // io.github.kormium/sum|sum@io.github.kormium.Column<0:0,*,*>(){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/times(#A): io.github.kormium/NumericExpr<#A> // io.github.kormium/times|times@io.github.kormium.Column<0:0,*,*>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/times(io.github.kormium/Column<#A, *, *>): io.github.kormium/NumericExpr<#A> // io.github.kormium/times|times@io.github.kormium.Column<0:0,*,*>(io.github.kormium.Column<0:0,*,*>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Column<#A, *, *>).io.github.kormium/times(io.github.kormium/NumericExpr<#A>): io.github.kormium/NumericExpr<#A> // io.github.kormium/times|times@io.github.kormium.Column<0:0,*,*>(io.github.kormium.NumericExpr<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/ConnectionPool).io.github.kormium/runPinned(kotlin/Boolean, io.github.kormium/TransactionIsolation? = ..., kotlin/Boolean = ..., kotlin/Function1<io.github.kormium/SqlExecutor, #A>): #A // io.github.kormium/runPinned|runPinned@io.github.kormium.ConnectionPool(kotlin.Boolean;io.github.kormium.TransactionIsolation?;kotlin.Boolean;kotlin.Function1<io.github.kormium.SqlExecutor,0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/div(#A): io.github.kormium/NumericExpr<#A> // io.github.kormium/div|div@io.github.kormium.NumericExpr<0:0>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/div(io.github.kormium/Column<#A, *, *>): io.github.kormium/NumericExpr<#A> // io.github.kormium/div|div@io.github.kormium.NumericExpr<0:0>(io.github.kormium.Column<0:0,*,*>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/div(io.github.kormium/NumericExpr<#A>): io.github.kormium/NumericExpr<#A> // io.github.kormium/div|div@io.github.kormium.NumericExpr<0:0>(io.github.kormium.NumericExpr<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/minus(#A): io.github.kormium/NumericExpr<#A> // io.github.kormium/minus|minus@io.github.kormium.NumericExpr<0:0>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/minus(io.github.kormium/Column<#A, *, *>): io.github.kormium/NumericExpr<#A> // io.github.kormium/minus|minus@io.github.kormium.NumericExpr<0:0>(io.github.kormium.Column<0:0,*,*>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/minus(io.github.kormium/NumericExpr<#A>): io.github.kormium/NumericExpr<#A> // io.github.kormium/minus|minus@io.github.kormium.NumericExpr<0:0>(io.github.kormium.NumericExpr<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/plus(#A): io.github.kormium/NumericExpr<#A> // io.github.kormium/plus|plus@io.github.kormium.NumericExpr<0:0>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/plus(io.github.kormium/Column<#A, *, *>): io.github.kormium/NumericExpr<#A> // io.github.kormium/plus|plus@io.github.kormium.NumericExpr<0:0>(io.github.kormium.Column<0:0,*,*>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/plus(io.github.kormium/NumericExpr<#A>): io.github.kormium/NumericExpr<#A> // io.github.kormium/plus|plus@io.github.kormium.NumericExpr<0:0>(io.github.kormium.NumericExpr<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/rem(#A): io.github.kormium/NumericExpr<#A> // io.github.kormium/rem|rem@io.github.kormium.NumericExpr<0:0>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/rem(io.github.kormium/Column<#A, *, *>): io.github.kormium/NumericExpr<#A> // io.github.kormium/rem|rem@io.github.kormium.NumericExpr<0:0>(io.github.kormium.Column<0:0,*,*>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/rem(io.github.kormium/NumericExpr<#A>): io.github.kormium/NumericExpr<#A> // io.github.kormium/rem|rem@io.github.kormium.NumericExpr<0:0>(io.github.kormium.NumericExpr<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/times(#A): io.github.kormium/NumericExpr<#A> // io.github.kormium/times|times@io.github.kormium.NumericExpr<0:0>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/times(io.github.kormium/Column<#A, *, *>): io.github.kormium/NumericExpr<#A> // io.github.kormium/times|times@io.github.kormium.NumericExpr<0:0>(io.github.kormium.Column<0:0,*,*>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/NumericExpr<#A>).io.github.kormium/times(io.github.kormium/NumericExpr<#A>): io.github.kormium/NumericExpr<#A> // io.github.kormium/times|times@io.github.kormium.NumericExpr<0:0>(io.github.kormium.NumericExpr<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Operand<#A>).io.github.kormium/eq(#A): io.github.kormium/Expression // io.github.kormium/eq|eq@io.github.kormium.Operand<0:0>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Operand<#A>).io.github.kormium/gt(#A): io.github.kormium/Expression // io.github.kormium/gt|gt@io.github.kormium.Operand<0:0>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Operand<#A>).io.github.kormium/gtEq(#A): io.github.kormium/Expression // io.github.kormium/gtEq|gtEq@io.github.kormium.Operand<0:0>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Operand<#A>).io.github.kormium/inList(kotlin.collections/List<#A>): io.github.kormium/Expression // io.github.kormium/inList|inList@io.github.kormium.Operand<0:0>(kotlin.collections.List<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Operand<#A>).io.github.kormium/lt(#A): io.github.kormium/Expression // io.github.kormium/lt|lt@io.github.kormium.Operand<0:0>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Operand<#A>).io.github.kormium/ltEq(#A): io.github.kormium/Expression // io.github.kormium/ltEq|ltEq@io.github.kormium.Operand<0:0>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (io.github.kormium/Operand<#A>).io.github.kormium/neq(#A): io.github.kormium/Expression // io.github.kormium/neq|neq@io.github.kormium.Operand<0:0>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> io.github.kormium/case(io.github.kormium/ColumnType<#A>, kotlin/Function1<io.github.kormium/CaseBuilder<#A>, kotlin/Unit>): io.github.kormium/CaseOp<#A> // io.github.kormium/case|case(io.github.kormium.ColumnType<0:0>;kotlin.Function1<io.github.kormium.CaseBuilder<0:0>,kotlin.Unit>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Comparable<#A>> (io.github.kormium/Operand<#A>).io.github.kormium/between(kotlin.ranges/ClosedRange<#A>): io.github.kormium/Expression // io.github.kormium/between|between@io.github.kormium.Operand<0:0>(kotlin.ranges.ClosedRange<0:0>){0§<kotlin.Comparable<0:0>>}[0]
+final fun io.github.kormium/count(): io.github.kormium/Operand<kotlin/Long> // io.github.kormium/count|count(){}[0]
+final fun io.github.kormium/decodeTablePayload(kotlin/String): kotlin.collections/Set<kotlin/String> // io.github.kormium/decodeTablePayload|decodeTablePayload(kotlin.String){}[0]
+final fun io.github.kormium/encodeTablePayload(kotlin.collections/Set<kotlin/String>): kotlin/String // io.github.kormium/encodeTablePayload|encodeTablePayload(kotlin.collections.Set<kotlin.String>){}[0]
+final fun io.github.kormium/not(io.github.kormium/Expression): io.github.kormium/Expression // io.github.kormium/not|not(io.github.kormium.Expression){}[0]
+final fun io.github.kormium/sqlException(kotlin/String, kotlin/String?, kotlin/Throwable? = ...): io.github.kormium/QueryException // io.github.kormium/sqlException|sqlException(kotlin.String;kotlin.String?;kotlin.Throwable?){}[0]
+final inline fun <#A: reified kotlin/Any?> io.github.kormium/case(noinline kotlin/Function1<io.github.kormium/CaseBuilder<#A>, kotlin/Unit>): io.github.kormium/CaseOp<#A> // io.github.kormium/case|case(kotlin.Function1<io.github.kormium.CaseBuilder<0:0>,kotlin.Unit>){0§<kotlin.Any?>}[0]
+final inline fun <#A: reified kotlin/Any?> io.github.kormium/jsonColumnType(kotlinx.serialization.json/Json = ...): io.github.kormium/ColumnType<#A> // io.github.kormium/jsonColumnType|jsonColumnType(kotlinx.serialization.json.Json){0§<kotlin.Any?>}[0]
+final inline fun <#A: reified kotlin/Enum<#A>> io.github.kormium/enumColumnType(): io.github.kormium/ColumnType<#A> // io.github.kormium/enumColumnType|enumColumnType(){0§<kotlin.Enum<0:0>>}[0]
+final suspend fun <#A: io.github.kormium/Catalog, #B: kotlin/Any?> (io.github.kormium.database/SuspendDatabase<#A>).io.github.kormium/suspendAutocommit(kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium/suspendAutocommit|suspendAutocommit@io.github.kormium.database.SuspendDatabase<0:0>(kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final suspend fun <#A: io.github.kormium/Catalog, #B: kotlin/Any?> (io.github.kormium.database/SuspendDatabase<#A>).io.github.kormium/suspendTransaction(io.github.kormium/TransactionIsolation? = ..., kotlin/Boolean = ..., kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium/suspendTransaction|suspendTransaction@io.github.kormium.database.SuspendDatabase<0:0>(io.github.kormium.TransactionIsolation?;kotlin.Boolean;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final suspend fun <#A: kotlin/Any?> (io.github.kormium/ConnectionPool).io.github.kormium/runConnection(kotlin/Boolean, io.github.kormium/TransactionIsolation? = ..., kotlin/Boolean = ..., kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendSqlExecutor, #A>): #A // io.github.kormium/runConnection|runConnection@io.github.kormium.ConnectionPool(kotlin.Boolean;io.github.kormium.TransactionIsolation?;kotlin.Boolean;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendSqlExecutor,0:0>){0§<kotlin.Any?>}[0]

--- a/kormium-core/build.gradle.kts
+++ b/kormium-core/build.gradle.kts
@@ -13,6 +13,8 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm {

--- a/kormium-core/src/commonMain/kotlin/Aggregate.kt
+++ b/kormium-core/src/commonMain/kotlin/Aggregate.kt
@@ -6,14 +6,14 @@ import kotlin.jvm.JvmName
 // like any operand — `total gt 100`), and since Operand is an Expression they also work in `having(...)`.
 
 /** `COUNT(*)` — the number of rows in the group. */
-fun count(): Operand<Long> = object : Operand<Long> {
+public fun count(): Operand<Long> = object : Operand<Long> {
     override val columnType = LongColumnType
     override fun toSql(builder: ParamBuilder) = "COUNT(*)"
     override fun resultKey() = "COUNT(*)"
 }
 
 /** `COUNT(column)` — the non-null values of the column in the group. */
-fun Column<*, *, *>.count(): Operand<Long> {
+public fun Column<*, *, *>.count(): Operand<Long> {
     val column = this
     return object : Operand<Long> {
         override val columnType = LongColumnType
@@ -28,24 +28,24 @@ fun Column<*, *, *>.count(): Operand<Long> {
 // (toInt() throws). The integer-family sum() overloads below therefore return Operand<Long>
 // and read the aggregate as a Long; SUM of a Decimal/Double column keeps the column type
 // via the generic sum().
-fun <Z> Column<Z, *, *>.min(): Operand<Z> = ColumnAggregate("MIN", this)
-fun <Z> Column<Z, *, *>.max(): Operand<Z> = ColumnAggregate("MAX", this)
+public fun <Z> Column<Z, *, *>.min(): Operand<Z> = ColumnAggregate("MIN", this)
+public fun <Z> Column<Z, *, *>.max(): Operand<Z> = ColumnAggregate("MAX", this)
 
 /** `SUM(column)` for a non-integer column (e.g. Decimal/Double), read through its type. */
-fun <Z> Column<Z, *, *>.sum(): Operand<Z> = ColumnAggregate("SUM", this)
+public fun <Z> Column<Z, *, *>.sum(): Operand<Z> = ColumnAggregate("SUM", this)
 
 // More-specific sum() overloads for integer columns: they win overload resolution over the
 // generic sum() above and return Operand<Long>, reading the (bigint) aggregate as a Long so
 // sums beyond Int.MAX_VALUE don't overflow. @JvmName disambiguates the otherwise-identical JVM
 // signatures (generic erasure collides with these).
 @JvmName("sumInt")
-fun Column<kotlin.Int, *, *>.sum(): Operand<Long> = LongAggregate(this)
+public fun Column<kotlin.Int, *, *>.sum(): Operand<Long> = LongAggregate(this)
 
 @JvmName("sumShort")
-fun Column<kotlin.Short, *, *>.sum(): Operand<Long> = LongAggregate(this)
+public fun Column<kotlin.Short, *, *>.sum(): Operand<Long> = LongAggregate(this)
 
 @JvmName("sumLong")
-fun Column<kotlin.Long, *, *>.sum(): Operand<Long> = LongAggregate(this)
+public fun Column<kotlin.Long, *, *>.sum(): Operand<Long> = LongAggregate(this)
 
 private class ColumnAggregate<Z>(private val fn: String, private val column: Column<Z, *, *>) : Operand<Z> {
     override val columnType: ColumnType<Z> = column.columnType
@@ -61,7 +61,7 @@ private class LongAggregate(private val column: Column<*, *, *>) : Operand<Long>
 }
 
 /** `AVG(column)` as a Double. */
-fun Column<*, *, *>.avg(): Operand<Double> {
+public fun Column<*, *, *>.avg(): Operand<Double> {
     val column = this
     return object : Operand<Double> {
         override val columnType = DoubleColumnType

--- a/kormium-core/src/commonMain/kotlin/Catalog.kt
+++ b/kormium-core/src/commonMain/kotlin/Catalog.kt
@@ -7,4 +7,4 @@ package io.github.kormium
  * to, and a [Table] is tagged with the catalog it belongs to. Many database instances
  * may share a catalog (sharding).
  */
-interface Catalog
+public interface Catalog

--- a/kormium-core/src/commonMain/kotlin/Column.kt
+++ b/kormium-core/src/commonMain/kotlin/Column.kt
@@ -27,17 +27,17 @@ private val logger = kormiumLogger()
  * rendered SQL identifier. They differ only when a custom `name = ...` is given, so custom
  * SQL names never leak into entity internals or absent/null tracking.
  */
-sealed class Column<Z, T: Table<*, N>, N: Entity>(
+public sealed class Column<Z, T: Table<*, N>, N: Entity>(
     private val table: T,
     /** Key under which the value is stored in [Entity.fields]; follows the Kotlin property name. */
-    val fieldKey: String,
+    public val fieldKey: String,
     /** Rendered SQL column identifier. Equals [fieldKey] unless a custom name was supplied. */
-    val name: String,
-    val nullable: kotlin.Boolean,
+    public val name: String,
+    public val nullable: kotlin.Boolean,
     override val columnType: ColumnType<Z>,
 ) : Expression, Operand<Z> {
 
-    open fun init() {
+    public open fun init() {
         logger.trace { "init column $fieldKey (sql: $name)" }
         table.addColumn(fieldKey, this)
     }
@@ -69,45 +69,45 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
      * A non-null column. Its entity property is `Z`: assigning `null` is a compile error, and
      * reading a field that was never assigned (or that the database returned as `NULL`) throws.
      */
-    class NotNullColumn<Z, T: Table<*, N>, N: Entity>(table: T, fieldKey: String, name: String, columnType: ColumnType<Z>)
+    public class NotNullColumn<Z, T: Table<*, N>, N: Entity>(table: T, fieldKey: String, name: String, columnType: ColumnType<Z>)
         : Column<Z, T, N>(table, fieldKey, name, nullable = false, columnType) {
-        operator fun getValue(n: N, property: KProperty<*>): Z {
+        public operator fun getValue(n: N, property: KProperty<*>): Z {
             logger.trace { "Get value $fieldKey" }
             if (!n.fields.containsKey(fieldKey)) error("Field '$fieldKey' is not present on ${tableRef.tableName}")
             @Suppress("UNCHECKED_CAST")
             return (n.fields[fieldKey] ?: error("Field '$fieldKey' is null but column '$name' is non-null")) as Z
         }
 
-        operator fun setValue(n: N, property: KProperty<*>, z: Z) {
+        public operator fun setValue(n: N, property: KProperty<*>, z: Z) {
             logger.trace { "Set value $fieldKey" }
             n.fields[fieldKey] = z
         }
     }
 
     /** A nullable column. Its entity property is `Z?`: an absent field reads back as `null`. */
-    class NullableColumn<Z, T: Table<*, N>, N: Entity>(table: T, fieldKey: String, name: String, columnType: ColumnType<Z>)
+    public class NullableColumn<Z, T: Table<*, N>, N: Entity>(table: T, fieldKey: String, name: String, columnType: ColumnType<Z>)
         : Column<Z, T, N>(table, fieldKey, name, nullable = true, columnType) {
         @Suppress("UNCHECKED_CAST")
-        operator fun getValue(n: N, property: KProperty<*>): Z? {
+        public operator fun getValue(n: N, property: KProperty<*>): Z? {
             logger.trace { "Get value $fieldKey" }
             return n.fields[fieldKey] as Z?
         }
 
-        operator fun setValue(n: N, property: KProperty<*>, z: Z?) {
+        public operator fun setValue(n: N, property: KProperty<*>, z: Z?) {
             logger.trace { "Set value $fieldKey" }
             n.fields[fieldKey] = z
         }
     }
 
-    companion object {
+    public companion object {
         /** Declares a column of any [ColumnType] — the open extension point. */
-        fun <Z> of(type: ColumnType<Z>, name: String? = null): Spec<Z> = Spec(name, type)
+        public fun <Z> of(type: ColumnType<Z>, name: String? = null): Spec<Z> = Spec(name, type)
 
         /** A column storing the enum [E] by name (text). */
-        inline fun <reified E : Enum<E>> enum(name: String? = null): Spec<E> = of(enumColumnType<E>(), name)
+        public inline fun <reified E : Enum<E>> enum(name: String? = null): Spec<E> = of(enumColumnType<E>(), name)
 
         /** A column storing the `@Serializable` value [T] as JSON. */
-        inline fun <reified T> json(name: String? = null): Spec<T> = of(jsonColumnType<T>(), name)
+        public inline fun <reified T> json(name: String? = null): Spec<T> = of(jsonColumnType<T>(), name)
     }
 
     // ---- column specs (the public declaration builders) ----
@@ -117,30 +117,30 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
      * [nullable] or [primaryKey] (mutually exclusive — a nullable primary key cannot be
      * expressed).
      */
-    open class Spec<Z>(private val name: String?, private val columnType: ColumnType<Z>) {
-        operator fun <T: Table<*, N>, N: Entity> provideDelegate(table: T, property: KProperty<*>): ReadOnlyProperty<T, NotNullColumn<Z, T, N>> {
+    public open class Spec<Z>(private val name: String?, private val columnType: ColumnType<Z>) {
+        public operator fun <T: Table<*, N>, N: Entity> provideDelegate(table: T, property: KProperty<*>): ReadOnlyProperty<T, NotNullColumn<Z, T, N>> {
             val column = NotNullColumn<Z, T, N>(table, property.name, name ?: property.name, columnType).also { it.init() }
             return ReadOnlyProperty { _, _ -> column }
         }
 
         /** Makes the column nullable; its entity property becomes `Z?`. */
-        fun nullable(): NullableSpec<Z> = NullableSpec(name, columnType)
+        public fun nullable(): NullableSpec<Z> = NullableSpec(name, columnType)
 
         /** Marks the column as the (or part of the) primary key. Non-null by construction. */
-        fun primaryKey(): PrimaryKeySpec<Z> = PrimaryKeySpec(name, columnType)
+        public fun primaryKey(): PrimaryKeySpec<Z> = PrimaryKeySpec(name, columnType)
     }
 
     /** Spec for a nullable column. Has no [primaryKey] — nullable primary keys are not allowed. */
-    class NullableSpec<Z> internal constructor(private val name: String?, private val columnType: ColumnType<Z>) {
-        operator fun <T: Table<*, N>, N: Entity> provideDelegate(table: T, property: KProperty<*>): ReadOnlyProperty<T, NullableColumn<Z, T, N>> {
+    public class NullableSpec<Z> internal constructor(private val name: String?, private val columnType: ColumnType<Z>) {
+        public operator fun <T: Table<*, N>, N: Entity> provideDelegate(table: T, property: KProperty<*>): ReadOnlyProperty<T, NullableColumn<Z, T, N>> {
             val column = NullableColumn<Z, T, N>(table, property.name, name ?: property.name, columnType).also { it.init() }
             return ReadOnlyProperty { _, _ -> column }
         }
     }
 
     /** Spec for a primary-key column. Has no [nullable] — nullable primary keys are not allowed. */
-    class PrimaryKeySpec<Z> internal constructor(private val name: String?, private val columnType: ColumnType<Z>) {
-        operator fun <T: Table<*, N>, N: Entity> provideDelegate(table: T, property: KProperty<*>): ReadOnlyProperty<T, NotNullColumn<Z, T, N>> {
+    public class PrimaryKeySpec<Z> internal constructor(private val name: String?, private val columnType: ColumnType<Z>) {
+        public operator fun <T: Table<*, N>, N: Entity> provideDelegate(table: T, property: KProperty<*>): ReadOnlyProperty<T, NotNullColumn<Z, T, N>> {
             val column = NotNullColumn<Z, T, N>(table, property.name, name ?: property.name, columnType)
                 .also { it.isPrimaryKey = true; it.init() }
             return ReadOnlyProperty { _, _ -> column }
@@ -149,18 +149,18 @@ sealed class Column<Z, T: Table<*, N>, N: Entity>(
 
     // ---- the 13 typed column declarations (decimal columns live in kormium-decimal) ----
 
-    class UUID(name: String? = null) : Spec<kotlin.uuid.Uuid>(name, UuidColumnType)
-    class Double(name: String? = null) : Spec<kotlin.Double>(name, DoubleColumnType)
-    class Int(name: String? = null) : Spec<kotlin.Int>(name, IntColumnType)
-    class Boolean(name: String? = null) : Spec<kotlin.Boolean>(name, BooleanColumnType)
-    class Text(name: String? = null) : Spec<kotlin.String>(name, TextColumnType)
-    class Instant(name: String? = null) : Spec<kotlin.time.Instant>(name, InstantColumnType)
-    class Json(name: String? = null) : Spec<JsonElement>(name, JsonColumnType)
-    class Long(name: String? = null) : Spec<kotlin.Long>(name, LongColumnType)
-    class Float(name: String? = null) : Spec<kotlin.Float>(name, FloatColumnType)
-    class Short(name: String? = null) : Spec<kotlin.Short>(name, ShortColumnType)
-    class LocalDate(name: String? = null) : Spec<kotlinx.datetime.LocalDate>(name, LocalDateColumnType)
-    class LocalTime(name: String? = null) : Spec<kotlinx.datetime.LocalTime>(name, LocalTimeColumnType)
-    class LocalDateTime(name: String? = null) : Spec<kotlinx.datetime.LocalDateTime>(name, LocalDateTimeColumnType)
-    class Bytes(name: String? = null) : Spec<kotlin.ByteArray>(name, BytesColumnType)
+    public class UUID(name: String? = null) : Spec<kotlin.uuid.Uuid>(name, UuidColumnType)
+    public class Double(name: String? = null) : Spec<kotlin.Double>(name, DoubleColumnType)
+    public class Int(name: String? = null) : Spec<kotlin.Int>(name, IntColumnType)
+    public class Boolean(name: String? = null) : Spec<kotlin.Boolean>(name, BooleanColumnType)
+    public class Text(name: String? = null) : Spec<kotlin.String>(name, TextColumnType)
+    public class Instant(name: String? = null) : Spec<kotlin.time.Instant>(name, InstantColumnType)
+    public class Json(name: String? = null) : Spec<JsonElement>(name, JsonColumnType)
+    public class Long(name: String? = null) : Spec<kotlin.Long>(name, LongColumnType)
+    public class Float(name: String? = null) : Spec<kotlin.Float>(name, FloatColumnType)
+    public class Short(name: String? = null) : Spec<kotlin.Short>(name, ShortColumnType)
+    public class LocalDate(name: String? = null) : Spec<kotlinx.datetime.LocalDate>(name, LocalDateColumnType)
+    public class LocalTime(name: String? = null) : Spec<kotlinx.datetime.LocalTime>(name, LocalTimeColumnType)
+    public class LocalDateTime(name: String? = null) : Spec<kotlinx.datetime.LocalDateTime>(name, LocalDateTimeColumnType)
+    public class Bytes(name: String? = null) : Spec<kotlin.ByteArray>(name, BytesColumnType)
 }

--- a/kormium-core/src/commonMain/kotlin/ColumnType.kt
+++ b/kormium-core/src/commonMain/kotlin/ColumnType.kt
@@ -21,23 +21,23 @@ import kotlin.uuid.Uuid
  * Note there is no DDL here — Kormium does not own schema (`CREATE TABLE` is raw SQL / migrations),
  * so a column type only describes value conversion, not the SQL column type.
  */
-interface ColumnType<T> {
+public interface ColumnType<T> {
     /** Reads the value at [index] (0-based per [ResultSet]) from [rs], or null for SQL NULL. */
-    fun read(rs: ResultSet, index: Int): T?
+    public fun read(rs: ResultSet, index: Int): T?
 
     /**
      * Converts a domain value into what gets bound as a parameter. The result still flows
      * through the backend's [TypeMapper.toParameter] and the dialect's bind rendering (so e.g.
      * a returned [JsonElement] is cast to `::jsonb` on Postgres). The default is identity.
      */
-    fun toParam(value: T): Any? = value
+    public fun toParam(value: T): Any? = value
 
     /**
      * A short human-readable name for this type, used only in diagnostics (e.g. result-mapping
      * errors). The default derives it from the class name (`IntColumnType` → `Int`); [convert]
      * and custom types may override for a clearer label.
      */
-    val description: String get() = this::class.simpleName?.removeSuffix("ColumnType") ?: "custom"
+    public val description: String get() = this::class.simpleName?.removeSuffix("ColumnType") ?: "custom"
 }
 
 /**
@@ -45,7 +45,7 @@ interface ColumnType<T> {
  * the lightweight path for custom types (Exposed's `transform`, Hibernate's `AttributeConverter`).
  * Storage, reading and any dialect casts are inherited; you only translate the value.
  */
-fun <Domain, Stored> ColumnType<Stored>.convert(
+public fun <Domain, Stored> ColumnType<Stored>.convert(
     toStored: (Domain) -> Stored,
     fromStored: (Stored) -> Domain,
 ): ColumnType<Domain> = object : ColumnType<Domain> {
@@ -56,25 +56,25 @@ fun <Domain, Stored> ColumnType<Stored>.convert(
 
 // ---- built-in column types (the 13 Kormium ships; decimal lives in kormium-decimal) ----
 
-object UuidColumnType : ColumnType<Uuid> { override fun read(rs: ResultSet, index: Int) = rs.getUUID(index) }
-object DoubleColumnType : ColumnType<Double> { override fun read(rs: ResultSet, index: Int) = rs.getDouble(index) }
-object IntColumnType : ColumnType<Int> { override fun read(rs: ResultSet, index: Int) = rs.getInt(index) }
-object BooleanColumnType : ColumnType<Boolean> { override fun read(rs: ResultSet, index: Int) = rs.getBoolean(index) }
-object TextColumnType : ColumnType<String> { override fun read(rs: ResultSet, index: Int) = rs.getString(index) }
-object InstantColumnType : ColumnType<Instant> { override fun read(rs: ResultSet, index: Int) = rs.getInstant(index) }
-object JsonColumnType : ColumnType<JsonElement> { override fun read(rs: ResultSet, index: Int) = rs.getJson(index) }
-object LongColumnType : ColumnType<Long> { override fun read(rs: ResultSet, index: Int) = rs.getLong(index) }
-object FloatColumnType : ColumnType<Float> { override fun read(rs: ResultSet, index: Int) = rs.getFloat(index) }
-object ShortColumnType : ColumnType<Short> { override fun read(rs: ResultSet, index: Int) = rs.getShort(index) }
-object LocalDateColumnType : ColumnType<LocalDate> { override fun read(rs: ResultSet, index: Int) = rs.getDate(index) }
-object LocalTimeColumnType : ColumnType<LocalTime> { override fun read(rs: ResultSet, index: Int) = rs.getTime(index) }
-object LocalDateTimeColumnType : ColumnType<LocalDateTime> { override fun read(rs: ResultSet, index: Int) = rs.getLocalDateTime(index) }
-object BytesColumnType : ColumnType<ByteArray> { override fun read(rs: ResultSet, index: Int) = rs.getBytes(index) }
+public object UuidColumnType : ColumnType<Uuid> { override fun read(rs: ResultSet, index: Int): Uuid? = rs.getUUID(index) }
+public object DoubleColumnType : ColumnType<Double> { override fun read(rs: ResultSet, index: Int): Double? = rs.getDouble(index) }
+public object IntColumnType : ColumnType<Int> { override fun read(rs: ResultSet, index: Int): Int? = rs.getInt(index) }
+public object BooleanColumnType : ColumnType<Boolean> { override fun read(rs: ResultSet, index: Int): Boolean? = rs.getBoolean(index) }
+public object TextColumnType : ColumnType<String> { override fun read(rs: ResultSet, index: Int): String? = rs.getString(index) }
+public object InstantColumnType : ColumnType<Instant> { override fun read(rs: ResultSet, index: Int): Instant? = rs.getInstant(index) }
+public object JsonColumnType : ColumnType<JsonElement> { override fun read(rs: ResultSet, index: Int): JsonElement? = rs.getJson(index) }
+public object LongColumnType : ColumnType<Long> { override fun read(rs: ResultSet, index: Int): Long? = rs.getLong(index) }
+public object FloatColumnType : ColumnType<Float> { override fun read(rs: ResultSet, index: Int): Float? = rs.getFloat(index) }
+public object ShortColumnType : ColumnType<Short> { override fun read(rs: ResultSet, index: Int): Short? = rs.getShort(index) }
+public object LocalDateColumnType : ColumnType<LocalDate> { override fun read(rs: ResultSet, index: Int): LocalDate? = rs.getDate(index) }
+public object LocalTimeColumnType : ColumnType<LocalTime> { override fun read(rs: ResultSet, index: Int): LocalTime? = rs.getTime(index) }
+public object LocalDateTimeColumnType : ColumnType<LocalDateTime> { override fun read(rs: ResultSet, index: Int): LocalDateTime? = rs.getLocalDateTime(index) }
+public object BytesColumnType : ColumnType<ByteArray> { override fun read(rs: ResultSet, index: Int): ByteArray? = rs.getBytes(index) }
 
 // ---- ready-made custom types built on [convert] ----
 
 /** Stores an enum by its [Enum.name] in a text column. */
-inline fun <reified E : Enum<E>> enumColumnType(): ColumnType<E> {
+public inline fun <reified E : Enum<E>> enumColumnType(): ColumnType<E> {
     val byName = enumValues<E>().associateBy { it.name }
     return TextColumnType.convert(
         toStored = { e: E -> e.name },
@@ -83,7 +83,7 @@ inline fun <reified E : Enum<E>> enumColumnType(): ColumnType<E> {
 }
 
 /** Stores a `@Serializable` value [T] as JSON (jsonb on Postgres, text on SQLite). */
-inline fun <reified T> jsonColumnType(json: Json = Json.Default): ColumnType<T> {
+public inline fun <reified T> jsonColumnType(json: Json = Json.Default): ColumnType<T> {
     val ser = serializer<T>()
     return JsonColumnType.convert(
         toStored = { value: T -> json.encodeToJsonElement(ser, value) },

--- a/kormium-core/src/commonMain/kotlin/ConnectionPool.kt
+++ b/kormium-core/src/commonMain/kotlin/ConnectionPool.kt
@@ -9,19 +9,19 @@ import kotlinx.coroutines.withContext
  * suspend [runConnection] drive these the same way; only how they're scheduled
  * differs.
  */
-interface PinnedConnection {
-    val executor: SqlExecutor
+public interface PinnedConnection {
+    public val executor: SqlExecutor
 
     /**
      * Opens a transaction. [isolation] (when non-null) and [readOnly] are applied here; how
      * each backend honors them — and any state it must restore on [release] — is backend-specific
      * (see [TransactionIsolation]).
      */
-    fun begin(isolation: TransactionIsolation? = null, readOnly: Boolean = false)
-    fun commit()
-    fun rollback()
+    public fun begin(isolation: TransactionIsolation? = null, readOnly: Boolean = false)
+    public fun commit()
+    public fun rollback()
     /** Returns the connection to the pool (and restores any per-borrow state). */
-    fun release()
+    public fun release()
 }
 
 /**
@@ -32,19 +32,19 @@ interface PinnedConnection {
  * it overrides [acquireSuspending] for that free path — otherwise the default just
  * offloads the blocking [acquire] to the IO dispatcher.
  */
-interface ConnectionPool {
+public interface ConnectionPool {
     /** Borrows a connection, blocking until one is free. */
-    fun acquire(): PinnedConnection
+    public fun acquire(): PinnedConnection
 
     /** Borrows a connection, suspending until one is free. */
-    suspend fun acquireSuspending(): PinnedConnection = withContext(ioDispatcher) { acquire() }
+    public suspend fun acquireSuspending(): PinnedConnection = withContext(ioDispatcher) { acquire() }
 }
 
 /**
  * Blocking pinned-connection run: borrow, BEGIN/COMMIT/ROLLBACK around [block] when
  * [transactional], always release. Backs [Database.usePinned].
  */
-fun <R> ConnectionPool.runPinned(
+public fun <R> ConnectionPool.runPinned(
     transactional: Boolean,
     isolation: TransactionIsolation? = null,
     readOnly: Boolean = false,
@@ -74,7 +74,7 @@ fun <R> ConnectionPool.runPinned(
  * [io.github.kormium.database.SuspendDatabase.useConnection] for blocking drivers;
  * a truly async backend (r2dbc) implements useConnection itself instead.
  */
-suspend fun <R> ConnectionPool.runConnection(
+public suspend fun <R> ConnectionPool.runConnection(
     transactional: Boolean,
     isolation: TransactionIsolation? = null,
     readOnly: Boolean = false,

--- a/kormium-core/src/commonMain/kotlin/DatabaseLifecycle.kt
+++ b/kormium-core/src/commonMain/kotlin/DatabaseLifecycle.kt
@@ -17,19 +17,19 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
  * [teardown] where they can wait for borrowed connections to come back.
  */
 @OptIn(ExperimentalAtomicApi::class)
-class DatabaseLifecycle(private val teardown: () -> Unit) {
+public class DatabaseLifecycle(private val teardown: () -> Unit) {
     private val closed = AtomicReference(false)
 
     /** Whether [close] has been called. */
-    val isClosed: Boolean get() = closed.load()
+    public val isClosed: Boolean get() = closed.load()
 
     /** Throws [DatabaseClosedException] if already closed; call before borrowing a connection. */
-    fun checkOpen() {
+    public fun checkOpen() {
         if (closed.load()) throw DatabaseClosedException()
     }
 
     /** Idempotent: runs [teardown] on the first call only; later calls return immediately. */
-    fun close() {
+    public fun close() {
         if (closed.compareAndSet(expectedValue = false, newValue = true)) teardown()
     }
 }

--- a/kormium-core/src/commonMain/kotlin/DelicateKormiumApi.kt
+++ b/kormium-core/src/commonMain/kotlin/DelicateKormiumApi.kt
@@ -14,4 +14,4 @@ package io.github.kormium
     level = RequiresOptIn.Level.ERROR,
 )
 @Retention(AnnotationRetention.BINARY)
-annotation class DelicateKormiumApi
+public annotation class DelicateKormiumApi

--- a/kormium-core/src/commonMain/kotlin/Dialect.kt
+++ b/kormium-core/src/commonMain/kotlin/Dialect.kt
@@ -5,18 +5,18 @@ package io.github.kormium
  * [Dialect] instead of hardcoding one SQL flavour, so other backends (SQLite, ...)
  * can plug in their own rendering.
  */
-interface Dialect {
+public interface Dialect {
     /** Quotes a column/table identifier. */
-    fun quoteIdentifier(name: String): String
+    public fun quoteIdentifier(name: String): String
 
     /** Renders the bind placeholder for [name], optionally casting based on [value]'s type. */
-    fun renderBind(name: String, value: Any?): String
+    public fun renderBind(name: String, value: Any?): String
 
     /** Renders a `LIMIT` clause (trailing space included), or "" when unbounded. */
-    fun renderLimit(limit: UInt): String
+    public fun renderLimit(limit: UInt): String
 
     /** Renders an `OFFSET` clause (trailing space included), or "" when zero. */
-    fun renderOffset(offset: UInt): String
+    public fun renderOffset(offset: UInt): String
 
     /**
      * Renders the combined `LIMIT`/`OFFSET` tail. The default composes the two independent
@@ -25,7 +25,7 @@ interface Dialect {
      * dialect overrides this to emit the two together (a sentinel `LIMIT` when only an offset
      * is set). Standard/Postgres/SQLite keep the default and render identically to before.
      */
-    fun renderLimitOffset(limit: UInt, offset: UInt): String =
+    public fun renderLimitOffset(limit: UInt, offset: UInt): String =
         renderLimit(limit) + renderOffset(offset)
 
     /**
@@ -34,7 +34,7 @@ interface Dialect {
      * concurrently-starting application instances; the lock is released automatically when the
      * surrounding transaction commits. The default is `null` (no lock).
      */
-    fun advisoryLockSql(key: Long): String? = null
+    public fun advisoryLockSql(key: Long): String? = null
 
     // ---- write-path rendering (Postgres/SQLite-flavoured by default; MySQL overrides) ----
 
@@ -43,14 +43,14 @@ interface Dialect {
      * `insert(returning = true)` runs the insert without a RETURNING clause and re-selects the
      * stored row by primary key instead. Default `true` (Postgres and SQLite both support it).
      */
-    val supportsReturning: Boolean get() = true
+    public val supportsReturning: Boolean get() = true
 
     /**
      * The full `INSERT` statement for a row with no assigned columns (every column takes its DB
      * default). Standard SQL is `INSERT INTO t DEFAULT VALUES`; MySQL has no `DEFAULT VALUES` and
      * spells it `INSERT INTO t () VALUES ()`.
      */
-    fun renderInsertDefaultValues(qualifiedTable: String): String =
+    public fun renderInsertDefaultValues(qualifiedTable: String): String =
         "INSERT INTO $qualifiedTable DEFAULT VALUES"
 
     /**
@@ -59,7 +59,7 @@ interface Dialect {
      * Standard SQL targets the conflict columns (`ON CONFLICT (...) DO UPDATE SET ...`); MySQL keys
      * on any declared unique/primary index and ignores the column list (`ON DUPLICATE KEY UPDATE`).
      */
-    fun renderUpsertSuffix(conflictColumns: List<String>, setClause: String): String =
+    public fun renderUpsertSuffix(conflictColumns: List<String>, setClause: String): String =
         "ON CONFLICT (${conflictColumns.joinToString(", ")}) DO UPDATE SET $setClause"
 
     /**
@@ -67,7 +67,7 @@ interface Dialect {
      * [conflictColumns] are already quoted. Standard SQL is `ON CONFLICT (...) DO NOTHING`; MySQL
      * uses a no-op `ON DUPLICATE KEY UPDATE col = col` (ignores only a duplicate-key conflict).
      */
-    fun renderInsertOrIgnoreSuffix(conflictColumns: List<String>): String =
+    public fun renderInsertOrIgnoreSuffix(conflictColumns: List<String>): String =
         "ON CONFLICT (${conflictColumns.joinToString(", ")}) DO NOTHING"
 
     /**
@@ -75,7 +75,7 @@ interface Dialect {
      * on PostgreSQL and SQLite, but **bytes** on MySQL — so MySQL overrides this with `CHAR_LENGTH`
      * to keep `length()` portable (a multibyte string counts the same everywhere).
      */
-    fun renderCharLength(arg: String): String = "LENGTH($arg)"
+    public fun renderCharLength(arg: String): String = "LENGTH($arg)"
 
     // ---- transaction options (isolation / read-only); see [TransactionIsolation] ----
 
@@ -84,7 +84,7 @@ interface Dialect {
      * which has a single effective level ≈ `SERIALIZABLE`), a [TransactionIsolation] passed to a
      * transaction is silently ignored rather than emulated or rejected. Default `true`.
      */
-    val supportsTransactionIsolation: Boolean get() = true
+    public val supportsTransactionIsolation: Boolean get() = true
 
     /**
      * SQL a backend runs to enter / leave a read-only transaction, for databases that toggle
@@ -94,7 +94,7 @@ interface Dialect {
      * [SqliteDialect] supplies `PRAGMA query_only` here — the single source the JDBC and the
      * native/Android SQLite backends all read.
      */
-    val readOnlyToggle: ReadOnlyToggle? get() = null
+    public val readOnlyToggle: ReadOnlyToggle? get() = null
 }
 
 /**
@@ -102,14 +102,14 @@ interface Dialect {
  * used by a backend whose database toggles read-only with a statement rather than a native
  * connection flag (see [Dialect.readOnlyToggle]).
  */
-data class ReadOnlyToggle(val enter: String, val exit: String)
+public data class ReadOnlyToggle(val enter: String, val exit: String)
 
 /**
  * Standard-SQL rendering: double-quoted identifiers, `:name` placeholders, plain
  * `LIMIT`/`OFFSET`. Serves as the agnostic default (e.g. [Query] debug rendering)
  * and a base that backend dialects can delegate to.
  */
-object StandardDialect : Dialect {
+public object StandardDialect : Dialect {
     override fun quoteIdentifier(name: String): String =
         "\"${name.replace("\"", "\"\"")}\""
 

--- a/kormium-core/src/commonMain/kotlin/Entity.kt
+++ b/kormium-core/src/commonMain/kotlin/Entity.kt
@@ -17,7 +17,7 @@ package io.github.kormium
  * implementation detail: it is not part of the public API and entities are not
  * serializable. Map entities to your own DTOs for transport.
  */
-abstract class Entity protected constructor() {
+public abstract class Entity protected constructor() {
     internal var fields: MutableMap<String, Any?> = mutableMapOf()
 
     /** Replaces the backing field storage. Used by Kormium when hydrating a row from the database. */
@@ -32,7 +32,7 @@ abstract class Entity protected constructor() {
  *
  * The column must belong to this entity's type: `user.isSet(Orders.id)` is a compile error.
  */
-fun <N : Entity> N.isSet(column: Column<*, *, N>): Boolean = fields.containsKey(column.fieldKey)
+public fun <N : Entity> N.isSet(column: Column<*, *, N>): Boolean = fields.containsKey(column.fieldKey)
 
 /**
  * Removes [column]'s value, returning it to absent state (so it is omitted from
@@ -41,6 +41,6 @@ fun <N : Entity> N.isSet(column: Column<*, *, N>): Boolean = fields.containsKey(
  *
  * The column must belong to this entity's type: `user.unset(Orders.id)` is a compile error.
  */
-fun <N : Entity> N.unset(column: Column<*, *, N>) {
+public fun <N : Entity> N.unset(column: Column<*, *, N>) {
     fields.remove(column.fieldKey)
 }

--- a/kormium-core/src/commonMain/kotlin/Exceptions.kt
+++ b/kormium-core/src/commonMain/kotlin/Exceptions.kt
@@ -1,7 +1,7 @@
 package io.github.kormium
 
 /** Base type for all korm errors. */
-open class KormiumException(message: String, cause: Throwable? = null) : Exception(message, cause)
+public open class KormiumException(message: String, cause: Throwable? = null) : Exception(message, cause)
 
 /**
  * Thrown when a `usePinned` / `useConnection` (and therefore any `transaction` / `autocommit`)
@@ -10,29 +10,29 @@ open class KormiumException(message: String, cause: Throwable? = null) : Excepti
  * been called. Every backend reports use-after-close as this single type, so callers can catch
  * it uniformly instead of a backend-specific closed-connection error.
  */
-class DatabaseClosedException(message: String = "database is closed") : KormiumException(message)
+public class DatabaseClosedException(message: String = "database is closed") : KormiumException(message)
 
 /**
  * A SQL statement failed on the server. [sqlState] is the 5-character SQLSTATE code when
  * the backend reports one (e.g. "23505"); subtypes cover the common constraint violations.
  */
-open class QueryException(message: String, val sqlState: String? = null, cause: Throwable? = null) :
+public open class QueryException(message: String, public val sqlState: String? = null, cause: Throwable? = null) :
     KormiumException(message, cause)
 
 /** Unique / primary-key constraint violation (SQLSTATE 23505). */
-class UniqueViolationException(message: String, sqlState: String?, cause: Throwable? = null) :
+public class UniqueViolationException(message: String, sqlState: String?, cause: Throwable? = null) :
     QueryException(message, sqlState, cause)
 
 /** Foreign-key constraint violation (SQLSTATE 23503). */
-class ForeignKeyViolationException(message: String, sqlState: String?, cause: Throwable? = null) :
+public class ForeignKeyViolationException(message: String, sqlState: String?, cause: Throwable? = null) :
     QueryException(message, sqlState, cause)
 
 /** NOT NULL constraint violation (SQLSTATE 23502). */
-class NotNullViolationException(message: String, sqlState: String?, cause: Throwable? = null) :
+public class NotNullViolationException(message: String, sqlState: String?, cause: Throwable? = null) :
     QueryException(message, sqlState, cause)
 
 /** CHECK constraint violation (SQLSTATE 23514). */
-class CheckViolationException(message: String, sqlState: String?, cause: Throwable? = null) :
+public class CheckViolationException(message: String, sqlState: String?, cause: Throwable? = null) :
     QueryException(message, sqlState, cause)
 
 /**
@@ -45,7 +45,7 @@ class CheckViolationException(message: String, sqlState: String?, cause: Throwab
  * backoff — is the application's, and the retried block must be idempotent outside the database since
  * it re-runs. See the retry recipe in `AGENTS.md` and [ADR 0007](../../docs/adr/0007-concurrency-conflict-exception.md).
  */
-class ConcurrencyConflictException(message: String, sqlState: String?, cause: Throwable? = null) :
+public class ConcurrencyConflictException(message: String, sqlState: String?, cause: Throwable? = null) :
     QueryException(message, sqlState, cause)
 
 /**
@@ -53,10 +53,10 @@ class ConcurrencyConflictException(message: String, sqlState: String?, cause: Th
  * declares non-null came back as SQL `NULL` (a schema mismatch or a bad row). The message names
  * the table and column so the offending row/schema is easy to find.
  */
-class ResultMappingException(message: String, cause: Throwable? = null) : KormiumException(message, cause)
+public class ResultMappingException(message: String, cause: Throwable? = null) : KormiumException(message, cause)
 
 /** Maps a SQLSTATE to the most specific [QueryException] subtype. */
-fun sqlException(message: String, sqlState: String?, cause: Throwable? = null): QueryException = when (sqlState) {
+public fun sqlException(message: String, sqlState: String?, cause: Throwable? = null): QueryException = when (sqlState) {
     "23505" -> UniqueViolationException(message, sqlState, cause)
     "23503" -> ForeignKeyViolationException(message, sqlState, cause)
     "23502" -> NotNullViolationException(message, sqlState, cause)

--- a/kormium-core/src/commonMain/kotlin/Exists.kt
+++ b/kormium-core/src/commonMain/kotlin/Exists.kt
@@ -5,7 +5,7 @@ package io.github.kormium
  * qualified by their table, so a reference to an outer column (`users.id`) correlates correctly
  * against an inner one (`orders.userId`). Built by [any] / [none].
  */
-class ExistsOp internal constructor(
+public class ExistsOp internal constructor(
     private val table: Table<*, *>,
     private val predicate: Expression,
     private val negated: Boolean,
@@ -26,7 +26,7 @@ class ExistsOp internal constructor(
  * Users.find { where { Orders.any { (Orders.userId eq Users.id) and (Orders.total gt 100) } } }
  * ```
  */
-fun <T : Entity> Table<*, T>.any(predicate: () -> Expression): Expression = ExistsOp(this, predicate(), negated = false)
+public fun <T : Entity> Table<*, T>.any(predicate: () -> Expression): Expression = ExistsOp(this, predicate(), negated = false)
 
 /**
  * `NOT EXISTS (SELECT 1 FROM this WHERE …)` — true when no row of this table matches the
@@ -36,4 +36,4 @@ fun <T : Entity> Table<*, T>.any(predicate: () -> Expression): Expression = Exis
  * Users.find { where { Orders.none { Orders.userId eq Users.id } } }   // users with no orders
  * ```
  */
-fun <T : Entity> Table<*, T>.none(predicate: () -> Expression): Expression = ExistsOp(this, predicate(), negated = true)
+public fun <T : Entity> Table<*, T>.none(predicate: () -> Expression): Expression = ExistsOp(this, predicate(), negated = true)

--- a/kormium-core/src/commonMain/kotlin/Expression.kt
+++ b/kormium-core/src/commonMain/kotlin/Expression.kt
@@ -15,28 +15,28 @@ import kotlin.uuid.Uuid
  * quoting and placeholder rendering are delegated to [dialect]; value conversion
  * to [typeMapper].
  */
-class ParamBuilder private constructor(
-    val dialect: Dialect,
+public class ParamBuilder private constructor(
+    public val dialect: Dialect,
     private val typeMapper: TypeMapper?,
     private val keyMode: Boolean,
     qualifyColumns: Boolean,
 ) {
     /** The normal builder: binds values as real parameters through [typeMapper]. */
-    constructor(dialect: Dialect, typeMapper: TypeMapper, qualifyColumns: Boolean = false) :
+    public constructor(dialect: Dialect, typeMapper: TypeMapper, qualifyColumns: Boolean = false) :
         this(dialect, typeMapper, keyMode = false, qualifyColumns = qualifyColumns)
 
     /** When true, a [Column] renders as `"table"."col"` (needed to disambiguate joins / subqueries). */
-    var qualifyColumns: Boolean = qualifyColumns
+    public var qualifyColumns: Boolean = qualifyColumns
         private set
 
     private var counter = 0
     private val collected = LinkedHashMap<String, Any?>()
 
     /** The bind values gathered so far, keyed by their generated placeholder name. */
-    val params: Map<String, Any?> get() = collected
+    public val params: Map<String, Any?> get() = collected
 
     /** Registers [value] as a bind parameter and returns the placeholder to embed in the SQL. */
-    fun bind(value: Any?): String {
+    public fun bind(value: Any?): String {
         // Key mode inlines the literal instead of binding it (and never touches the type mapper),
         // so an expression can render a stable structural key that distinguishes its literals.
         if (keyMode) return "lit($value)"
@@ -60,7 +60,7 @@ class ParamBuilder private constructor(
         }
     }
 
-    companion object {
+    public companion object {
         // A builder that inlines literals instead of binding them, used to derive an expression's
         // structural result key (see CaseOp) — never executed, so the dialect only needs to be
         // deterministic (any fixed one), and no type mapper is required.
@@ -76,12 +76,12 @@ class ParamBuilder private constructor(
  * verbatim [RawExpression]. [toSql] registers any compared values as bind parameters on the builder
  * rather than inlining them.
  */
-interface Expression {
-    fun toSql(builder: ParamBuilder): String
+public interface Expression {
+    public fun toSql(builder: ParamBuilder): String
 }
 
 /** A bound literal value: renders as a bind-parameter placeholder, never inlined into the SQL. */
-class Value(internal val value: Any?) : Expression {
+public class Value(internal val value: Any?) : Expression {
     override fun toSql(builder: ParamBuilder): String = builder.bind(value)
 }
 
@@ -101,7 +101,7 @@ internal fun structuralKey(expr: Expression): Any = when (expr) {
  * fully control.
  */
 @DelicateKormiumApi
-class RawExpression(val expression: String) : Expression {
+public class RawExpression(public val expression: String) : Expression {
     override fun toSql(builder: ParamBuilder): String = expression
 }
 
@@ -126,14 +126,14 @@ internal sealed class CompoundBooleanOp(
 
 internal class AndOp(first: Expression, second: Expression) : CompoundBooleanOp(" AND ", first, second)
 
-infix fun <T : Expression, T2 : Expression> T.and(other: T2): Expression = AndOp(this, other)
+public infix fun <T : Expression, T2 : Expression> T.and(other: T2): Expression = AndOp(this, other)
 
 /**
  * Represents a logical operator that performs an `or` operation between all the specified [expressions].
  */
 internal class OrOp(first: Expression, second: Expression) : CompoundBooleanOp(" OR ", first, second)
 
-infix fun <T : Expression, T2 : Expression> T.or(other: T2): Expression = OrOp(this, other)
+public infix fun <T : Expression, T2 : Expression> T.or(other: T2): Expression = OrOp(this, other)
 
 
 internal abstract class ComparisonOp(
@@ -154,44 +154,44 @@ internal abstract class ComparisonOp(
 
 internal class EqOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "=")
 
-infix fun <T : Expression, T2 : Expression> T.eq(other: T2): Expression = EqOp(this, other)
+public infix fun <T : Expression, T2 : Expression> T.eq(other: T2): Expression = EqOp(this, other)
 
 /** Checks that the operands are not equal. */
 internal class NeqOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "<>")
 
-infix fun <T : Expression, T2 : Expression> T.neq(other: T2): Expression = NeqOp(this, other)
+public infix fun <T : Expression, T2 : Expression> T.neq(other: T2): Expression = NeqOp(this, other)
 
 /** Checks that the left operand is less than the right. */
 internal class LessOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "<")
 
-infix fun <T : Expression, T2 : Expression> T.lt(other: T2): Expression = LessOp(this, other)
+public infix fun <T : Expression, T2 : Expression> T.lt(other: T2): Expression = LessOp(this, other)
 
 /** Checks that the left operand is less than or equal to the right. */
 internal class LessEqOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, "<=")
 
-infix fun <T : Expression, T2 : Expression> T.ltEq(other: T2): Expression = LessEqOp(this, other)
+public infix fun <T : Expression, T2 : Expression> T.ltEq(other: T2): Expression = LessEqOp(this, other)
 
 /** Checks that the left operand is greater than the right. */
 internal class GreaterOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, ">")
 
-infix fun <T : Expression, T2 : Expression> T.gt(other: T2): Expression = GreaterOp(this, other)
+public infix fun <T : Expression, T2 : Expression> T.gt(other: T2): Expression = GreaterOp(this, other)
 
 /** Checks that the left operand is greater than or equal to the right. */
 internal class GreaterEqOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1, expr2, ">=")
 
-infix fun <T : Expression, T2 : Expression> T.gtEq(other: T2): Expression = GreaterEqOp(this, other)
+public infix fun <T : Expression, T2 : Expression> T.gtEq(other: T2): Expression = GreaterEqOp(this, other)
 
 // The typed-value forms of the comparison and membership operators are defined ONCE over [Operand]
 // (a [Selectable] that carries its [ColumnType] — a Column, aggregate, arithmetic, COALESCE, CASE or
 // string function), so every operand compares to a same-typed literal the same way, the literal binds
 // through the operand's column type, and a new operand type composes for free. Operand-to-operand and
 // column-to-column comparisons go through the generic `Expression` operators above.
-infix fun <Z> Operand<Z>.eq(value: Z): Expression = EqOp(this, columnType.lit(value))
-infix fun <Z> Operand<Z>.neq(value: Z): Expression = NeqOp(this, columnType.lit(value))
-infix fun <Z> Operand<Z>.lt(value: Z): Expression = LessOp(this, columnType.lit(value))
-infix fun <Z> Operand<Z>.ltEq(value: Z): Expression = LessEqOp(this, columnType.lit(value))
-infix fun <Z> Operand<Z>.gt(value: Z): Expression = GreaterOp(this, columnType.lit(value))
-infix fun <Z> Operand<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, columnType.lit(value))
+public infix fun <Z> Operand<Z>.eq(value: Z): Expression = EqOp(this, columnType.lit(value))
+public infix fun <Z> Operand<Z>.neq(value: Z): Expression = NeqOp(this, columnType.lit(value))
+public infix fun <Z> Operand<Z>.lt(value: Z): Expression = LessOp(this, columnType.lit(value))
+public infix fun <Z> Operand<Z>.ltEq(value: Z): Expression = LessEqOp(this, columnType.lit(value))
+public infix fun <Z> Operand<Z>.gt(value: Z): Expression = GreaterOp(this, columnType.lit(value))
+public infix fun <Z> Operand<Z>.gtEq(value: Z): Expression = GreaterEqOp(this, columnType.lit(value))
 
 /** `column IN (v1, v2, ...)`. An empty list renders to `FALSE` (matches nothing). */
 internal class InListOp(private val column: Expression, private val values: List<*>) : Expression {
@@ -200,7 +200,7 @@ internal class InListOp(private val column: Expression, private val values: List
         else "${column.toSql(builder)} IN (${values.joinToString(", ") { builder.bind(it) }})"
 }
 
-infix fun <Z> Operand<Z>.inList(values: List<Z>): Expression = InListOp(this, values.map { columnType.lit(it).value })
+public infix fun <Z> Operand<Z>.inList(values: List<Z>): Expression = InListOp(this, values.map { columnType.lit(it).value })
 
 /** The SQL `FALSE` literal — what a predicate over an empty set (`inList`, `between`) renders to. */
 internal object FalseExpression : Expression {
@@ -217,7 +217,7 @@ internal class BetweenOp(private val expr: Expression, private val low: Expressi
 // admits exactly the orderable types (numbers, dates, text) and rejects Json/Bytes/Uuid at compile
 // time, where BETWEEN is meaningless. A reversed/empty range (lo > hi) renders to FALSE, like an
 // empty `inList`. Bounds bind through the operand's column type, as in `eq` / `gtEq`.
-infix fun <Z : Comparable<Z>> Operand<Z>.between(range: ClosedRange<Z>): Expression =
+public infix fun <Z : Comparable<Z>> Operand<Z>.between(range: ClosedRange<Z>): Expression =
     if (range.isEmpty()) FalseExpression
     else BetweenOp(this, columnType.lit(range.start), columnType.lit(range.endInclusive))
 
@@ -227,8 +227,8 @@ internal class LikeOp(expr1: Expression, expr2: Expression) : ComparisonOp(expr1
 // `like` has no generic Expression form, so both the literal-pattern and operand-to-operand forms
 // live here. A bare string comparison follows the engine collation (see docs) — wrap both sides in
 // `lower()` for deterministic case folding.
-infix fun Operand<String>.like(pattern: String): Expression = LikeOp(this, Value(pattern))
-infix fun Operand<String>.like(other: Operand<String>): Expression = LikeOp(this, other)
+public infix fun Operand<String>.like(pattern: String): Expression = LikeOp(this, Value(pattern))
+public infix fun Operand<String>.like(other: Operand<String>): Expression = LikeOp(this, other)
 
 /** `column IS NULL` / `column IS NOT NULL`. */
 internal class IsNullOp(private val column: Expression, private val negated: Boolean) : Expression {
@@ -239,8 +239,8 @@ internal class IsNullOp(private val column: Expression, private val negated: Boo
 // `IS [NOT] NULL` on any operand — a column or a computed expression (`COALESCE` of nullable columns,
 // a `CASE`, an aggregate, …). This is the general form; nullable columns also get the `eq null` sugar
 // below. (A non-null column's `.isNull()` is allowed but always false — use it on the nullable ones.)
-fun Operand<*>.isNull(): Expression = IsNullOp(this, false)
-fun Operand<*>.isNotNull(): Expression = IsNullOp(this, true)
+public fun Operand<*>.isNull(): Expression = IsNullOp(this, false)
+public fun Operand<*>.isNotNull(): Expression = IsNullOp(this, true)
 
 // `column eq null` / `column neq null` render as IS [NOT] NULL. The `Nothing?` parameter makes the
 // null literal bind here instead of the typed `eq(value: Z)` overload, so the comparison vocabulary
@@ -248,8 +248,8 @@ fun Operand<*>.isNotNull(): Expression = IsNullOp(this, true)
 // column is never NULL, so `eq null` on one is a bug — and keeping this overload off non-null columns
 // means a typed mismatch (`age eq "x"`) reports against the real `eq(value: Z)` candidate ("Int
 // expected") instead of this one ("Nothing? expected"). A computed nullable expression uses `.isNull()`.
-infix fun Column.NullableColumn<*, *, *>.eq(value: Nothing?): Expression = IsNullOp(this, false)
-infix fun Column.NullableColumn<*, *, *>.neq(value: Nothing?): Expression = IsNullOp(this, true)
+public infix fun Column.NullableColumn<*, *, *>.eq(value: Nothing?): Expression = IsNullOp(this, false)
+public infix fun Column.NullableColumn<*, *, *>.neq(value: Nothing?): Expression = IsNullOp(this, true)
 
 /**
  * A typed SQL operand: a [Selectable] that knows the [ColumnType] of the value it yields. Every
@@ -258,8 +258,8 @@ infix fun Column.NullableColumn<*, *, *>.neq(value: Nothing?): Expression = IsNu
  * defined once over `Operand<Z>` instead of per type, and reading a row defaults to the column type.
  * Carrying [columnType] also lets a compared literal bind through the originating column's converter.
  */
-interface Operand<Z> : Selectable<Z> {
-    val columnType: ColumnType<Z>
+public interface Operand<Z> : Selectable<Z> {
+    public val columnType: ColumnType<Z>
     override fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z? = columnType.read(rs, index)
 }
 
@@ -267,7 +267,7 @@ interface Operand<Z> : Selectable<Z> {
  * A typed numeric operand: every arithmetic result is itself a [NumericExpr] of the same type [Z],
  * so expressions chain and nest while staying type-checked (`(base + bonus) * 2`).
  */
-interface NumericExpr<Z> : Operand<Z>
+public interface NumericExpr<Z> : Operand<Z>
 
 /**
  * Arithmetic node: renders `left op right`, binding any literal as a parameter. A nested
@@ -298,40 +298,40 @@ private fun <Z> ColumnType<Z>.lit(value: Z): Value = Value(if (value == null) nu
 // a same-typed literal `Z`, a same-typed `Column`, or another `NumericExpr<Z>`, and returns a
 // `NumericExpr<Z>`. So a wrong-typed operand is a compile error, and results nest (the left operand
 // always carries the result's column type). Usable in `WHERE` or an `update { }` `set`.
-operator fun <Z> Column<Z, *, *>.plus(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "+", columnType)
-operator fun <Z> Column<Z, *, *>.plus(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "+", columnType)
-operator fun <Z> Column<Z, *, *>.plus(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "+", columnType)
-operator fun <Z> NumericExpr<Z>.plus(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "+", columnType)
-operator fun <Z> NumericExpr<Z>.plus(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "+", columnType)
-operator fun <Z> NumericExpr<Z>.plus(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "+", columnType)
+public operator fun <Z> Column<Z, *, *>.plus(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "+", columnType)
+public operator fun <Z> Column<Z, *, *>.plus(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "+", columnType)
+public operator fun <Z> Column<Z, *, *>.plus(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "+", columnType)
+public operator fun <Z> NumericExpr<Z>.plus(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "+", columnType)
+public operator fun <Z> NumericExpr<Z>.plus(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "+", columnType)
+public operator fun <Z> NumericExpr<Z>.plus(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "+", columnType)
 
-operator fun <Z> Column<Z, *, *>.minus(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "-", columnType)
-operator fun <Z> Column<Z, *, *>.minus(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "-", columnType)
-operator fun <Z> Column<Z, *, *>.minus(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "-", columnType)
-operator fun <Z> NumericExpr<Z>.minus(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "-", columnType)
-operator fun <Z> NumericExpr<Z>.minus(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "-", columnType)
-operator fun <Z> NumericExpr<Z>.minus(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "-", columnType)
+public operator fun <Z> Column<Z, *, *>.minus(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "-", columnType)
+public operator fun <Z> Column<Z, *, *>.minus(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "-", columnType)
+public operator fun <Z> Column<Z, *, *>.minus(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "-", columnType)
+public operator fun <Z> NumericExpr<Z>.minus(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "-", columnType)
+public operator fun <Z> NumericExpr<Z>.minus(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "-", columnType)
+public operator fun <Z> NumericExpr<Z>.minus(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "-", columnType)
 
-operator fun <Z> Column<Z, *, *>.times(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "*", columnType)
-operator fun <Z> Column<Z, *, *>.times(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "*", columnType)
-operator fun <Z> Column<Z, *, *>.times(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "*", columnType)
-operator fun <Z> NumericExpr<Z>.times(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "*", columnType)
-operator fun <Z> NumericExpr<Z>.times(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "*", columnType)
-operator fun <Z> NumericExpr<Z>.times(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "*", columnType)
+public operator fun <Z> Column<Z, *, *>.times(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "*", columnType)
+public operator fun <Z> Column<Z, *, *>.times(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "*", columnType)
+public operator fun <Z> Column<Z, *, *>.times(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "*", columnType)
+public operator fun <Z> NumericExpr<Z>.times(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "*", columnType)
+public operator fun <Z> NumericExpr<Z>.times(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "*", columnType)
+public operator fun <Z> NumericExpr<Z>.times(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "*", columnType)
 
-operator fun <Z> Column<Z, *, *>.div(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "/", columnType)
-operator fun <Z> Column<Z, *, *>.div(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "/", columnType)
-operator fun <Z> Column<Z, *, *>.div(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "/", columnType)
-operator fun <Z> NumericExpr<Z>.div(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "/", columnType)
-operator fun <Z> NumericExpr<Z>.div(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "/", columnType)
-operator fun <Z> NumericExpr<Z>.div(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "/", columnType)
+public operator fun <Z> Column<Z, *, *>.div(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "/", columnType)
+public operator fun <Z> Column<Z, *, *>.div(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "/", columnType)
+public operator fun <Z> Column<Z, *, *>.div(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "/", columnType)
+public operator fun <Z> NumericExpr<Z>.div(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "/", columnType)
+public operator fun <Z> NumericExpr<Z>.div(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "/", columnType)
+public operator fun <Z> NumericExpr<Z>.div(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "/", columnType)
 
-operator fun <Z> Column<Z, *, *>.rem(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "%", columnType)
-operator fun <Z> Column<Z, *, *>.rem(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
-operator fun <Z> Column<Z, *, *>.rem(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
-operator fun <Z> NumericExpr<Z>.rem(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "%", columnType)
-operator fun <Z> NumericExpr<Z>.rem(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
-operator fun <Z> NumericExpr<Z>.rem(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
+public operator fun <Z> Column<Z, *, *>.rem(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "%", columnType)
+public operator fun <Z> Column<Z, *, *>.rem(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
+public operator fun <Z> Column<Z, *, *>.rem(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
+public operator fun <Z> NumericExpr<Z>.rem(value: Z): NumericExpr<Z> = ArithmeticOp(this, columnType.lit(value), "%", columnType)
+public operator fun <Z> NumericExpr<Z>.rem(other: Column<Z, *, *>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
+public operator fun <Z> NumericExpr<Z>.rem(other: NumericExpr<Z>): NumericExpr<Z> = ArithmeticOp(this, other, "%", columnType)
 
 /**
  * A typed string-valued SQL expression. A string [Column] yields one via the scalar functions
@@ -341,7 +341,7 @@ operator fun <Z> NumericExpr<Z>.rem(other: NumericExpr<Z>): NumericExpr<Z> = Ari
  * `lt` / `ltEq` against a `String` literal, or — through the generic expression operators —
  * against another [StringExpr] (`a.lower() eq b.lower()`).
  */
-interface StringExpr : Operand<String> {
+public interface StringExpr : Operand<String> {
     override val columnType: ColumnType<String> get() = TextColumnType
 }
 
@@ -359,16 +359,16 @@ internal class StringFunction(private val fn: String, private val args: List<Exp
 // Scalar string functions, defined on both Column<String> and StringExpr so they chain like the
 // arithmetic operators do. LOWER/UPPER/TRIM/LTRIM/RTRIM are standard and render identically on
 // PostgreSQL, MySQL and SQLite, so no dialect hook is needed.
-fun Column<String, *, *>.lower(): StringExpr = StringFunction("LOWER", listOf(this))
-fun StringExpr.lower(): StringExpr = StringFunction("LOWER", listOf(this))
-fun Column<String, *, *>.upper(): StringExpr = StringFunction("UPPER", listOf(this))
-fun StringExpr.upper(): StringExpr = StringFunction("UPPER", listOf(this))
-fun Column<String, *, *>.trim(): StringExpr = StringFunction("TRIM", listOf(this))
-fun StringExpr.trim(): StringExpr = StringFunction("TRIM", listOf(this))
-fun Column<String, *, *>.ltrim(): StringExpr = StringFunction("LTRIM", listOf(this))
-fun StringExpr.ltrim(): StringExpr = StringFunction("LTRIM", listOf(this))
-fun Column<String, *, *>.rtrim(): StringExpr = StringFunction("RTRIM", listOf(this))
-fun StringExpr.rtrim(): StringExpr = StringFunction("RTRIM", listOf(this))
+public fun Column<String, *, *>.lower(): StringExpr = StringFunction("LOWER", listOf(this))
+public fun StringExpr.lower(): StringExpr = StringFunction("LOWER", listOf(this))
+public fun Column<String, *, *>.upper(): StringExpr = StringFunction("UPPER", listOf(this))
+public fun StringExpr.upper(): StringExpr = StringFunction("UPPER", listOf(this))
+public fun Column<String, *, *>.trim(): StringExpr = StringFunction("TRIM", listOf(this))
+public fun StringExpr.trim(): StringExpr = StringFunction("TRIM", listOf(this))
+public fun Column<String, *, *>.ltrim(): StringExpr = StringFunction("LTRIM", listOf(this))
+public fun StringExpr.ltrim(): StringExpr = StringFunction("LTRIM", listOf(this))
+public fun Column<String, *, *>.rtrim(): StringExpr = StringFunction("RTRIM", listOf(this))
+public fun StringExpr.rtrim(): StringExpr = StringFunction("RTRIM", listOf(this))
 
 /**
  * The number of **characters** in a string, as an `Int` (a [NumericExpr], so it compares, does
@@ -381,8 +381,8 @@ internal class LengthOp(private val arg: Expression) : NumericExpr<Int> {
     override fun resultKey(): Any = "CHAR_LENGTH(${structuralKey(arg)})"
 }
 
-fun Column<String, *, *>.length(): NumericExpr<Int> = LengthOp(this)
-fun StringExpr.length(): NumericExpr<Int> = LengthOp(this)
+public fun Column<String, *, *>.length(): NumericExpr<Int> = LengthOp(this)
+public fun StringExpr.length(): NumericExpr<Int> = LengthOp(this)
 
 /**
  * `COALESCE(a, b, ...)` — the first non-null argument. It is a [Selectable] (readable from a
@@ -392,7 +392,7 @@ fun StringExpr.length(): NumericExpr<Int> = LengthOp(this)
  * value is non-null when the last argument is (e.g. a literal default), so `row[...]` is safe then;
  * otherwise read it with `getOrNull`.
  */
-class CoalesceOp<Z> internal constructor(
+public class CoalesceOp<Z> internal constructor(
     internal val args: List<Expression>,
     override val columnType: ColumnType<Z>,
 ) : Operand<Z> {
@@ -401,18 +401,18 @@ class CoalesceOp<Z> internal constructor(
 }
 
 /** `COALESCE("col", default)` — read a nullable column with a fallback; the default binds through the column's converter. */
-fun <Z> Column<Z, *, *>.coalesce(default: Z): CoalesceOp<Z> = CoalesceOp(listOf(this, Value(bindParam(default))), columnType)
+public fun <Z> Column<Z, *, *>.coalesce(default: Z): CoalesceOp<Z> = CoalesceOp(listOf(this, Value(bindParam(default))), columnType)
 
 /** `COALESCE("col", "c2", "c3", ...)` — the first non-null of this column and the [others], in order. */
-fun <Z> Column<Z, *, *>.coalesce(vararg others: Column<Z, *, *>): CoalesceOp<Z> =
+public fun <Z> Column<Z, *, *>.coalesce(vararg others: Column<Z, *, *>): CoalesceOp<Z> =
     CoalesceOp(listOf(this, *others), columnType)
 
 /** Extends a `COALESCE` with more columns: `a.coalesce(b).coalesce(c, d)` → `COALESCE(a, b, c, d)`. */
-fun <Z> CoalesceOp<Z>.coalesce(vararg others: Column<Z, *, *>): CoalesceOp<Z> =
+public fun <Z> CoalesceOp<Z>.coalesce(vararg others: Column<Z, *, *>): CoalesceOp<Z> =
     CoalesceOp(args + others, columnType)
 
 /** Appends a literal fallback to a `COALESCE`, typically last: `a.coalesce(b).coalesce("default")`. */
-fun <Z> CoalesceOp<Z>.coalesce(default: Z): CoalesceOp<Z> =
+public fun <Z> CoalesceOp<Z>.coalesce(default: Z): CoalesceOp<Z> =
     CoalesceOp(args + columnType.lit(default), columnType)
 
 /**
@@ -422,7 +422,7 @@ fun <Z> CoalesceOp<Z>.coalesce(default: Z): CoalesceOp<Z> =
  * identical `case { … }` reads back from a row — a `val` is handy for reuse, not required. Compare
  * it to a typed literal with the operators below, or to another expression through the generic ones.
  */
-class CaseOp<Z> internal constructor(
+public class CaseOp<Z> internal constructor(
     private val branches: List<Pair<Expression, Expression>>,
     private val elseValue: Expression?,
     override val columnType: ColumnType<Z>,
@@ -440,19 +440,19 @@ class CaseOp<Z> internal constructor(
 }
 
 /** Builds the branches of a [case]. `whenever(cond) then value` adds a branch; `otherwise(value)` sets the ELSE. */
-class CaseBuilder<Z> internal constructor(private val columnType: ColumnType<Z>) {
+public class CaseBuilder<Z> internal constructor(private val columnType: ColumnType<Z>) {
     internal val branches = mutableListOf<Pair<Expression, Expression>>()
     internal var elseValue: Expression? = null
 
-    fun whenever(condition: Expression): WhenStep = WhenStep(condition)
+    public fun whenever(condition: Expression): WhenStep = WhenStep(condition)
 
-    inner class WhenStep internal constructor(private val condition: Expression) {
-        infix fun then(value: Z) {
+    public inner class WhenStep internal constructor(private val condition: Expression) {
+        public infix fun then(value: Z) {
             branches += condition to columnType.lit(value)
         }
     }
 
-    fun otherwise(value: Z) {
+    public fun otherwise(value: Z) {
         elseValue = columnType.lit(value)
     }
 }
@@ -462,7 +462,7 @@ class CaseBuilder<Z> internal constructor(private val columnType: ColumnType<Z>)
  * types, where the reader cannot be inferred from [Z]:
  * `case(StatusColumnType) { whenever(...) then Status.ACTIVE; otherwise Status.INACTIVE }`.
  */
-fun <Z> case(columnType: ColumnType<Z>, block: CaseBuilder<Z>.() -> Unit): CaseOp<Z> {
+public fun <Z> case(columnType: ColumnType<Z>, block: CaseBuilder<Z>.() -> Unit): CaseOp<Z> {
     val builder = CaseBuilder(columnType).apply(block)
     require(builder.branches.isNotEmpty()) { "case { } needs at least one `whenever(...) then ...`" }
     return CaseOp(builder.branches, builder.elseValue, columnType)
@@ -482,7 +482,7 @@ fun <Z> case(columnType: ColumnType<Z>, block: CaseBuilder<Z>.() -> Unit): CaseO
  *
  * For an enum or other custom-mapped result, use the [case] overload that takes a `ColumnType`.
  */
-inline fun <reified Z> case(noinline block: CaseBuilder<Z>.() -> Unit): CaseOp<Z> {
+public inline fun <reified Z> case(noinline block: CaseBuilder<Z>.() -> Unit): CaseOp<Z> {
     @Suppress("UNCHECKED_CAST")
     val columnType = when (Z::class) {
         String::class -> TextColumnType
@@ -515,4 +515,4 @@ internal class NotOp(private val expr: Expression) : Expression {
     override fun toSql(builder: ParamBuilder): String = "NOT (${expr.toSql(builder)})"
 }
 
-fun not(expr: Expression): Expression = NotOp(expr)
+public fun not(expr: Expression): Expression = NotOp(expr)

--- a/kormium-core/src/commonMain/kotlin/Join.kt
+++ b/kormium-core/src/commonMain/kotlin/Join.kt
@@ -8,9 +8,9 @@ import io.github.kormium.resultset.ResultSet
  * is the SELECT-list SQL), so aggregates can be used in `having(...)`. [Z] is the value
  * type read.
  */
-interface Selectable<Z> : Expression {
+public interface Selectable<Z> : Expression {
     /** Reads this field's value from the result row at [index]. */
-    fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z?
+    public fun read(rs: ResultSet, index: Int, typeMapper: TypeMapper): Z?
 
     /**
      * A stable, structural key identifying this field in a [ResultRow] — independent of the
@@ -18,7 +18,7 @@ interface Selectable<Z> : Expression {
      * can be read with a freshly built field (`row[Orders.total.sum()]`) without hoisting it into
      * a `val`. Columns key by `table.name`; aggregates by their function over their target's key.
      */
-    fun resultKey(): Any
+    public fun resultKey(): Any
 }
 
 internal enum class JoinType(val sql: String) { INNER("INNER JOIN"), LEFT("LEFT JOIN") }
@@ -31,7 +31,7 @@ internal class JoinClause<G : Catalog>(val type: JoinType, val table: Table<G, *
  * from two tables ([JoinPair]) can also be read as entity pairs with `find()`. Supports
  * `where`, `groupBy`, `having` and `distinct`.
  */
-class Join<G : Catalog> internal constructor(
+public class Join<G : Catalog> internal constructor(
     internal val base: Table<G, *>,
     internal val clauses: List<JoinClause<G>>,
     internal val whereExpr: Expression?,
@@ -51,31 +51,31 @@ class Join<G : Catalog> internal constructor(
     ) = Join(base, clauses, whereExpr, groupByCols, havingExpr, distinct)
 
     /** Restricts the joined rows; combined with AND if called more than once. */
-    fun where(condition: Expression): Join<G> = copy(whereExpr = whereExpr?.let { it and condition } ?: condition)
+    public fun where(condition: Expression): Join<G> = copy(whereExpr = whereExpr?.let { it and condition } ?: condition)
 
     /** Groups rows by [columns] (for use with aggregates). */
-    fun groupBy(vararg columns: Column<*, *, *>): Join<G> = copy(groupByCols = groupByCols + columns)
+    public fun groupBy(vararg columns: Column<*, *, *>): Join<G> = copy(groupByCols = groupByCols + columns)
 
     /** Filters groups (combined with AND if called more than once). */
-    fun having(condition: Expression): Join<G> = copy(havingExpr = havingExpr?.let { it and condition } ?: condition)
+    public fun having(condition: Expression): Join<G> = copy(havingExpr = havingExpr?.let { it and condition } ?: condition)
 
     /** Selects distinct rows. */
-    fun distinct(): Join<G> = copy(distinct = true)
+    public fun distinct(): Join<G> = copy(distinct = true)
 
-    infix fun innerJoin(other: Table<G, *>): JoinStep<G> = JoinStep(this, JoinType.INNER, other)
-    infix fun leftJoin(other: Table<G, *>): JoinStep<G> = JoinStep(this, JoinType.LEFT, other)
+    public infix fun innerJoin(other: Table<G, *>): JoinStep<G> = JoinStep(this, JoinType.INNER, other)
+    public infix fun leftJoin(other: Table<G, *>): JoinStep<G> = JoinStep(this, JoinType.LEFT, other)
 }
 
 /** Starts a query over a single table (for aggregates / grouping / distinct). */
-fun <G : Catalog> Table<G, *>.query(): Join<G> = Join(this, emptyList(), null)
+public fun <G : Catalog> Table<G, *>.query(): Join<G> = Join(this, emptyList(), null)
 
 /** A pending (erased) join awaiting its ON condition. */
-class JoinStep<G : Catalog> internal constructor(
+public class JoinStep<G : Catalog> internal constructor(
     private val join: Join<G>,
     private val type: JoinType,
     private val table: Table<G, *>,
 ) {
-    infix fun on(condition: Expression): Join<G> =
+    public infix fun on(condition: Expression): Join<G> =
         Join(join.base, join.clauses + JoinClause(type, table, condition), join.whereExpr, join.groupByCols, join.havingExpr, join.distinct)
 }
 
@@ -84,23 +84,23 @@ class JoinStep<G : Catalog> internal constructor(
  * (`find()`) in addition to the `select(...)` forms. Joining a third table — or grouping —
  * degrades to an (erased) [Join] that supports only the `select(...)` forms.
  */
-class JoinPair<G : Catalog, A : Entity, B : Entity> internal constructor(
+public class JoinPair<G : Catalog, A : Entity, B : Entity> internal constructor(
     internal val left: Table<G, A>,
     internal val right: Table<G, B>,
     private val type: JoinType,
     private val on: Expression,
     internal val whereExpr: Expression?,
 ) {
-    fun where(condition: Expression): JoinPair<G, A, B> =
+    public fun where(condition: Expression): JoinPair<G, A, B> =
         JoinPair(left, right, type, on, whereExpr?.let { it and condition } ?: condition)
 
     internal fun asJoin(): Join<G> = Join(left, listOf(JoinClause(type, right, on)), whereExpr)
 
-    fun groupBy(vararg columns: Column<*, *, *>): Join<G> = asJoin().groupBy(*columns)
-    fun distinct(): Join<G> = asJoin().distinct()
+    public fun groupBy(vararg columns: Column<*, *, *>): Join<G> = asJoin().groupBy(*columns)
+    public fun distinct(): Join<G> = asJoin().distinct()
 
-    infix fun innerJoin(other: Table<G, *>): JoinStep<G> = asJoin().innerJoin(other)
-    infix fun leftJoin(other: Table<G, *>): JoinStep<G> = asJoin().leftJoin(other)
+    public infix fun innerJoin(other: Table<G, *>): JoinStep<G> = asJoin().innerJoin(other)
+    public infix fun leftJoin(other: Table<G, *>): JoinStep<G> = asJoin().leftJoin(other)
 }
 
 /**
@@ -109,53 +109,53 @@ class JoinPair<G : Catalog, A : Entity, B : Entity> internal constructor(
  * with no match. Joining a third table — or grouping — degrades to an (erased) [Join] that
  * supports only the `select(...)` forms.
  */
-class LeftJoinPair<G : Catalog, A : Entity, B : Entity> internal constructor(
+public class LeftJoinPair<G : Catalog, A : Entity, B : Entity> internal constructor(
     internal val left: Table<G, A>,
     internal val right: Table<G, B>,
     private val on: Expression,
     internal val whereExpr: Expression?,
 ) {
-    fun where(condition: Expression): LeftJoinPair<G, A, B> =
+    public fun where(condition: Expression): LeftJoinPair<G, A, B> =
         LeftJoinPair(left, right, on, whereExpr?.let { it and condition } ?: condition)
 
     internal fun asJoin(): Join<G> = Join(left, listOf(JoinClause(JoinType.LEFT, right, on)), whereExpr)
 
-    fun groupBy(vararg columns: Column<*, *, *>): Join<G> = asJoin().groupBy(*columns)
-    fun distinct(): Join<G> = asJoin().distinct()
+    public fun groupBy(vararg columns: Column<*, *, *>): Join<G> = asJoin().groupBy(*columns)
+    public fun distinct(): Join<G> = asJoin().distinct()
 
-    infix fun innerJoin(other: Table<G, *>): JoinStep<G> = asJoin().innerJoin(other)
-    infix fun leftJoin(other: Table<G, *>): JoinStep<G> = asJoin().leftJoin(other)
+    public infix fun innerJoin(other: Table<G, *>): JoinStep<G> = asJoin().innerJoin(other)
+    public infix fun leftJoin(other: Table<G, *>): JoinStep<G> = asJoin().leftJoin(other)
 }
 
 /** A two-table join awaiting its ON condition, keeping both entity types. */
-class JoinPairStep<G : Catalog, A : Entity, B : Entity> internal constructor(
+public class JoinPairStep<G : Catalog, A : Entity, B : Entity> internal constructor(
     private val left: Table<G, A>,
     private val right: Table<G, B>,
     private val type: JoinType,
 ) {
-    infix fun on(condition: Expression): JoinPair<G, A, B> = JoinPair(left, right, type, condition, null)
+    public infix fun on(condition: Expression): JoinPair<G, A, B> = JoinPair(left, right, type, condition, null)
 }
 
 /** A two-table LEFT join awaiting its ON condition, keeping both entity types. */
-class LeftJoinPairStep<G : Catalog, A : Entity, B : Entity> internal constructor(
+public class LeftJoinPairStep<G : Catalog, A : Entity, B : Entity> internal constructor(
     private val left: Table<G, A>,
     private val right: Table<G, B>,
 ) {
-    infix fun on(condition: Expression): LeftJoinPair<G, A, B> = LeftJoinPair(left, right, condition, null)
+    public infix fun on(condition: Expression): LeftJoinPair<G, A, B> = LeftJoinPair(left, right, condition, null)
 }
 
-infix fun <G : Catalog, A : Entity, B : Entity> Table<G, A>.innerJoin(other: Table<G, B>): JoinPairStep<G, A, B> =
+public infix fun <G : Catalog, A : Entity, B : Entity> Table<G, A>.innerJoin(other: Table<G, B>): JoinPairStep<G, A, B> =
     JoinPairStep(this, other, JoinType.INNER)
 
-infix fun <G : Catalog, A : Entity, B : Entity> Table<G, A>.leftJoin(other: Table<G, B>): LeftJoinPairStep<G, A, B> =
+public infix fun <G : Catalog, A : Entity, B : Entity> Table<G, A>.leftJoin(other: Table<G, B>): LeftJoinPairStep<G, A, B> =
     LeftJoinPairStep(this, other)
 
 /**
  * One row of a query result. Read fields by the [Selectable] you selected:
  * `row[Users.name]` / `row[total]` (throws if NULL/absent) or `row.getOrNull(...)`.
  */
-class ResultRow internal constructor(private val values: Map<Any, Any?>) {
-    operator fun <Z> get(field: Selectable<Z>): Z {
+public class ResultRow internal constructor(private val values: Map<Any, Any?>) {
+    public operator fun <Z> get(field: Selectable<Z>): Z {
         val key = fieldKey(field)
         if (key !in values) {
             error("Field '$key' was not selected in this projection — add it to select(...), or use getOrNull.")
@@ -165,7 +165,7 @@ class ResultRow internal constructor(private val values: Map<Any, Any?>) {
             ?: error("Selected field '$key' is NULL; use getOrNull for nullable fields.")
     }
 
-    fun <Z> getOrNull(field: Selectable<Z>): Z? {
+    public fun <Z> getOrNull(field: Selectable<Z>): Z? {
         @Suppress("UNCHECKED_CAST")
         return values[fieldKey(field)] as Z?
     }
@@ -187,7 +187,7 @@ class ResultRow internal constructor(private val values: Map<Any, Any?>) {
  * NULL); detect the unmatched case yourself, e.g. `row.getOrNull(Right.id) == null`. The
  * two-table `find()` does this for you and returns `Pair<A, B?>`.
  */
-fun <T : Entity> ResultRow.entity(table: Table<*, T>): T = table.hydrateFrom(this)
+public fun <T : Entity> ResultRow.entity(table: Table<*, T>): T = table.hydrateFrom(this)
 
 // Identifies a selected field by its structural key, so a row reads back regardless of which
 // instance is used — both a Column's property delegate and an aggregate factory yield a fresh

--- a/kormium-core/src/commonMain/kotlin/KormiumBuilder.kt
+++ b/kormium-core/src/commonMain/kotlin/KormiumBuilder.kt
@@ -7,9 +7,9 @@ import io.github.kormium.database.Database
  * config and produces a new one via `copy`, so adding a field to [KormiumConfig] only needs a
  * matching `var` here (no default is duplicated). See [KormiumBuilder.config].
  */
-class KormiumConfigBuilder internal constructor(private val base: KormiumConfig) {
+public class KormiumConfigBuilder internal constructor(private val base: KormiumConfig) {
     /** See [KormiumConfig.batchInsertMode]. */
-    var batchInsertMode: BatchInsertMode = base.batchInsertMode
+    public var batchInsertMode: BatchInsertMode = base.batchInsertMode
 
     internal fun build(): KormiumConfig = base.copy(
         batchInsertMode = batchInsertMode,
@@ -22,12 +22,12 @@ class KormiumConfigBuilder internal constructor(private val base: KormiumConfig)
  * is returned — the place to run migrations (the `kormium-migrate` module, or Flyway/Liquibase).
  * Migrations are intentionally NOT a built-in concern of this builder.
  */
-class KormiumBuilder {
+public class KormiumBuilder {
     private var config: KormiumConfig = KormiumConfig()
     private var beforeStart: (Database<Nothing>.() -> Unit)? = null
 
     /** Configures the [KormiumConfig] carried by the database. Calls accumulate. */
-    fun config(block: KormiumConfigBuilder.() -> Unit) {
+    public fun config(block: KormiumConfigBuilder.() -> Unit) {
         config = KormiumConfigBuilder(config).apply(block).build()
     }
 
@@ -38,7 +38,7 @@ class KormiumBuilder {
      * them here with your connection settings (they manage their own JDBC connection). Seed data
      * belongs in a migration, not here.
      */
-    fun beforeStart(block: Database<Nothing>.() -> Unit) {
+    public fun beforeStart(block: Database<Nothing>.() -> Unit) {
         beforeStart = block
     }
 
@@ -46,6 +46,6 @@ class KormiumBuilder {
      * Builds the database with [create] (passing the configured [KormiumConfig]), then runs the
      * [beforeStart] hook on it. Called by the `createX { }` factory overloads.
      */
-    fun <D : Database<Nothing>> finish(create: (KormiumConfig) -> D): D =
+    public fun <D : Database<Nothing>> finish(create: (KormiumConfig) -> D): D =
         create(config).also { driver -> beforeStart?.invoke(driver) }
 }

--- a/kormium-core/src/commonMain/kotlin/KormiumConfig.kt
+++ b/kormium-core/src/commonMain/kotlin/KormiumConfig.kt
@@ -4,7 +4,7 @@ package io.github.kormium
  * How [insertAll] handles a batch whose entities do not all have the same set of assigned
  * fields (their "shape" — the ordered set of present fields).
  */
-enum class BatchInsertMode {
+public enum class BatchInsertMode {
     /** All entities must share one shape; otherwise [insertAll] fails fast. Most explicit. */
     Strict,
 
@@ -28,7 +28,7 @@ enum class BatchInsertMode {
  * Per-database Kormium configuration, supplied to the `createDatabase` / `createSqliteDatabase` /
  * `createR2dbcDatabase` factories and carried on the resulting database handle.
  */
-data class KormiumConfig(
+public data class KormiumConfig(
     /** Default [BatchInsertMode] for [insertAll] when no per-call override is given. */
     val batchInsertMode: BatchInsertMode = BatchInsertMode.GroupByAssignedFields,
 

--- a/kormium-core/src/commonMain/kotlin/KormiumDsl.kt
+++ b/kormium-core/src/commonMain/kotlin/KormiumDsl.kt
@@ -20,4 +20,4 @@ package io.github.kormium
  * `this@transaction` qualifier.
  */
 @DslMarker
-annotation class KormiumDsl
+public annotation class KormiumDsl

--- a/kormium-core/src/commonMain/kotlin/NotificationTransport.kt
+++ b/kormium-core/src/commonMain/kotlin/NotificationTransport.kt
@@ -20,20 +20,20 @@ import kotlinx.coroutines.launch
  * SINGLE suspend shape (not a blocking/suspend pair): the sync-vs-suspend bridging is handled
  * by [connectNotifications], so an implementer writes exactly one version.
  */
-interface NotificationTransport {
+public interface NotificationTransport {
     /**
      * Publishes the table names a local commit just wrote. `suspend` so coroutine-based clients
      * (rethis, r2dbc) are idiomatic; [connectNotifications] invokes this fire-and-forget on a
      * background scope, so it never blocks the committing thread. Delivery is best-effort.
      */
-    suspend fun publish(tables: Set<String>)
+    public suspend fun publish(tables: Set<String>)
 
     /**
      * A cold [Flow] of remote change signals: each element is the set of tables some OTHER
      * instance committed. [connectNotifications] collects it on a background coroutine and feeds
      * each element into the local write-notification registry.
      */
-    fun subscribe(): Flow<Set<String>>
+    public fun subscribe(): Flow<Set<String>>
 }
 
 /**
@@ -60,13 +60,13 @@ interface NotificationTransport {
  * interoperate. Table-granular and tiny (well within Postgres NOTIFY's ~8KB payload). Table names
  * don't contain commas in practice; [decodeTablePayload] drops blanks defensively.
  */
-fun encodeTablePayload(tables: Set<String>): String = tables.joinToString(",")
+public fun encodeTablePayload(tables: Set<String>): String = tables.joinToString(",")
 
 /** Inverse of [encodeTablePayload]. */
-fun decodeTablePayload(payload: String): Set<String> =
+public fun decodeTablePayload(payload: String): Set<String> =
     payload.split(",").filter { it.isNotEmpty() }.toSet()
 
-fun <G : Catalog> SuspendDatabase<G>.connectNotifications(transport: NotificationTransport): Registration {
+public fun <G : Catalog> SuspendDatabase<G>.connectNotifications(transport: NotificationTransport): Registration {
     val listeners = writeListeners
     // Errors are swallowed (best-effort delivery); a real deployment relies on a cache TTL as the
     // safety net for dropped notifications. See the cross-instance-cache sample README.

--- a/kormium-core/src/commonMain/kotlin/Query.kt
+++ b/kormium-core/src/commonMain/kotlin/Query.kt
@@ -1,7 +1,7 @@
 package io.github.kormium
 
 
-data class Query(
+public data class Query(
     val whereExpression: Expression? = null,
     val limit: UInt = UInt.MAX_VALUE,
     val offset: UInt = 0u,
@@ -12,7 +12,7 @@ data class Query(
      * bind parameters on [builder] instead of inlining them. Identifier quoting and
      * LIMIT/OFFSET rendering go through the builder's [Dialect].
      */
-    fun toSql(builder: ParamBuilder): String {
+    public fun toSql(builder: ParamBuilder): String {
         val whereStr = whereExpression?.let { "WHERE ${it.toSql(builder)} " } ?: ""
         val orderByStr = orderBy?.let { "ORDER BY ${prepareOrderBy(it, builder)} " } ?: ""
         val limitOffsetStr = builder.dialect.renderLimitOffset(limit, offset)
@@ -25,7 +25,7 @@ data class Query(
      * skip the single aggregate row and read as 0), and `UPDATE` / `DELETE` (plain mutation
      * statements don't take `ORDER BY` / `LIMIT` / `OFFSET` in Postgres).
      */
-    fun toWhereSql(builder: ParamBuilder): String =
+    public fun toWhereSql(builder: ParamBuilder): String =
         whereExpression?.let { "WHERE ${it.toSql(builder)} " } ?: ""
 
     // Debug-friendly rendering; placeholders are emitted in place of values.
@@ -35,6 +35,6 @@ data class Query(
         orderBy.entries.joinToString(",") { (key, value) -> "${key.toSql(builder)} ${value.name}" }
 }
 
-enum class AscDescOrder{
+public enum class AscDescOrder{
     ASC, DESC
 }

--- a/kormium-core/src/commonMain/kotlin/QueryBuilder.kt
+++ b/kormium-core/src/commonMain/kotlin/QueryBuilder.kt
@@ -18,24 +18,24 @@ package io.github.kormium
  * no ordering, no limit/offset). [Query] stays available for reusable/prebuilt queries.
  */
 @KormiumDsl
-class QueryBuilder {
+public class QueryBuilder {
     private val conditions = mutableListOf<Expression>()
     private val orderings = LinkedHashMap<Selectable<*>, AscDescOrder>()
 
     /** `orderBy DESC Users.age`, `orderBy ASC Users.name`. Multiple calls keep their order. */
-    val orderBy: OrderByDsl = OrderByDsl(orderings)
+    public val orderBy: OrderByDsl = OrderByDsl(orderings)
 
     /** No `LIMIT` when left null. */
-    var limit: Int? = null
+    public var limit: Int? = null
 
     /** No `OFFSET` when left null. */
-    var offset: Int? = null
+    public var offset: Int? = null
 
     /**
      * Adds a predicate. Multiple `where { ... }` calls combine with `AND`; put complex
      * boolean logic inside a single block using `and` / `or` / `not(...)`.
      */
-    fun where(block: () -> Expression) {
+    public fun where(block: () -> Expression) {
         conditions += block()
     }
 
@@ -65,12 +65,12 @@ class QueryBuilder {
  * operand is any [Selectable] — a column, or a computed value like `Users.name.lower()` or
  * `Users.qty * 2` (for case-insensitive or computed ordering).
  */
-class OrderByDsl internal constructor(private val orderings: MutableMap<Selectable<*>, AscDescOrder>) {
-    infix fun ASC(expression: Selectable<*>) {
+public class OrderByDsl internal constructor(private val orderings: MutableMap<Selectable<*>, AscDescOrder>) {
+    public infix fun ASC(expression: Selectable<*>) {
         orderings[expression] = AscDescOrder.ASC
     }
 
-    infix fun DESC(expression: Selectable<*>) {
+    public infix fun DESC(expression: Selectable<*>) {
         orderings[expression] = AscDescOrder.DESC
     }
 }

--- a/kormium-core/src/commonMain/kotlin/QueryObserver.kt
+++ b/kormium-core/src/commonMain/kotlin/QueryObserver.kt
@@ -4,12 +4,12 @@ import io.github.kormium.resultset.ResultSet
 import kotlin.time.TimeSource
 
 /** Coarse classification of a statement, derived from its leading SQL keyword. */
-enum class QueryKind {
+public enum class QueryKind {
     Select, Insert, Update, Delete, Other;
 
-    companion object {
+    public companion object {
         /** Classifies [sql] by its first keyword. Cheap: scans only the leading token. */
-        fun of(sql: String): QueryKind {
+        public fun of(sql: String): QueryKind {
             var i = 0
             val n = sql.length
             // Skip leading whitespace and a single line comment / leading parenthesis (CTEs, etc.).
@@ -35,27 +35,27 @@ enum class QueryKind {
  * Intended as the single seam for query-level metrics and tracing: tag a timer by [backend] and
  * [kind], count failures by [sqlState], log [sql] for slow queries, etc.
  */
-class QueryEvent(
+public class QueryEvent(
     /** Backend/dialect tag (the dialect implementation's simple name, e.g. "SqliteDialect"). */
-    val backend: String,
+    public val backend: String,
     /** The parameterized SQL template as sent to the driver. Contains placeholders, not values. */
-    val sql: String,
+    public val sql: String,
     /** Coarse operation kind derived from [sql]. */
-    val kind: QueryKind,
+    public val kind: QueryKind,
     /** Wall-clock duration of the statement, measured with a monotonic clock. */
-    val durationNanos: Long,
+    public val durationNanos: Long,
     /**
      * Rows returned (for queries) or rows affected (for INSERT/UPDATE/DELETE), when the backend
      * reports one; `null` when not applicable or unknown.
      */
-    val rowCount: Long?,
+    public val rowCount: Long?,
     /** The failure that ended the statement, or `null` on success. */
-    val error: Throwable?,
+    public val error: Throwable?,
     /** SQLSTATE / backend error code when the failure carried one (see [QueryException.sqlState]). */
-    val sqlState: String?,
+    public val sqlState: String?,
 ) {
     /** Whether the statement completed without throwing. */
-    val succeeded: Boolean get() = error == null
+    public val succeeded: Boolean get() = error == null
 }
 
 /**
@@ -66,8 +66,8 @@ class QueryEvent(
  * The callback runs synchronously on the executing thread, so keep it cheap (record a metric,
  * enqueue, log). Exceptions thrown by the observer are swallowed and never affect the query.
  */
-fun interface QueryObserver {
-    fun onQuery(event: QueryEvent)
+public fun interface QueryObserver {
+    public fun onQuery(event: QueryEvent)
 }
 
 /** Backend tag for an executor: the dialect implementation's simple name, stable enough to group by. */

--- a/kormium-core/src/commonMain/kotlin/RenderSql.kt
+++ b/kormium-core/src/commonMain/kotlin/RenderSql.kt
@@ -7,7 +7,7 @@ import io.github.kormium.database.Database
  * without touching a database. The parameter values are neutral representations (the SQL string
  * is faithful to the dialect; only the displayed values go through [StandardTypeMapper]).
  */
-class RenderedSql(val sql: String, val params: Map<String, Any?>) {
+public class RenderedSql(public val sql: String, public val params: Map<String, Any?>) {
     internal constructor(rendered: Pair<String, Map<String, Any?>>) : this(rendered.first, rendered.second)
 
     override fun toString(): String = if (params.isEmpty()) sql else "$sql\nparams: $params"
@@ -19,62 +19,62 @@ class RenderedSql(val sql: String, val params: Map<String, Any?>) {
  * call-site syntax (`Users.find { where { } }`), a different return type. Obtain one via the
  * top-level [renderSql] (offline, explicit dialect) or [Database.renderSql] (the backend's dialect).
  */
-class RenderScope<G : Catalog> internal constructor(val dialect: Dialect, val typeMapper: TypeMapper) {
+public class RenderScope<G : Catalog> internal constructor(public val dialect: Dialect, public val typeMapper: TypeMapper) {
 
     // ---- reads ----
-    fun <T : Entity> Table<G, T>.find(query: Query): RenderedSql = RenderedSql(selectSql(query, dialect, typeMapper))
-    fun <T : Entity> Table<G, T>.find(block: QueryBuilder.() -> Unit): RenderedSql = find(QueryBuilder().apply(block).build())
-    fun <T : Entity> Table<G, T>.findOne(query: Query): RenderedSql = RenderedSql(selectSql(query.copy(limit = 1u), dialect, typeMapper))
-    fun <T : Entity> Table<G, T>.findOne(block: QueryBuilder.() -> Unit): RenderedSql = findOne(QueryBuilder().apply(block).build())
-    fun <T : Entity> Table<G, T>.all(): RenderedSql = RenderedSql(selectAllSql(dialect) to emptyMap())
-    fun <T : Entity> Table<G, T>.count(query: Query = Query()): RenderedSql = RenderedSql(countSql(query, dialect, typeMapper))
-    fun <T : Entity> Table<G, T>.count(block: QueryBuilder.() -> Unit): RenderedSql = count(QueryBuilder().apply(block).build())
+    public fun <T : Entity> Table<G, T>.find(query: Query): RenderedSql = RenderedSql(selectSql(query, dialect, typeMapper))
+    public fun <T : Entity> Table<G, T>.find(block: QueryBuilder.() -> Unit): RenderedSql = find(QueryBuilder().apply(block).build())
+    public fun <T : Entity> Table<G, T>.findOne(query: Query): RenderedSql = RenderedSql(selectSql(query.copy(limit = 1u), dialect, typeMapper))
+    public fun <T : Entity> Table<G, T>.findOne(block: QueryBuilder.() -> Unit): RenderedSql = findOne(QueryBuilder().apply(block).build())
+    public fun <T : Entity> Table<G, T>.all(): RenderedSql = RenderedSql(selectAllSql(dialect) to emptyMap())
+    public fun <T : Entity> Table<G, T>.count(query: Query = Query()): RenderedSql = RenderedSql(countSql(query, dialect, typeMapper))
+    public fun <T : Entity> Table<G, T>.count(block: QueryBuilder.() -> Unit): RenderedSql = count(QueryBuilder().apply(block).build())
 
     // ---- writes ----
-    fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): RenderedSql =
+    public fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): RenderedSql =
         RenderedSql(insertSql(entity, dialect, typeMapper, returning))
 
     /** A batch insert may split into several statements (per [BatchInsertMode]), so this returns one [RenderedSql] each. */
-    fun <T : Entity> Table<G, T>.insertAll(
+    public fun <T : Entity> Table<G, T>.insertAll(
         entities: List<T>,
         returning: Boolean = false,
         batchInsertMode: BatchInsertMode = BatchInsertMode.GroupByAssignedFields,
     ): List<RenderedSql> =
         buildBatchStatements(entities, batchInsertMode, dialect, typeMapper, returning).map { RenderedSql(it.sql, it.params) }
 
-    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, T>, update: T, returning: Boolean = false): RenderedSql =
+    public fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, T>, update: T, returning: Boolean = false): RenderedSql =
         upsert(entity, listOf(onConflict), update, returning)
 
-    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, T>>, update: T, returning: Boolean = false): RenderedSql =
+    public fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, T>>, update: T, returning: Boolean = false): RenderedSql =
         RenderedSql(upsertSql(entity, onConflict, update, dialect, typeMapper, returning))
 
-    fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: Column<*, *, T>): RenderedSql =
+    public fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: Column<*, *, T>): RenderedSql =
         insertOrIgnore(entity, listOf(onConflict))
 
-    fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: List<Column<*, *, T>>): RenderedSql =
+    public fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: List<Column<*, *, T>>): RenderedSql =
         RenderedSql(insertOrIgnoreSql(entity, onConflict, dialect, typeMapper))
 
-    fun <T : Entity> Table<G, T>.update(entity: T, query: Query): RenderedSql =
+    public fun <T : Entity> Table<G, T>.update(entity: T, query: Query): RenderedSql =
         RenderedSql(updateSql(query, entity, dialect, typeMapper))
 
-    fun <T : Entity> Table<G, T>.update(entity: T, block: QueryBuilder.() -> Unit): RenderedSql =
+    public fun <T : Entity> Table<G, T>.update(entity: T, block: QueryBuilder.() -> Unit): RenderedSql =
         update(entity, QueryBuilder().apply(block).build())
 
-    fun <T : Entity> Table<G, T>.update(block: UpdateBuilder.() -> Unit): RenderedSql {
+    public fun <T : Entity> Table<G, T>.update(block: UpdateBuilder.() -> Unit): RenderedSql {
         val builder = UpdateBuilder().apply(block)
         return RenderedSql(updateSql(builder.buildWhere(), builder.buildAssignments(), dialect, typeMapper))
     }
 
-    fun <T : Entity> Table<G, T>.deleteWhere(query: Query): RenderedSql = RenderedSql(deleteSql(query, dialect, typeMapper))
-    fun <T : Entity> Table<G, T>.deleteWhere(block: QueryBuilder.() -> Unit): RenderedSql =
+    public fun <T : Entity> Table<G, T>.deleteWhere(query: Query): RenderedSql = RenderedSql(deleteSql(query, dialect, typeMapper))
+    public fun <T : Entity> Table<G, T>.deleteWhere(block: QueryBuilder.() -> Unit): RenderedSql =
         deleteWhere(QueryBuilder().apply(block).build())
 
     // ---- joins (SQL-producing form only; result-mapping variants render the same SQL) ----
-    fun Join<G>.select(vararg fields: Selectable<*>): RenderedSql =
+    public fun Join<G>.select(vararg fields: Selectable<*>): RenderedSql =
         RenderedSql(buildSelect(this, if (fields.isEmpty()) allColumns() else fields.toList(), dialect, typeMapper))
 
-    fun <A : Entity, B : Entity> JoinPair<G, A, B>.select(vararg fields: Selectable<*>): RenderedSql = asJoin().select(*fields)
-    fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>): RenderedSql = asJoin().select(*fields)
+    public fun <A : Entity, B : Entity> JoinPair<G, A, B>.select(vararg fields: Selectable<*>): RenderedSql = asJoin().select(*fields)
+    public fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>): RenderedSql = asJoin().select(*fields)
 }
 
 /**
@@ -91,7 +91,7 @@ class RenderScope<G : Catalog> internal constructor(val dialect: Dialect, val ty
  * [catalog] is the [Catalog] object (`App`) — passed so the catalog tag [G] is inferred, the same
  * tag a `Database<App>` pins; it is not otherwise used.
  */
-fun <G : Catalog, R> renderSql(
+public fun <G : Catalog, R> renderSql(
     catalog: G,
     dialect: Dialect = StandardDialect,
     typeMapper: TypeMapper = StandardTypeMapper,
@@ -99,5 +99,5 @@ fun <G : Catalog, R> renderSql(
 ): R = RenderScope<G>(dialect, typeMapper).block()
 
 /** Renders queries using this database's own [Dialect], so the preview matches the real backend. */
-fun <G : Catalog, R> Database<G>.renderSql(block: RenderScope<G>.() -> R): R =
+public fun <G : Catalog, R> Database<G>.renderSql(block: RenderScope<G>.() -> R): R =
     RenderScope<G>(dialect, StandardTypeMapper).block()

--- a/kormium-core/src/commonMain/kotlin/Scope.kt
+++ b/kormium-core/src/commonMain/kotlin/Scope.kt
@@ -13,7 +13,7 @@ import kotlin.contracts.contract
  * [execute] / [executeUpdate] goes to the same pinned connection.
  */
 @KormiumDsl
-class Scope<G : Catalog> internal constructor(
+public class Scope<G : Catalog> internal constructor(
     private val exec: SqlExecutor,
     /** The owning database's configuration (e.g. the default [BatchInsertMode]). */
     internal val config: KormiumConfig = KormiumConfig(),
@@ -38,7 +38,7 @@ class Scope<G : Catalog> internal constructor(
      * path). Pass `returning = true` to fetch the stored row back via SQL `RETURNING`, e.g. to
      * read database-generated columns; then it returns that row (or null if none).
      */
-    fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): T {
+    public fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): T {
         markWritten()
         return insert(entity, exec, returning)
     }
@@ -47,7 +47,7 @@ class Scope<G : Catalog> internal constructor(
      * Inserts all [entities] in one statement. By default returns [entities] as given; pass
      * `returning = true` to fetch the stored rows back via SQL `RETURNING`.
      */
-    fun <T : Entity> Table<G, T>.insertAll(
+    public fun <T : Entity> Table<G, T>.insertAll(
         entities: List<T>,
         returning: Boolean = false,
         batchInsertMode: BatchInsertMode = config.batchInsertMode,
@@ -61,50 +61,50 @@ class Scope<G : Catalog> internal constructor(
      * and on conflict with [onConflict] updates with [update]'s present fields. Pass
      * `returning = true` to fetch the resulting row.
      */
-    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, T>, update: T, returning: Boolean = false): T {
+    public fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, T>, update: T, returning: Boolean = false): T {
         markWritten()
         return upsert(entity, listOf(onConflict), update, exec, returning)
     }
 
     /** Insert-or-update on a composite (multi-column) conflict target; see the single-column overload. */
-    fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, T>>, update: T, returning: Boolean = false): T {
+    public fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, T>>, update: T, returning: Boolean = false): T {
         markWritten()
         return upsert(entity, onConflict, update, exec, returning)
     }
 
     /** Insert-or-do-nothing on a single-column conflict target; returns the affected row count (1 inserted, 0 ignored). */
-    fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: Column<*, *, T>): Long {
+    public fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: Column<*, *, T>): Long {
         markWritten()
         return insertOrIgnore(entity, listOf(onConflict), exec)
     }
 
     /** Insert-or-do-nothing on a composite conflict target; see the single-column overload. */
-    fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: List<Column<*, *, T>>): Long {
+    public fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: List<Column<*, *, T>>): Long {
         markWritten()
         return insertOrIgnore(entity, onConflict, exec)
     }
 
     /** Counts rows matching [query] (all rows by default). */
-    fun <T : Entity> Table<G, T>.count(query: Query = Query()): Long = count(query, exec)
+    public fun <T : Entity> Table<G, T>.count(query: Query = Query()): Long = count(query, exec)
 
     /** Block form of [count]: `Users.count { where { Users.deletedAt eq null } }`. */
-    fun <T : Entity> Table<G, T>.count(block: QueryBuilder.() -> Unit): Long =
+    public fun <T : Entity> Table<G, T>.count(block: QueryBuilder.() -> Unit): Long =
         count(QueryBuilder().apply(block).build(), exec)
 
-    fun <T : Entity> Table<G, T>.find(query: Query): List<T> = select(query, exec)
+    public fun <T : Entity> Table<G, T>.find(query: Query): List<T> = select(query, exec)
 
     /** Block form of [find]: `Users.find { where { ... }; orderBy DESC col; limit = 50 }`. */
-    fun <T : Entity> Table<G, T>.find(block: QueryBuilder.() -> Unit): List<T> =
+    public fun <T : Entity> Table<G, T>.find(block: QueryBuilder.() -> Unit): List<T> =
         select(QueryBuilder().apply(block).build(), exec)
     /** The first row matching [query] (typically a unique predicate), or null. Applies `LIMIT 1`. */
-    fun <T : Entity> Table<G, T>.findOne(query: Query): T? = select(query.copy(limit = 1u), exec).firstOrNull()
+    public fun <T : Entity> Table<G, T>.findOne(query: Query): T? = select(query.copy(limit = 1u), exec).firstOrNull()
 
     /** Block form of [findOne]: `Users.findOne { where { Users.id eq id } }`. */
-    fun <T : Entity> Table<G, T>.findOne(block: QueryBuilder.() -> Unit): T? =
+    public fun <T : Entity> Table<G, T>.findOne(block: QueryBuilder.() -> Unit): T? =
         findOne(QueryBuilder().apply(block).build())
-    fun <T : Entity> Table<G, T>.all(): List<T> = selectAll(exec)
+    public fun <T : Entity> Table<G, T>.all(): List<T> = selectAll(exec)
     /** Updates rows matching [query] with the present fields of [entity]; returns the affected row count. */
-    fun <T : Entity> Table<G, T>.update(entity: T, query: Query): Long {
+    public fun <T : Entity> Table<G, T>.update(entity: T, query: Query): Long {
         markWritten()
         return updateRows(query, entity, exec)
     }
@@ -114,7 +114,7 @@ class Scope<G : Catalog> internal constructor(
      * `where { }` blocks AND together; an empty block updates every row. Returns the affected
      * row count (e.g. 0 means no row matched — useful for not-found / optimistic-locking checks).
      */
-    fun <T : Entity> Table<G, T>.update(entity: T, block: QueryBuilder.() -> Unit): Long {
+    public fun <T : Entity> Table<G, T>.update(entity: T, block: QueryBuilder.() -> Unit): Long {
         markWritten()
         return updateRows(QueryBuilder().apply(block).build(), entity, exec)
     }
@@ -125,14 +125,14 @@ class Scope<G : Catalog> internal constructor(
      * `where { }` blocks AND together; an empty `where` updates every row. Returns the affected
      * row count. See [UpdateBuilder].
      */
-    fun <T : Entity> Table<G, T>.update(block: UpdateBuilder.() -> Unit): Long {
+    public fun <T : Entity> Table<G, T>.update(block: UpdateBuilder.() -> Unit): Long {
         markWritten()
         val builder = UpdateBuilder().apply(block)
         return updateRows(builder.buildWhere(), builder.buildAssignments(), exec)
     }
 
     /** Deletes rows matching [query]; returns the affected row count. */
-    fun <T : Entity> Table<G, T>.deleteWhere(query: Query): Long {
+    public fun <T : Entity> Table<G, T>.deleteWhere(query: Query): Long {
         markWritten()
         return deleteRows(query, exec)
     }
@@ -141,50 +141,50 @@ class Scope<G : Catalog> internal constructor(
      * Block form of [deleteWhere]: `Users.deleteWhere { where { Users.deletedAt neq null } }`.
      * An empty block deletes every row. Returns the affected row count.
      */
-    fun <T : Entity> Table<G, T>.deleteWhere(block: QueryBuilder.() -> Unit): Long {
+    public fun <T : Entity> Table<G, T>.deleteWhere(block: QueryBuilder.() -> Unit): Long {
         markWritten()
         return deleteRows(QueryBuilder().apply(block).build(), exec)
     }
 
     @DelicateKormiumApi
-    fun <T : Entity> Table<G, T>.execSql(sql: String) {
+    public fun <T : Entity> Table<G, T>.execSql(sql: String) {
         markWritten()
         runRaw(sql, exec)
     }
 
     /** Runs the query, selecting the given fields (or all columns if none are given). */
-    fun Join<G>.select(vararg fields: Selectable<*>): List<ResultRow> =
+    public fun Join<G>.select(vararg fields: Selectable<*>): List<ResultRow> =
         runSelect(exec, this, if (fields.isEmpty()) allColumns() else fields.toList())
 
     /** Runs the query, mapping each [ResultRow] with [map] (a projection into your own type). */
-    fun <R> Join<G>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
+    public fun <R> Join<G>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
         select(*fields).map(map)
 
     /** Runs a two-table join, selecting the given fields (or all columns if none are given). */
-    fun <A : Entity, B : Entity> JoinPair<G, A, B>.select(vararg fields: Selectable<*>): List<ResultRow> =
+    public fun <A : Entity, B : Entity> JoinPair<G, A, B>.select(vararg fields: Selectable<*>): List<ResultRow> =
         asJoin().select(*fields)
 
     /** Runs a two-table join, mapping each [ResultRow] with [map]. */
-    fun <A : Entity, B : Entity, R> JoinPair<G, A, B>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
+    public fun <A : Entity, B : Entity, R> JoinPair<G, A, B>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
         asJoin().select(*fields, map = map)
 
     /** Runs a two-table join, reconstructing both sides as a `Pair` of entities. */
-    fun <A : Entity, B : Entity> JoinPair<G, A, B>.find(): List<Pair<A, B>> =
+    public fun <A : Entity, B : Entity> JoinPair<G, A, B>.find(): List<Pair<A, B>> =
         hydrateInnerPairs(left, right, runSelect(exec, asJoin(), pairSelectFields(left, right)))
 
     /** Runs a two-table LEFT join, selecting the given fields (or all columns if none are given). */
-    fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>): List<ResultRow> =
+    public fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>): List<ResultRow> =
         asJoin().select(*fields)
 
     /** Runs a two-table LEFT join, mapping each [ResultRow] with [map]. */
-    fun <A : Entity, B : Entity, R> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
+    public fun <A : Entity, B : Entity, R> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
         asJoin().select(*fields, map = map)
 
     /**
      * Runs a two-table LEFT join, reconstructing both sides as entity pairs. The right side
      * is `null` for left rows with no match (detected by a NULL right-side primary key).
      */
-    fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.find(): List<Pair<A, B?>> =
+    public fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.find(): List<Pair<A, B?>> =
         hydrateLeftPairs(left, right, runSelect(exec, asJoin(), pairSelectFields(left, right)))
 
     /**
@@ -195,7 +195,7 @@ class Scope<G : Catalog> internal constructor(
      * effort than concatenating values into [sql].
      */
     @DelicateKormiumApi
-    fun <R> execute(
+    public fun <R> execute(
         sql: String,
         params: Map<String, Any?>,
         invalidates: List<Table<G, *>>,
@@ -207,7 +207,7 @@ class Scope<G : Catalog> internal constructor(
 
     /** Runs a raw statement (DDL/DML) on the pinned connection, returning the affected row count. See [execute]. */
     @DelicateKormiumApi
-    fun executeUpdate(
+    public fun executeUpdate(
         sql: String,
         params: Map<String, Any?>,
         invalidates: List<Table<G, *>>,
@@ -226,7 +226,7 @@ class Scope<G : Catalog> internal constructor(
      * error on PostgreSQL and backend-dependent elsewhere).
      */
     @OptIn(ExperimentalContracts::class)
-    fun <R> savepoint(block: Scope<G>.() -> R): R {
+    public fun <R> savepoint(block: Scope<G>.() -> R): R {
         contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
         check(transactional) { "savepoint { } requires a transaction; use transaction { }, not autocommit { }" }
         val name = "korm_sp_${savepointCounter++}"
@@ -251,7 +251,7 @@ class Scope<G : Catalog> internal constructor(
  * where the backend supports it.
  */
 @OptIn(ExperimentalContracts::class)
-fun <G : Catalog, R> Database<G>.transaction(
+public fun <G : Catalog, R> Database<G>.transaction(
     isolation: TransactionIsolation? = null,
     readOnly: Boolean = false,
     block: Scope<G>.() -> R,
@@ -270,7 +270,7 @@ fun <G : Catalog, R> Database<G>.transaction(
  * the cheap path for reads / single statements.
  */
 @OptIn(ExperimentalContracts::class)
-fun <G : Catalog, R> Database<G>.autocommit(block: Scope<G>.() -> R): R {
+public fun <G : Catalog, R> Database<G>.autocommit(block: Scope<G>.() -> R): R {
     contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
     val dirty = mutableSetOf<String>()
     val result = usePinned(transactional = false) { Scope<G>(it.observed(config), config, dirty, transactional = false).block() }

--- a/kormium-core/src/commonMain/kotlin/SqlExecutor.kt
+++ b/kormium-core/src/commonMain/kotlin/SqlExecutor.kt
@@ -8,14 +8,14 @@ import io.github.kormium.resultset.ResultSet
  * is an [SqlExecutor] backed by a pool; inside a transaction / autocommit scope the
  * executor is pinned to a single connection.
  */
-interface SqlExecutor {
-    val dialect: Dialect
-    val typeMapper: TypeMapper
+public interface SqlExecutor {
+    public val dialect: Dialect
+    public val typeMapper: TypeMapper
 
-    fun <T> execute(sql: String, namedParameters: Map<String, Any?> = emptyMap(), handler: (ResultSet) -> T): List<T>
-    fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T>
-    fun execute(sql: String, namedParameters: Map<String, Any?> = emptyMap()): Long
-    fun execute(sql: String, paramSource: SqlParameterSource): Long
+    public fun <T> execute(sql: String, namedParameters: Map<String, Any?> = emptyMap(), handler: (ResultSet) -> T): List<T>
+    public fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T>
+    public fun execute(sql: String, namedParameters: Map<String, Any?> = emptyMap()): Long
+    public fun execute(sql: String, paramSource: SqlParameterSource): Long
     /** Runs an INSERT/UPDATE/DELETE/DDL statement and returns the backend-reported affected row count. */
-    fun executeUpdate(sql: String, namedParameters: Map<String, Any?> = emptyMap()): Long
+    public fun executeUpdate(sql: String, namedParameters: Map<String, Any?> = emptyMap()): Long
 }

--- a/kormium-core/src/commonMain/kotlin/SqlParameterSource.kt
+++ b/kormium-core/src/commonMain/kotlin/SqlParameterSource.kt
@@ -10,13 +10,13 @@ package io.github.kormium
  * specifying the name of the parameter.
  *
  */
-interface SqlParameterSource {
+public interface SqlParameterSource {
     /**
      * Determine whether there is a value for the specified named parameter.
      * @param paramName the name of the parameter
      * @return whether there is a value defined
      */
-    fun hasValue(paramName: String): Boolean
+    public fun hasValue(paramName: String): Boolean
 
     /**
      * Return the parameter value for the requested named parameter.
@@ -25,7 +25,7 @@ interface SqlParameterSource {
      * @throws IllegalArgumentException if there is no value for the requested parameter
      */
     @Throws(IllegalArgumentException::class)
-    fun getValue(paramName: String): Any?
+    public fun getValue(paramName: String): Any?
 
     /**
      * Determine the SQL type for the specified named parameter.
@@ -34,7 +34,7 @@ interface SqlParameterSource {
      * or `TYPE_UNKNOWN` if not known
      * @see .TYPE_UNKNOWN
      */
-    fun getSqlType(paramName: String) = TYPE_UNKNOWN
+    public fun getSqlType(paramName: String): UInt = TYPE_UNKNOWN
 
     /**
      * Determine the type name for the specified named parameter.
@@ -42,22 +42,22 @@ interface SqlParameterSource {
      * @return the type name of the specified parameter,
      * or `null` if not known
      */
-    fun getTypeName(paramName: String?): String? = null
+    public fun getTypeName(paramName: String?): String? = null
 
     /**
      * Enumerate all available parameter names if possible.
      */
-    val parameterNames: Array<String>?
+    public val parameterNames: Array<String>?
         get() = null
 
-    companion object {
+    public companion object {
         /**
          * Constant that indicates an unknown (or unspecified) SQL type.
          * To be returned from `getType` when no specific SQL type known.
          * @see getSqlType
          *
          */
-        val TYPE_UNKNOWN: UInt = UInt.MIN_VALUE
+        public val TYPE_UNKNOWN: UInt = UInt.MIN_VALUE
         // TODO check if libpq has a default param type oid
     }
 }

--- a/kormium-core/src/commonMain/kotlin/SuspendScope.kt
+++ b/kormium-core/src/commonMain/kotlin/SuspendScope.kt
@@ -15,7 +15,7 @@ import kotlin.contracts.contract
  * the same pinned connection.
  */
 @KormiumDsl
-class SuspendScope<G : Catalog> internal constructor(
+public class SuspendScope<G : Catalog> internal constructor(
     private val exec: SuspendSqlExecutor,
     /** The owning database's configuration (e.g. the default [BatchInsertMode]). */
     internal val config: KormiumConfig = KormiumConfig(),
@@ -31,13 +31,13 @@ class SuspendScope<G : Catalog> internal constructor(
     }
 
     /** Inserts [entity]; see [Scope.insert]. */
-    suspend fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): T {
+    public suspend fun <T : Entity> Table<G, T>.insert(entity: T, returning: Boolean = false): T {
         markWritten()
         return insert(entity, exec, returning)
     }
 
     /** Inserts all [entities] in one statement; see [Scope.insertAll]. */
-    suspend fun <T : Entity> Table<G, T>.insertAll(
+    public suspend fun <T : Entity> Table<G, T>.insertAll(
         entities: List<T>,
         returning: Boolean = false,
         batchInsertMode: BatchInsertMode = config.batchInsertMode,
@@ -47,118 +47,118 @@ class SuspendScope<G : Catalog> internal constructor(
     }
 
     /** Insert-or-update on a single-column conflict target; see [Scope.upsert]. */
-    suspend fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, T>, update: T, returning: Boolean = false): T {
+    public suspend fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: Column<*, *, T>, update: T, returning: Boolean = false): T {
         markWritten()
         return upsert(entity, listOf(onConflict), update, exec, returning)
     }
 
     /** Insert-or-update on a composite conflict target; see [Scope.upsert]. */
-    suspend fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, T>>, update: T, returning: Boolean = false): T {
+    public suspend fun <T : Entity> Table<G, T>.upsert(entity: T, onConflict: List<Column<*, *, T>>, update: T, returning: Boolean = false): T {
         markWritten()
         return upsert(entity, onConflict, update, exec, returning)
     }
 
     /** Insert-or-do-nothing on a single-column conflict target; see [Scope.insertOrIgnore]. */
-    suspend fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: Column<*, *, T>): Long {
+    public suspend fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: Column<*, *, T>): Long {
         markWritten()
         return insertOrIgnore(entity, listOf(onConflict), exec)
     }
 
     /** Insert-or-do-nothing on a composite conflict target; see [Scope.insertOrIgnore]. */
-    suspend fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: List<Column<*, *, T>>): Long {
+    public suspend fun <T : Entity> Table<G, T>.insertOrIgnore(entity: T, onConflict: List<Column<*, *, T>>): Long {
         markWritten()
         return insertOrIgnore(entity, onConflict, exec)
     }
 
     /** Counts rows matching [query] (all rows by default). */
-    suspend fun <T : Entity> Table<G, T>.count(query: Query = Query()): Long = count(query, exec)
+    public suspend fun <T : Entity> Table<G, T>.count(query: Query = Query()): Long = count(query, exec)
 
     /** Block form of [count]; see [Scope.count]. */
-    suspend fun <T : Entity> Table<G, T>.count(block: QueryBuilder.() -> Unit): Long =
+    public suspend fun <T : Entity> Table<G, T>.count(block: QueryBuilder.() -> Unit): Long =
         count(QueryBuilder().apply(block).build(), exec)
 
-    suspend fun <T : Entity> Table<G, T>.find(query: Query): List<T> = select(query, exec)
+    public suspend fun <T : Entity> Table<G, T>.find(query: Query): List<T> = select(query, exec)
 
     /** Block form of [find]; see [Scope.find]. */
-    suspend fun <T : Entity> Table<G, T>.find(block: QueryBuilder.() -> Unit): List<T> =
+    public suspend fun <T : Entity> Table<G, T>.find(block: QueryBuilder.() -> Unit): List<T> =
         select(QueryBuilder().apply(block).build(), exec)
     /** The first row matching [query] (typically a unique predicate), or null. Applies `LIMIT 1`. */
-    suspend fun <T : Entity> Table<G, T>.findOne(query: Query): T? = select(query.copy(limit = 1u), exec).firstOrNull()
+    public suspend fun <T : Entity> Table<G, T>.findOne(query: Query): T? = select(query.copy(limit = 1u), exec).firstOrNull()
 
     /** Block form of [findOne]: `Users.findOne { where { Users.id eq id } }`. */
-    suspend fun <T : Entity> Table<G, T>.findOne(block: QueryBuilder.() -> Unit): T? =
+    public suspend fun <T : Entity> Table<G, T>.findOne(block: QueryBuilder.() -> Unit): T? =
         findOne(QueryBuilder().apply(block).build())
-    suspend fun <T : Entity> Table<G, T>.all(): List<T> = selectAll(exec)
+    public suspend fun <T : Entity> Table<G, T>.all(): List<T> = selectAll(exec)
     /** Updates rows matching [query] with the present fields of [entity]; returns the affected row count. */
-    suspend fun <T : Entity> Table<G, T>.update(entity: T, query: Query): Long {
+    public suspend fun <T : Entity> Table<G, T>.update(entity: T, query: Query): Long {
         markWritten()
         return updateRows(query, entity, exec)
     }
 
     /** Block form of [update]; see [Scope.update]. */
-    suspend fun <T : Entity> Table<G, T>.update(entity: T, block: QueryBuilder.() -> Unit): Long {
+    public suspend fun <T : Entity> Table<G, T>.update(entity: T, block: QueryBuilder.() -> Unit): Long {
         markWritten()
         return updateRows(QueryBuilder().apply(block).build(), entity, exec)
     }
 
     /** Expression form of [update]: `Posts.views set (Posts.views + 1)`; see [Scope.update]. */
-    suspend fun <T : Entity> Table<G, T>.update(block: UpdateBuilder.() -> Unit): Long {
+    public suspend fun <T : Entity> Table<G, T>.update(block: UpdateBuilder.() -> Unit): Long {
         markWritten()
         val builder = UpdateBuilder().apply(block)
         return updateRows(builder.buildWhere(), builder.buildAssignments(), exec)
     }
 
     /** Deletes rows matching [query]; returns the affected row count. */
-    suspend fun <T : Entity> Table<G, T>.deleteWhere(query: Query): Long {
+    public suspend fun <T : Entity> Table<G, T>.deleteWhere(query: Query): Long {
         markWritten()
         return deleteRows(query, exec)
     }
 
     /** Block form of [deleteWhere]; see [Scope.deleteWhere]. */
-    suspend fun <T : Entity> Table<G, T>.deleteWhere(block: QueryBuilder.() -> Unit): Long {
+    public suspend fun <T : Entity> Table<G, T>.deleteWhere(block: QueryBuilder.() -> Unit): Long {
         markWritten()
         return deleteRows(QueryBuilder().apply(block).build(), exec)
     }
 
     @DelicateKormiumApi
-    suspend fun <T : Entity> Table<G, T>.execSql(sql: String) {
+    public suspend fun <T : Entity> Table<G, T>.execSql(sql: String) {
         markWritten()
         runRaw(sql, exec)
     }
 
     /** Runs the query, selecting the given fields (or all columns if none are given). */
-    suspend fun Join<G>.select(vararg fields: Selectable<*>): List<ResultRow> =
+    public suspend fun Join<G>.select(vararg fields: Selectable<*>): List<ResultRow> =
         runSelect(exec, this, if (fields.isEmpty()) allColumns() else fields.toList())
 
     /** Runs the query, mapping each [ResultRow] with [map] (a projection into your own type). */
-    suspend fun <R> Join<G>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
+    public suspend fun <R> Join<G>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
         select(*fields).map(map)
 
     /** Runs a two-table join, selecting the given fields (or all columns if none are given). */
-    suspend fun <A : Entity, B : Entity> JoinPair<G, A, B>.select(vararg fields: Selectable<*>): List<ResultRow> =
+    public suspend fun <A : Entity, B : Entity> JoinPair<G, A, B>.select(vararg fields: Selectable<*>): List<ResultRow> =
         asJoin().select(*fields)
 
     /** Runs a two-table join, mapping each [ResultRow] with [map]. */
-    suspend fun <A : Entity, B : Entity, R> JoinPair<G, A, B>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
+    public suspend fun <A : Entity, B : Entity, R> JoinPair<G, A, B>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
         asJoin().select(*fields, map = map)
 
     /** Runs a two-table join, reconstructing both sides as a `Pair` of entities. */
-    suspend fun <A : Entity, B : Entity> JoinPair<G, A, B>.find(): List<Pair<A, B>> =
+    public suspend fun <A : Entity, B : Entity> JoinPair<G, A, B>.find(): List<Pair<A, B>> =
         hydrateInnerPairs(left, right, runSelect(exec, asJoin(), pairSelectFields(left, right)))
 
     /** Runs a two-table LEFT join, selecting the given fields (or all columns if none are given). */
-    suspend fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>): List<ResultRow> =
+    public suspend fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>): List<ResultRow> =
         asJoin().select(*fields)
 
     /** Runs a two-table LEFT join, mapping each [ResultRow] with [map]. */
-    suspend fun <A : Entity, B : Entity, R> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
+    public suspend fun <A : Entity, B : Entity, R> LeftJoinPair<G, A, B>.select(vararg fields: Selectable<*>, map: (ResultRow) -> R): List<R> =
         asJoin().select(*fields, map = map)
 
     /**
      * Runs a two-table LEFT join, reconstructing both sides as entity pairs. The right side
      * is `null` for left rows with no match (detected by a NULL right-side primary key).
      */
-    suspend fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.find(): List<Pair<A, B?>> =
+    public suspend fun <A : Entity, B : Entity> LeftJoinPair<G, A, B>.find(): List<Pair<A, B?>> =
         hydrateLeftPairs(left, right, runSelect(exec, asJoin(), pairSelectFields(left, right)))
 
     /**
@@ -166,7 +166,7 @@ class SuspendScope<G : Catalog> internal constructor(
      * [Scope.execute].
      */
     @DelicateKormiumApi
-    suspend fun <R> execute(
+    public suspend fun <R> execute(
         sql: String,
         params: Map<String, Any?>,
         invalidates: List<Table<G, *>>,
@@ -178,7 +178,7 @@ class SuspendScope<G : Catalog> internal constructor(
 
     /** Runs a raw statement (DDL/DML) on the pinned connection, returning the affected row count. See [Scope.executeUpdate]. */
     @DelicateKormiumApi
-    suspend fun executeUpdate(
+    public suspend fun executeUpdate(
         sql: String,
         params: Map<String, Any?>,
         invalidates: List<Table<G, *>>,
@@ -197,7 +197,7 @@ class SuspendScope<G : Catalog> internal constructor(
      * error on PostgreSQL and backend-dependent elsewhere).
      */
     @OptIn(ExperimentalContracts::class)
-    suspend fun <R> savepoint(block: suspend SuspendScope<G>.() -> R): R {
+    public suspend fun <R> savepoint(block: suspend SuspendScope<G>.() -> R): R {
         contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
         check(transactional) { "savepoint { } requires a transaction; use suspendTransaction { }, not suspendAutocommit { }" }
         val name = "korm_sp_${savepointCounter++}"
@@ -222,7 +222,7 @@ class SuspendScope<G : Catalog> internal constructor(
  * where the backend supports it.
  */
 @OptIn(ExperimentalContracts::class)
-suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendTransaction(
+public suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendTransaction(
     isolation: TransactionIsolation? = null,
     readOnly: Boolean = false,
     block: suspend SuspendScope<G>.() -> R,
@@ -240,7 +240,7 @@ suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendTransaction(
  * suspend counterpart of [autocommit], the cheap path for reads / single statements.
  */
 @OptIn(ExperimentalContracts::class)
-suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendAutocommit(block: suspend SuspendScope<G>.() -> R): R {
+public suspend fun <G : Catalog, R> SuspendDatabase<G>.suspendAutocommit(block: suspend SuspendScope<G>.() -> R): R {
     contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
     val dirty = mutableSetOf<String>()
     val result = useConnection(transactional = false) { SuspendScope<G>(it.observed(config), config, dirty, transactional = false).block() }

--- a/kormium-core/src/commonMain/kotlin/SuspendSqlExecutor.kt
+++ b/kormium-core/src/commonMain/kotlin/SuspendSqlExecutor.kt
@@ -14,14 +14,14 @@ import io.github.kormium.resultset.ResultSet
  * subtype — one object can't be both (a `suspend` and a non-`suspend` `execute`
  * with the same parameters clash).
  */
-interface SuspendSqlExecutor {
-    val dialect: Dialect
-    val typeMapper: TypeMapper
+public interface SuspendSqlExecutor {
+    public val dialect: Dialect
+    public val typeMapper: TypeMapper
 
-    suspend fun <T> execute(sql: String, namedParameters: Map<String, Any?> = emptyMap(), handler: (ResultSet) -> T): List<T>
-    suspend fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T>
-    suspend fun execute(sql: String, namedParameters: Map<String, Any?> = emptyMap()): Long
-    suspend fun execute(sql: String, paramSource: SqlParameterSource): Long
+    public suspend fun <T> execute(sql: String, namedParameters: Map<String, Any?> = emptyMap(), handler: (ResultSet) -> T): List<T>
+    public suspend fun <T> execute(sql: String, paramSource: SqlParameterSource, handler: (ResultSet) -> T): List<T>
+    public suspend fun execute(sql: String, namedParameters: Map<String, Any?> = emptyMap()): Long
+    public suspend fun execute(sql: String, paramSource: SqlParameterSource): Long
     /** Runs an INSERT/UPDATE/DELETE/DDL statement and returns the backend-reported affected row count. */
-    suspend fun executeUpdate(sql: String, namedParameters: Map<String, Any?> = emptyMap()): Long
+    public suspend fun executeUpdate(sql: String, namedParameters: Map<String, Any?> = emptyMap()): Long
 }

--- a/kormium-core/src/commonMain/kotlin/Table.kt
+++ b/kormium-core/src/commonMain/kotlin/Table.kt
@@ -16,7 +16,7 @@ private val logger = kormiumLogger()
  * and the suspend runner (taking [SuspendSqlExecutor]) share the same `*Sql`
  * helper and differ only in how they execute it.
  */
-abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: () -> T) {
+public abstract class Table<G: Catalog, T: Entity>(public val tableName: String, public val factory: () -> T) {
     /**
      * Builds an entity from a loaded field map (the database read path). Fails fast at the
      * database boundary when a column the entity declares non-null came back as SQL NULL — that
@@ -52,13 +52,13 @@ abstract class Table<G: Catalog, T: Entity>(val tableName: String, val factory: 
     private val fieldDisplayName: MutableMap<String, Column<*, *, T>> = mutableMapOf()
 
     /** The table's columns keyed by entity field name (Kotlin property name), in declaration order. */
-    fun getFieldDisplayNames(): Map<String, Column<*, *, *>> = fieldDisplayName
+    public fun getFieldDisplayNames(): Map<String, Column<*, *, *>> = fieldDisplayName
 
     /**
      * The primary-key column(s): those declared with `primaryKey = true`, or the column
      * named "id" if none are marked.
      */
-    val primaryKey: List<Column<*, *, T>>
+    public val primaryKey: List<Column<*, *, T>>
         get() = fieldDisplayName.values.filter { it.isPrimaryKey }
             .ifEmpty { fieldDisplayName.values.filter { it.fieldKey == "id" } }
     internal fun addColumn(fieldName: String, column: Column<*, *, T>) {

--- a/kormium-core/src/commonMain/kotlin/TransactionIsolation.kt
+++ b/kormium-core/src/commonMain/kotlin/TransactionIsolation.kt
@@ -19,7 +19,7 @@ package io.github.kormium
  * [sql] is the standard SQL spelling used by the SQL-driven native backends; the JDBC and
  * r2dbc backends translate the enum through their driver APIs instead.
  */
-enum class TransactionIsolation(val sql: String) {
+public enum class TransactionIsolation(public val sql: String) {
     ReadUncommitted("READ UNCOMMITTED"),
     ReadCommitted("READ COMMITTED"),
     RepeatableRead("REPEATABLE READ"),

--- a/kormium-core/src/commonMain/kotlin/TypeMapper.kt
+++ b/kormium-core/src/commonMain/kotlin/TypeMapper.kt
@@ -1,9 +1,9 @@
 package io.github.kormium
 
 /** Backend-specific conversion of a bound value to the driver's wire form. */
-interface TypeMapper {
+public interface TypeMapper {
     /** Converts [value] to the form bound as a parameter (e.g. UUID/Decimal → text). */
-    fun toParameter(value: Any?): Any?
+    public fun toParameter(value: Any?): Any?
 }
 
 /**
@@ -11,7 +11,7 @@ interface TypeMapper {
  * `stringtype=unspecified`). Non-primitive values are sent through toString(). Reading is
  * handled per column by [ColumnType.read], not here.
  */
-object StandardTypeMapper : TypeMapper {
+public object StandardTypeMapper : TypeMapper {
     override fun toParameter(value: Any?): Any? = when (value) {
         // ByteArray passes through so backends can bind it as binary (blob/bytea) rather than text.
         null, is Boolean, is Int, is Long, is Double, is String, is ByteArray -> value

--- a/kormium-core/src/commonMain/kotlin/UpdateBuilder.kt
+++ b/kormium-core/src/commonMain/kotlin/UpdateBuilder.kt
@@ -16,22 +16,22 @@ package io.github.kormium
  * `UPDATE` takes no `ORDER BY` / `LIMIT` / `OFFSET`, so this builder exposes only `set` and `where`.
  */
 @KormiumDsl
-class UpdateBuilder {
+public class UpdateBuilder {
     private val assignments = LinkedHashMap<Column<*, *, *>, Expression>()
     private val conditions = mutableListOf<Expression>()
 
     /** `Posts.views set (Posts.views + 1)`: assigns a SQL [Expression] to this column. */
-    infix fun <Z> Column<Z, *, *>.set(value: Expression) {
+    public infix fun <Z> Column<Z, *, *>.set(value: Expression) {
         assignments[this] = value
     }
 
     /** `Posts.pinned set false`: assigns a literal value, bound as a parameter. */
-    infix fun <Z> Column<Z, *, *>.set(value: Z) {
+    public infix fun <Z> Column<Z, *, *>.set(value: Z) {
         assignments[this] = Value(bindParam(value))
     }
 
     /** Adds a predicate; multiple `where { ... }` calls combine with `AND` (see [QueryBuilder.where]). */
-    fun where(block: () -> Expression) {
+    public fun where(block: () -> Expression) {
         conditions += block()
     }
 

--- a/kormium-core/src/commonMain/kotlin/WriteListener.kt
+++ b/kormium-core/src/commonMain/kotlin/WriteListener.kt
@@ -12,14 +12,14 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
  * [onCommit] is called synchronously on the thread that ran the transaction, so keep it
  * cheap and non-blocking — fan out to a coroutine/`Flow` off the hot path if you need to.
  */
-fun interface WriteListener {
+public fun interface WriteListener {
     /** [tables] is the non-empty set of table names written by the just-committed block. */
-    fun onCommit(tables: Set<String>)
+    public fun onCommit(tables: Set<String>)
 }
 
 /** Handle returned by [WriteListeners.add]; call [remove] to unregister the listener. */
-fun interface Registration {
-    fun remove()
+public fun interface Registration {
+    public fun remove()
 }
 
 /**
@@ -35,7 +35,7 @@ fun interface Registration {
  * collection, which can happen from many coroutines at once.
  */
 @OptIn(ExperimentalAtomicApi::class)
-open class WriteListeners {
+public open class WriteListeners {
     private val listeners = AtomicReference<List<WriteListener>>(emptyList())
 
     // The cross-process publish hook, set by `connectNotifications`. Kept SEPARATE from the
@@ -44,7 +44,7 @@ open class WriteListeners {
     private val commitPublish = AtomicReference<((Set<String>) -> Unit)?>(null)
 
     /** Registers [listener]; returns a [Registration] that removes it again. */
-    open fun add(listener: WriteListener): Registration {
+    public open fun add(listener: WriteListener): Registration {
         listeners.swap { it + listener }
         return Registration {
             listeners.swap { list -> list.filterNot { it === listener } }
@@ -52,17 +52,17 @@ open class WriteListeners {
     }
 
     /** Delivers [tables] to every registered listener. No-op when [tables] is empty. */
-    fun fire(tables: Set<String>) {
+    public fun fire(tables: Set<String>) {
         if (tables.isEmpty()) return
         val snapshot = listeners.load()
         for (l in snapshot) l.onCommit(tables)
     }
 
     /** True if at least one listener is registered (lets callers skip dirty-set bookkeeping). */
-    val isActive: Boolean get() = listeners.load().isNotEmpty()
+    public val isActive: Boolean get() = listeners.load().isNotEmpty()
 
     /** Installs (or clears, with `null`) the cross-process publish hook. Used by `connectNotifications`. */
-    open fun setCommitPublish(hook: ((Set<String>) -> Unit)?) {
+    public open fun setCommitPublish(hook: ((Set<String>) -> Unit)?) {
         commitPublish.swap { hook }
     }
 
@@ -71,13 +71,13 @@ open class WriteListeners {
      * commit path (after [fire]); the inbound/remote path uses [fire] alone, so remote signals are
      * never echoed back out.
      */
-    fun publishCommit(tables: Set<String>) {
+    public fun publishCommit(tables: Set<String>) {
         if (tables.isEmpty()) return
         commitPublish.load()?.invoke(tables)
     }
 
     /** The shared no-op registry for backends that don't support write notification. */
-    object Disabled : WriteListeners() {
+    public object Disabled : WriteListeners() {
         override fun add(listener: WriteListener): Registration = Registration {}
         override fun setCommitPublish(hook: ((Set<String>) -> Unit)?) {}
     }

--- a/kormium-core/src/commonMain/kotlin/database/Database.kt
+++ b/kormium-core/src/commonMain/kotlin/database/Database.kt
@@ -20,9 +20,9 @@ import io.github.kormium.WriteListeners
  * itself an [SqlExecutor]. Run one-off statements via `autocommit { execute(...) }` so every
  * write goes through a scope (and is therefore transactional and observable).
  */
-interface Database<out G : Catalog> : AutoCloseable {
+public interface Database<out G : Catalog> : AutoCloseable {
     /** Per-database configuration; defaults to [KormiumConfig] defaults unless a backend overrides it. */
-    val config: KormiumConfig get() = KormiumConfig()
+    public val config: KormiumConfig get() = KormiumConfig()
 
     /**
      * The SQL dialect this database renders to (placeholder style, identifier quoting, LIMIT/OFFSET,
@@ -30,14 +30,14 @@ interface Database<out G : Catalog> : AutoCloseable {
      * [StandardDialect] default keeps custom/test implementations compiling. Exposed so a query can
      * be rendered to its SQL without a connection — see [io.github.kormium.renderSql].
      */
-    val dialect: Dialect get() = StandardDialect
+    public val dialect: Dialect get() = StandardDialect
 
     /**
      * The write-notification registry for this database. The default [WriteListeners.Disabled]
      * means change observation (e.g. `kormium-observe`) does nothing; a backend opts in by
      * overriding this with a real [WriteListeners] instance.
      */
-    val writeListeners: WriteListeners get() = WriteListeners.Disabled
+    public val writeListeners: WriteListeners get() = WriteListeners.Disabled
 
     /**
      * Pins one connection for the duration of [block]; the [SqlExecutor] passed to it
@@ -46,7 +46,7 @@ interface Database<out G : Catalog> : AutoCloseable {
      * (if non-null) and [readOnly] are applied to the opened transaction; both are ignored in
      * autocommit. Backend-specific.
      */
-    fun <R> usePinned(
+    public fun <R> usePinned(
         transactional: Boolean,
         isolation: TransactionIsolation? = null,
         readOnly: Boolean = false,
@@ -58,7 +58,7 @@ interface Database<out G : Catalog> : AutoCloseable {
      * Once `true`, [usePinned] (and any `transaction` / `autocommit`) throws
      * [io.github.kormium.DatabaseClosedException].
      */
-    val isClosed: Boolean get() = false
+    public val isClosed: Boolean get() = false
 
     /**
      * Closes the underlying connection(s); the database is unusable afterwards. The contract,

--- a/kormium-core/src/commonMain/kotlin/database/SuspendDatabase.kt
+++ b/kormium-core/src/commonMain/kotlin/database/SuspendDatabase.kt
@@ -16,23 +16,23 @@ import io.github.kormium.WriteListeners
  * apart. A blocking backend (JDBC/SQLite) may implement BOTH; an async backend
  * implements only this one.
  */
-interface SuspendDatabase<out G : Catalog> : AutoCloseable {
+public interface SuspendDatabase<out G : Catalog> : AutoCloseable {
     /** Per-database configuration; defaults to [KormiumConfig] defaults unless a backend overrides it. */
-    val config: KormiumConfig get() = KormiumConfig()
+    public val config: KormiumConfig get() = KormiumConfig()
 
     /**
      * The SQL dialect this database renders to. Backends override it with their concrete dialect;
      * the neutral [StandardDialect] default keeps custom implementations compiling. Read it to render
      * a query for this backend offline: `renderSql(App, db.dialect) { ... }`.
      */
-    val dialect: Dialect get() = StandardDialect
+    public val dialect: Dialect get() = StandardDialect
 
     /**
      * The write-notification registry for this database. The default [WriteListeners.Disabled]
      * means change observation (e.g. `kormium-observe`) does nothing; a backend opts in by
      * overriding this with a real [WriteListeners] instance.
      */
-    val writeListeners: WriteListeners get() = WriteListeners.Disabled
+    public val writeListeners: WriteListeners get() = WriteListeners.Disabled
 
     /**
      * Pins one connection for the duration of [block]; the [SuspendSqlExecutor] passed
@@ -41,7 +41,7 @@ interface SuspendDatabase<out G : Catalog> : AutoCloseable {
      * (if non-null) and [readOnly] are applied to the opened transaction; both are ignored in
      * autocommit. Backend-specific.
      */
-    suspend fun <R> useConnection(
+    public suspend fun <R> useConnection(
         transactional: Boolean,
         isolation: TransactionIsolation? = null,
         readOnly: Boolean = false,
@@ -53,7 +53,7 @@ interface SuspendDatabase<out G : Catalog> : AutoCloseable {
      * Once `true`, [useConnection] (and any `suspendTransaction` / `suspendAutocommit`) throws
      * [io.github.kormium.DatabaseClosedException].
      */
-    val isClosed: Boolean get() = false
+    public val isClosed: Boolean get() = false
 
     /**
      * Closes the underlying connection(s); the database is unusable afterwards. Same contract as

--- a/kormium-core/src/commonMain/kotlin/resultset/ResultSet.kt
+++ b/kormium-core/src/commonMain/kotlin/resultset/ResultSet.kt
@@ -16,50 +16,50 @@ import kotlinx.datetime.LocalTime
  * The cursor starts before the first row; call [next] to advance.
  */
 @Suppress("TooManyFunctions")
-interface ResultSet {
+public interface ResultSet {
 
     /** The selected column names, in select-list order. */
-    val columns: Array<String>
+    public val columns: Array<String>
 
     /**
      * Moves the cursor forward one row. Returns `true` if the new current row is
      * valid, `false` when there are no more rows.
      */
-    fun next(): Boolean
+    public fun next(): Boolean
 
     /** Reads column [columnIndex] (0-based) as a [String], or `null` for SQL `NULL`. */
-    fun getString(columnIndex: Int): String?
+    public fun getString(columnIndex: Int): String?
 
     /** Reads column [columnIndex] (0-based) as a [Boolean], or `null` for SQL `NULL`. */
-    fun getBoolean(columnIndex: Int): Boolean?
+    public fun getBoolean(columnIndex: Int): Boolean?
 
     /** Reads column [columnIndex] (0-based) as a [Short], or `null` for SQL `NULL`. */
-    fun getShort(columnIndex: Int): Short?
+    public fun getShort(columnIndex: Int): Short?
 
     /** Reads column [columnIndex] (0-based) as an [Int], or `null` for SQL `NULL`. */
-    fun getInt(columnIndex: Int): Int?
+    public fun getInt(columnIndex: Int): Int?
 
     /** Reads column [columnIndex] (0-based) as a [Long], or `null` for SQL `NULL`. */
-    fun getLong(columnIndex: Int): Long?
+    public fun getLong(columnIndex: Int): Long?
 
     /** Reads column [columnIndex] (0-based) as a [Float], or `null` for SQL `NULL`. */
-    fun getFloat(columnIndex: Int): Float?
+    public fun getFloat(columnIndex: Int): Float?
 
     /** Reads column [columnIndex] (0-based) as a [Double], or `null` for SQL `NULL`. */
-    fun getDouble(columnIndex: Int): Double?
+    public fun getDouble(columnIndex: Int): Double?
 
     /** Reads column [columnIndex] (0-based) as the driver's raw bytes, or `null` for SQL `NULL`. */
-    fun getBytes(columnIndex: Int): ByteArray?
+    public fun getBytes(columnIndex: Int): ByteArray?
 
     /** Reads column [columnIndex] (0-based) as a [LocalDate], or `null` for SQL `NULL`. */
-    fun getDate(columnIndex: Int): LocalDate?
+    public fun getDate(columnIndex: Int): LocalDate?
 
     /** Reads column [columnIndex] (0-based) as a [LocalTime], or `null` for SQL `NULL`. */
-    fun getTime(columnIndex: Int): LocalTime?
+    public fun getTime(columnIndex: Int): LocalTime?
 
     /** Reads column [columnIndex] (0-based) as a [LocalDateTime], or `null` for SQL `NULL`. */
-    fun getLocalDateTime(columnIndex: Int): LocalDateTime?
+    public fun getLocalDateTime(columnIndex: Int): LocalDateTime?
 
     /** Reads column [columnIndex] (0-based) as an [Instant], or `null` for SQL `NULL`. */
-    fun getInstant(columnIndex: Int): Instant?
+    public fun getInstant(columnIndex: Int): Instant?
 }

--- a/kormium-core/src/commonMain/kotlin/sql/Extensions.kt
+++ b/kormium-core/src/commonMain/kotlin/sql/Extensions.kt
@@ -5,13 +5,13 @@ import kotlinx.serialization.json.JsonElement
 import kotlin.uuid.Uuid
 import io.github.kormium.resultset.ResultSet
 
-fun ResultSet.getUUID(columnIndex: Int): Uuid? {
+public fun ResultSet.getUUID(columnIndex: Int): Uuid? {
     return getString(columnIndex)?.let { Uuid.parse(it) }
 }
 
 // Note: ResultSet already provides getInstant() as a member (with the required
 // Postgres "space -> T" ISO-8601 fix), so no extension is defined here.
 
-fun ResultSet.getJson(columnIndex: Int): JsonElement? {
+public fun ResultSet.getJson(columnIndex: Int): JsonElement? {
     return getString(columnIndex)?.let { Json.parseToJsonElement(it) }
 }

--- a/kormium-decimal/api/jvm/kormium-decimal.api
+++ b/kormium-decimal/api/jvm/kormium-decimal.api
@@ -1,0 +1,14 @@
+public final class io/github/kormium/decimal/DecimalColumnType : io/github/kormium/ColumnType {
+	public static final field INSTANCE Lio/github/kormium/decimal/DecimalColumnType;
+	public fun getDescription ()Ljava/lang/String;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Lio/github/kormium/decimal/Decimal;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun toParam (Lio/github/kormium/decimal/Decimal;)Ljava/lang/Object;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/decimal/DecimalColumnTypeKt {
+	public static final fun decimal (Lio/github/kormium/Column$Companion;Ljava/lang/String;)Lio/github/kormium/Column$Spec;
+	public static synthetic fun decimal$default (Lio/github/kormium/Column$Companion;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kormium/Column$Spec;
+}
+

--- a/kormium-decimal/api/kormium-decimal.klib.api
+++ b/kormium-decimal/api/kormium-decimal.klib.api
@@ -1,0 +1,14 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64, macosArm64, macosX64, mingwX64, wasmJs, wasmWasi]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-decimal>
+final object io.github.kormium.decimal/DecimalColumnType : io.github.kormium/ColumnType<io.github.kormium.decimal/Decimal> { // io.github.kormium.decimal/DecimalColumnType|null[0]
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): io.github.kormium.decimal/Decimal? // io.github.kormium.decimal/DecimalColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+    final fun toParam(io.github.kormium.decimal/Decimal): kotlin/Any? // io.github.kormium.decimal/DecimalColumnType.toParam|toParam(io.github.kormium.decimal.Decimal){}[0]
+}
+
+final fun (io.github.kormium/Column.Companion).io.github.kormium.decimal/decimal(kotlin/String? = ...): io.github.kormium/Column.Spec<io.github.kormium.decimal/Decimal> // io.github.kormium.decimal/decimal|decimal@io.github.kormium.Column.Companion(kotlin.String?){}[0]

--- a/kormium-decimal/build.gradle.kts
+++ b/kormium-decimal/build.gradle.kts
@@ -9,6 +9,8 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm {

--- a/kormium-decimal/src/commonMain/kotlin/DecimalColumnType.kt
+++ b/kormium-decimal/src/commonMain/kotlin/DecimalColumnType.kt
@@ -11,12 +11,12 @@ import io.github.kormium.resultset.ResultSet
  * only carries the value — except on the JVM, where parameters bind as
  * `java.math.BigDecimal` so JDBC/r2dbc drivers declare the real `numeric` parameter type.
  */
-object DecimalColumnType : ColumnType<Decimal> {
+public object DecimalColumnType : ColumnType<Decimal> {
     override fun read(rs: ResultSet, index: Int): Decimal? = rs.getString(index)?.let(Decimal::parse)
     override fun toParam(value: Decimal): Any? = decimalToParam(value)
 }
 
 /** Declares a [Decimal] column: `val price by Column.decimal()`. */
-fun Column.Companion.decimal(name: String? = null): Column.Spec<Decimal> = of(DecimalColumnType, name)
+public fun Column.Companion.decimal(name: String? = null): Column.Spec<Decimal> = of(DecimalColumnType, name)
 
 internal expect fun decimalToParam(value: Decimal): Any?

--- a/kormium-jdbc/api/kormium-jdbc.api
+++ b/kormium-jdbc/api/kormium-jdbc.api
@@ -1,0 +1,42 @@
+public class io/github/kormium/jdbc/JdbcDatabase : io/github/kormium/database/Database, io/github/kormium/database/SuspendDatabase {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILio/github/kormium/Dialect;Lio/github/kormium/TypeMapper;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lio/github/kormium/KormiumConfig;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILio/github/kormium/Dialect;Lio/github/kormium/TypeMapper;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lio/github/kormium/KormiumConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public fun getConfig ()Lio/github/kormium/KormiumConfig;
+	public fun getDialect ()Lio/github/kormium/Dialect;
+	public fun getWriteListeners ()Lio/github/kormium/WriteListeners;
+	public fun isClosed ()Z
+	public fun useConnection (ZLio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun usePinned (ZLio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/jdbc/JdbcDatabaseKt {
+	public static final fun getStandardSqlExceptionTranslator ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class io/github/kormium/jdbc/JdbcExecutor : io/github/kormium/SqlExecutor {
+	public fun <init> (Ljava/sql/Connection;Lio/github/kormium/Dialect;Lio/github/kormium/TypeMapper;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/sql/Connection;Lio/github/kormium/Dialect;Lio/github/kormium/TypeMapper;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun execute (Ljava/lang/String;Lio/github/kormium/SqlParameterSource;)J
+	public fun execute (Ljava/lang/String;Lio/github/kormium/SqlParameterSource;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public fun execute (Ljava/lang/String;Ljava/util/Map;)J
+	public fun execute (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public fun executeUpdate (Ljava/lang/String;Ljava/util/Map;)J
+	public fun getDialect ()Lio/github/kormium/Dialect;
+	public fun getTypeMapper ()Lio/github/kormium/TypeMapper;
+}
+
+public final class io/github/kormium/jdbc/NamedParamStatement : java/lang/AutoCloseable {
+	public static final field Companion Lio/github/kormium/jdbc/NamedParamStatement$Companion;
+	public fun <init> (Ljava/sql/Connection;Ljava/lang/String;)V
+	public final fun bind (Lio/github/kormium/SqlParameterSource;)V
+	public fun close ()V
+	public final fun executeQuery ()Ljava/sql/ResultSet;
+	public final fun executeUpdate ()I
+	public final fun getPreparedStatement ()Ljava/sql/PreparedStatement;
+	public final fun setAny (Ljava/lang/String;Ljava/lang/Object;)V
+}
+
+public final class io/github/kormium/jdbc/NamedParamStatement$Companion {
+}
+

--- a/kormium-jdbc/build.gradle.kts
+++ b/kormium-jdbc/build.gradle.kts
@@ -7,6 +7,8 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm {

--- a/kormium-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/JdbcDatabase.kt
+++ b/kormium-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/JdbcDatabase.kt
@@ -25,17 +25,17 @@ import java.sql.PreparedStatement
 import java.sql.SQLException
 
 /** Wraps a driver [java.sql.ResultSet] in core's backend-agnostic [ResultSet]. */
-typealias ResultSetWrapper = (java.sql.ResultSet) -> ResultSet
+public typealias ResultSetWrapper = (java.sql.ResultSet) -> ResultSet
 
 /**
  * Translates a JDBC [SQLException] into a korm exception. Backends differ in how
  * they report constraint violations (Postgres via SQLSTATE, SQLite via result
  * codes), so each supplies its own mapping. The default maps the standard SQLSTATE.
  */
-typealias SqlExceptionTranslator = (SQLException) -> Throwable
+public typealias SqlExceptionTranslator = (SQLException) -> Throwable
 
 /** The default translator: maps the JDBC SQLSTATE to a typed core exception. */
-val StandardSqlExceptionTranslator: SqlExceptionTranslator =
+public val StandardSqlExceptionTranslator: SqlExceptionTranslator =
     { e -> sqlException(e.message ?: "SQL error", e.sqlState, e) }
 
 /**
@@ -47,7 +47,7 @@ val StandardSqlExceptionTranslator: SqlExceptionTranslator =
  * Open so a backend can subclass it purely to add its marker interface (e.g.
  * `class PostgresJdbcDriver(...) : JdbcDatabase(...), PostgresDriver`).
  */
-open class JdbcDatabase(
+public open class JdbcDatabase(
     jdbcUrl: String,
     username: String? = null,
     password: String? = null,
@@ -82,7 +82,7 @@ open class JdbcDatabase(
 
     override val isClosed: Boolean get() = lifecycle.isClosed
 
-    override fun close() = lifecycle.close()
+    override fun close(): Unit = lifecycle.close()
 
     override fun <R> usePinned(
         transactional: Boolean,
@@ -178,7 +178,7 @@ private val TransactionIsolation.jdbcLevel: Int
     }
 
 /** An [SqlExecutor] bound to one already-open JDBC connection. */
-class JdbcExecutor(
+public class JdbcExecutor(
     private val conn: Connection,
     override val dialect: Dialect,
     override val typeMapper: TypeMapper,

--- a/kormium-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/NamedParamStatement.kt
+++ b/kormium-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/NamedParamStatement.kt
@@ -12,8 +12,8 @@ import java.sql.SQLException
  * later be bound by name. `::` casts (Postgres) and quoted string literals are left
  * untouched, so the parser is backend-agnostic and shared by every JDBC backend.
  */
-class NamedParamStatement(conn: Connection, sql: String) : AutoCloseable {
-    val preparedStatement: PreparedStatement
+public class NamedParamStatement(conn: Connection, sql: String) : AutoCloseable {
+    public val preparedStatement: PreparedStatement
     private val fields: List<String>
 
     init {
@@ -30,24 +30,24 @@ class NamedParamStatement(conn: Connection, sql: String) : AutoCloseable {
     }
 
     @Throws(SQLException::class)
-    fun executeQuery(): java.sql.ResultSet {
+    public fun executeQuery(): java.sql.ResultSet {
         return preparedStatement.executeQuery()
     }
 
     @Throws(SQLException::class)
-    fun executeUpdate(): Int {
+    public fun executeUpdate(): Int {
         return preparedStatement.executeUpdate()
     }
 
     /** Binds every named placeholder in the statement from [paramSource], by name. */
-    fun bind(paramSource: SqlParameterSource) {
+    public fun bind(paramSource: SqlParameterSource) {
         for (name in fields.toSet()) {
             require(paramSource.hasValue(name)) { "No value supplied for parameter \"$name\"" }
             setAny(name, paramSource.getValue(name))
         }
     }
 
-    fun setAny(name: String, value: Any?) {
+    public fun setAny(name: String, value: Any?) {
         for (index in indexesOf(name)) {
             when (value) {
                 null -> preparedStatement.setObject(index, null)
@@ -73,7 +73,7 @@ class NamedParamStatement(conn: Connection, sql: String) : AutoCloseable {
 
     private class Parsed(val sql: String, val fields: List<String>)
 
-    companion object {
+    public companion object {
         // Reparsing is one cheap pass over the SQL string; the cache only saves it for hot,
         // repeated statements. Bound it so one-off SQL cannot grow it without limit: an
         // access-order LRU capped at MAX_CACHE_ENTRIES, and SQL longer than

--- a/kormium-ktor-di/api/kormium-ktor-di.klib.api
+++ b/kormium-ktor-di/api/kormium-ktor-di.klib.api
@@ -1,0 +1,13 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, linuxX64, macosArm64, macosX64, mingwX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-ktor-di>
+final suspend inline fun <#A: reified io.github.kormium/Catalog, #B: kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.github.kormium.ktor.di/autocommit(#A, noinline kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium.ktor.di/autocommit|autocommit@io.ktor.server.application.ApplicationCall(0:0;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final suspend inline fun <#A: reified io.github.kormium/Catalog, #B: kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.github.kormium.ktor.di/autocommit(noinline kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium.ktor.di/autocommit|autocommit@io.ktor.server.application.ApplicationCall(kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final suspend inline fun <#A: reified io.github.kormium/Catalog, #B: kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.github.kormium.ktor.di/transaction(#A, noinline kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium.ktor.di/transaction|transaction@io.ktor.server.application.ApplicationCall(0:0;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final suspend inline fun <#A: reified io.github.kormium/Catalog, #B: kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.github.kormium.ktor.di/transaction(noinline kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium.ktor.di/transaction|transaction@io.ktor.server.application.ApplicationCall(kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final suspend inline fun <#A: reified io.github.kormium/Catalog> (io.ktor.server.application/ApplicationCall).io.github.kormium.ktor.di/kormium(): io.github.kormium.ktor/KormiumHandle<#A> // io.github.kormium.ktor.di/kormium|kormium@io.ktor.server.application.ApplicationCall(){0§<io.github.kormium.Catalog>}[0]

--- a/kormium-ktor-di/build.gradle.kts
+++ b/kormium-ktor-di/build.gradle.kts
@@ -14,6 +14,8 @@ repositories {
 val ktorVersion = "3.5.0"
 
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm {

--- a/kormium-ktor-di/src/commonMain/kotlin/Dependencies.kt
+++ b/kormium-ktor-di/src/commonMain/kotlin/Dependencies.kt
@@ -19,29 +19,29 @@ import io.ktor.server.plugins.di.resolve
  * ```
  * This is the chain form (c): `call.kormium<AppCatalog>().transaction { ... }`.
  */
-suspend inline fun <reified G : Catalog> ApplicationCall.kormium(): KormiumHandle<G> =
+public suspend inline fun <reified G : Catalog> ApplicationCall.kormium(): KormiumHandle<G> =
     KormiumHandle(application.dependencies.resolve<SuspendDatabase<G>>())
 
 // --- (a) catalog as a TYPE argument — `call.transaction<AppCatalog, _> { ... }` ---------------
 // The `_` lets the return type infer while the catalog is given explicitly as a type.
 
-suspend inline fun <reified G : Catalog, R> ApplicationCall.transaction(
+public suspend inline fun <reified G : Catalog, R> ApplicationCall.transaction(
     noinline block: suspend SuspendScope<G>.() -> R,
 ): R = kormium<G>().database.suspendTransaction(block = block)
 
-suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
+public suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
     noinline block: suspend SuspendScope<G>.() -> R,
 ): R = kormium<G>().database.suspendAutocommit(block)
 
 // --- (b) catalog as a VALUE — `call.transaction(AppCatalog) { ... }` --------------------------
 // Both type parameters infer (G from the catalog argument, R from the block); no `_` needed.
 
-suspend inline fun <reified G : Catalog, R> ApplicationCall.transaction(
+public suspend inline fun <reified G : Catalog, R> ApplicationCall.transaction(
     catalog: G,
     noinline block: suspend SuspendScope<G>.() -> R,
 ): R = kormium<G>().database.suspendTransaction(block = block)
 
-suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
+public suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
     catalog: G,
     noinline block: suspend SuspendScope<G>.() -> R,
 ): R = kormium<G>().database.suspendAutocommit(block)

--- a/kormium-ktor-koin/api/kormium-ktor-koin.klib.api
+++ b/kormium-ktor-koin/api/kormium-ktor-koin.klib.api
@@ -1,0 +1,13 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, linuxX64, macosArm64, macosX64, mingwX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-ktor-koin>
+final inline fun <#A: reified io.github.kormium/Catalog> (io.ktor.server.application/ApplicationCall).io.github.kormium.ktor.koin/kormium(org.koin.core.qualifier/Qualifier? = ...): io.github.kormium.ktor/KormiumHandle<#A> // io.github.kormium.ktor.koin/kormium|kormium@io.ktor.server.application.ApplicationCall(org.koin.core.qualifier.Qualifier?){0§<io.github.kormium.Catalog>}[0]
+final suspend inline fun <#A: reified io.github.kormium/Catalog, #B: kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.github.kormium.ktor.koin/autocommit(#A, org.koin.core.qualifier/Qualifier? = ..., noinline kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium.ktor.koin/autocommit|autocommit@io.ktor.server.application.ApplicationCall(0:0;org.koin.core.qualifier.Qualifier?;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final suspend inline fun <#A: reified io.github.kormium/Catalog, #B: kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.github.kormium.ktor.koin/autocommit(noinline kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium.ktor.koin/autocommit|autocommit@io.ktor.server.application.ApplicationCall(kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final suspend inline fun <#A: reified io.github.kormium/Catalog, #B: kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.github.kormium.ktor.koin/transaction(#A, org.koin.core.qualifier/Qualifier? = ..., noinline kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium.ktor.koin/transaction|transaction@io.ktor.server.application.ApplicationCall(0:0;org.koin.core.qualifier.Qualifier?;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final suspend inline fun <#A: reified io.github.kormium/Catalog, #B: kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.github.kormium.ktor.koin/transaction(noinline kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium.ktor.koin/transaction|transaction@io.ktor.server.application.ApplicationCall(kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]

--- a/kormium-ktor-koin/build.gradle.kts
+++ b/kormium-ktor-koin/build.gradle.kts
@@ -14,6 +14,8 @@ repositories {
 val koinVersion = "4.1.0"
 
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm {

--- a/kormium-ktor-koin/src/commonMain/kotlin/Koin.kt
+++ b/kormium-ktor-koin/src/commonMain/kotlin/Koin.kt
@@ -22,31 +22,31 @@ import org.koin.ktor.ext.getKoin
  * // call.kormium<AppCatalog>(named("app"))
  * ```
  */
-inline fun <reified G : Catalog> ApplicationCall.kormium(qualifier: Qualifier? = null): KormiumHandle<G> =
+public inline fun <reified G : Catalog> ApplicationCall.kormium(qualifier: Qualifier? = null): KormiumHandle<G> =
     KormiumHandle(getKoin().get(qualifier = qualifier))
 
 // --- (a) catalog as a TYPE argument — `call.transaction<AppCatalog, _> { ... }` ---------------
 // The `_` lets the return type infer while the catalog is given explicitly as a type.
 // For a named dependency use the value form (b) or `kormium<G>(qualifier).transaction { }`.
 
-suspend inline fun <reified G : Catalog, R> ApplicationCall.transaction(
+public suspend inline fun <reified G : Catalog, R> ApplicationCall.transaction(
     noinline block: suspend SuspendScope<G>.() -> R,
 ): R = kormium<G>().database.suspendTransaction(block = block)
 
-suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
+public suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
     noinline block: suspend SuspendScope<G>.() -> R,
 ): R = kormium<G>().database.suspendAutocommit(block)
 
 // --- (b) catalog as a VALUE — `call.transaction(AppCatalog) { ... }` --------------------------
 // Both type parameters infer; pass a [qualifier] for a named dependency.
 
-suspend inline fun <reified G : Catalog, R> ApplicationCall.transaction(
+public suspend inline fun <reified G : Catalog, R> ApplicationCall.transaction(
     catalog: G,
     qualifier: Qualifier? = null,
     noinline block: suspend SuspendScope<G>.() -> R,
 ): R = kormium<G>(qualifier).database.suspendTransaction(block = block)
 
-suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
+public suspend inline fun <reified G : Catalog, R> ApplicationCall.autocommit(
     catalog: G,
     qualifier: Qualifier? = null,
     noinline block: suspend SuspendScope<G>.() -> R,

--- a/kormium-ktor/api/jvm/kormium-ktor.api
+++ b/kormium-ktor/api/jvm/kormium-ktor.api
@@ -1,0 +1,39 @@
+public final class io/github/kormium/ktor/HandleKt {
+	public static final fun autocommit-dyLudls (Lio/github/kormium/database/SuspendDatabase;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun transaction-4omT0h8 (Lio/github/kormium/database/SuspendDatabase;Lio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun transaction-4omT0h8$default (Lio/github/kormium/database/SuspendDatabase;Lio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/ktor/KormiumConfig {
+	public fun <init> ()V
+	public final fun manage (Ljava/lang/AutoCloseable;)V
+}
+
+public final class io/github/kormium/ktor/KormiumHandle {
+	public static final synthetic fun box-impl (Lio/github/kormium/database/SuspendDatabase;)Lio/github/kormium/ktor/KormiumHandle;
+	public static fun constructor-impl (Lio/github/kormium/database/SuspendDatabase;)Lio/github/kormium/database/SuspendDatabase;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Lio/github/kormium/database/SuspendDatabase;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Lio/github/kormium/database/SuspendDatabase;Lio/github/kormium/database/SuspendDatabase;)Z
+	public final fun getDatabase ()Lio/github/kormium/database/SuspendDatabase;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Lio/github/kormium/database/SuspendDatabase;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Lio/github/kormium/database/SuspendDatabase;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Lio/github/kormium/database/SuspendDatabase;
+}
+
+public final class io/github/kormium/ktor/KormiumPluginKt {
+	public static final fun getKormium ()Lio/ktor/server/application/ApplicationPlugin;
+}
+
+public final class io/github/kormium/ktor/StatusCodesKt {
+	public static final fun httpStatusCode (Lio/github/kormium/KormiumException;)Lio/ktor/http/HttpStatusCode;
+}
+
+public final class io/github/kormium/ktor/TransactionsKt {
+	public static final fun autocommit (Lio/ktor/server/application/ApplicationCall;Lio/github/kormium/database/SuspendDatabase;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun transaction (Lio/ktor/server/application/ApplicationCall;Lio/github/kormium/database/SuspendDatabase;Lio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun transaction$default (Lio/ktor/server/application/ApplicationCall;Lio/github/kormium/database/SuspendDatabase;Lio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+

--- a/kormium-ktor/api/kormium-ktor.klib.api
+++ b/kormium-ktor/api/kormium-ktor.klib.api
@@ -1,0 +1,33 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, linuxX64, macosArm64, macosX64, mingwX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-ktor>
+final class io.github.kormium.ktor/KormiumConfig { // io.github.kormium.ktor/KormiumConfig|null[0]
+    constructor <init>() // io.github.kormium.ktor/KormiumConfig.<init>|<init>(){}[0]
+
+    final fun manage(kotlin/AutoCloseable) // io.github.kormium.ktor/KormiumConfig.manage|manage(kotlin.AutoCloseable){}[0]
+}
+
+final value class <#A: io.github.kormium/Catalog> io.github.kormium.ktor/KormiumHandle { // io.github.kormium.ktor/KormiumHandle|null[0]
+    constructor <init>(io.github.kormium.database/SuspendDatabase<#A>) // io.github.kormium.ktor/KormiumHandle.<init>|<init>(io.github.kormium.database.SuspendDatabase<1:0>){}[0]
+
+    final val database // io.github.kormium.ktor/KormiumHandle.database|{}database[0]
+        final fun <get-database>(): io.github.kormium.database/SuspendDatabase<#A> // io.github.kormium.ktor/KormiumHandle.database.<get-database>|<get-database>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // io.github.kormium.ktor/KormiumHandle.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // io.github.kormium.ktor/KormiumHandle.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // io.github.kormium.ktor/KormiumHandle.toString|toString(){}[0]
+}
+
+final val io.github.kormium.ktor/Kormium // io.github.kormium.ktor/Kormium|{}Kormium[0]
+    final fun <get-Kormium>(): io.ktor.server.application/ApplicationPlugin<io.github.kormium.ktor/KormiumConfig> // io.github.kormium.ktor/Kormium.<get-Kormium>|<get-Kormium>(){}[0]
+
+final fun (io.github.kormium/KormiumException).io.github.kormium.ktor/httpStatusCode(): io.ktor.http/HttpStatusCode // io.github.kormium.ktor/httpStatusCode|httpStatusCode@io.github.kormium.KormiumException(){}[0]
+final suspend fun <#A: io.github.kormium/Catalog, #B: kotlin/Any?> (io.github.kormium.ktor/KormiumHandle<#A>).io.github.kormium.ktor/autocommit(kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium.ktor/autocommit|autocommit@io.github.kormium.ktor.KormiumHandle<0:0>(kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final suspend fun <#A: io.github.kormium/Catalog, #B: kotlin/Any?> (io.github.kormium.ktor/KormiumHandle<#A>).io.github.kormium.ktor/transaction(io.github.kormium/TransactionIsolation? = ..., kotlin/Boolean = ..., kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium.ktor/transaction|transaction@io.github.kormium.ktor.KormiumHandle<0:0>(io.github.kormium.TransactionIsolation?;kotlin.Boolean;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final suspend fun <#A: io.github.kormium/Catalog, #B: kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.github.kormium.ktor/autocommit(io.github.kormium.database/SuspendDatabase<#A>, kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium.ktor/autocommit|autocommit@io.ktor.server.application.ApplicationCall(io.github.kormium.database.SuspendDatabase<0:0>;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]
+final suspend fun <#A: io.github.kormium/Catalog, #B: kotlin/Any?> (io.ktor.server.application/ApplicationCall).io.github.kormium.ktor/transaction(io.github.kormium.database/SuspendDatabase<#A>, io.github.kormium/TransactionIsolation? = ..., kotlin/Boolean = ..., kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): #B // io.github.kormium.ktor/transaction|transaction@io.ktor.server.application.ApplicationCall(io.github.kormium.database.SuspendDatabase<0:0>;io.github.kormium.TransactionIsolation?;kotlin.Boolean;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]

--- a/kormium-ktor/build.gradle.kts
+++ b/kormium-ktor/build.gradle.kts
@@ -14,6 +14,8 @@ repositories {
 val ktorVersion = "3.5.0"
 
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm {

--- a/kormium-ktor/src/commonMain/kotlin/Handle.kt
+++ b/kormium-ktor/src/commonMain/kotlin/Handle.kt
@@ -16,15 +16,15 @@ import kotlin.jvm.JvmInline
  * `kormium<G>()` accessors.
  */
 @JvmInline
-value class KormiumHandle<G : Catalog>(val database: SuspendDatabase<G>)
+public value class KormiumHandle<G : Catalog>(public val database: SuspendDatabase<G>)
 
 /** Runs [block] in a transaction on the wrapped database; see [io.github.kormium.suspendTransaction]. */
-suspend fun <G : Catalog, R> KormiumHandle<G>.transaction(
+public suspend fun <G : Catalog, R> KormiumHandle<G>.transaction(
     isolation: TransactionIsolation? = null,
     readOnly: Boolean = false,
     block: suspend SuspendScope<G>.() -> R,
 ): R = database.suspendTransaction(isolation, readOnly, block)
 
 /** Runs [block] in autocommit on the wrapped database; see [io.github.kormium.suspendAutocommit]. */
-suspend fun <G : Catalog, R> KormiumHandle<G>.autocommit(block: suspend SuspendScope<G>.() -> R): R =
+public suspend fun <G : Catalog, R> KormiumHandle<G>.autocommit(block: suspend SuspendScope<G>.() -> R): R =
     database.suspendAutocommit(block)

--- a/kormium-ktor/src/commonMain/kotlin/KormiumPlugin.kt
+++ b/kormium-ktor/src/commonMain/kotlin/KormiumPlugin.kt
@@ -6,7 +6,7 @@ import io.ktor.server.application.hooks.MonitoringEvent
 import io.ktor.server.application.log
 
 /** Configuration for the [Kormium] plugin. */
-class KormiumConfig {
+public class KormiumConfig {
     internal val managed = mutableListOf<AutoCloseable>()
 
     /**
@@ -15,7 +15,7 @@ class KormiumConfig {
      * you are NOT managing the database's lifecycle elsewhere — Ktor's built-in DI already closes
      * `AutoCloseable` dependencies on shutdown, so registering it there makes this unnecessary.
      */
-    fun manage(db: AutoCloseable) {
+    public fun manage(db: AutoCloseable) {
         managed += db
     }
 }
@@ -29,7 +29,7 @@ class KormiumConfig {
  * install(Kormium) { manage(database) }
  * ```
  */
-val Kormium = createApplicationPlugin(name = "Kormium", createConfiguration = ::KormiumConfig) {
+public val Kormium: io.ktor.server.application.ApplicationPlugin<KormiumConfig> = createApplicationPlugin(name = "Kormium", createConfiguration = ::KormiumConfig) {
     val managed = pluginConfig.managed.toList()
     on(MonitoringEvent(ApplicationStopped)) { application ->
         managed.forEach { db ->

--- a/kormium-ktor/src/commonMain/kotlin/StatusCodes.kt
+++ b/kormium-ktor/src/commonMain/kotlin/StatusCodes.kt
@@ -22,7 +22,7 @@ import io.ktor.http.HttpStatusCode
  * }
  * ```
  */
-fun KormiumException.httpStatusCode(): HttpStatusCode = when (this) {
+public fun KormiumException.httpStatusCode(): HttpStatusCode = when (this) {
     is UniqueViolationException -> HttpStatusCode.Conflict
     is ForeignKeyViolationException -> HttpStatusCode.BadRequest
     is NotNullViolationException -> HttpStatusCode.BadRequest

--- a/kormium-ktor/src/commonMain/kotlin/Transactions.kt
+++ b/kormium-ktor/src/commonMain/kotlin/Transactions.kt
@@ -18,7 +18,7 @@ import io.ktor.server.application.ApplicationCall
  * reference. The `kormium-ktor-di` / `kormium-ktor-koin` artifacts add reified overloads that resolve
  * the database for you.
  */
-suspend fun <G : Catalog, R> ApplicationCall.transaction(
+public suspend fun <G : Catalog, R> ApplicationCall.transaction(
     db: SuspendDatabase<G>,
     isolation: TransactionIsolation? = null,
     readOnly: Boolean = false,
@@ -29,7 +29,7 @@ suspend fun <G : Catalog, R> ApplicationCall.transaction(
  * Runs [block] on [db] in autocommit (no surrounding transaction) — the cheap path for reads /
  * single statements. See [transaction] for the DI-agnostic rationale.
  */
-suspend fun <G : Catalog, R> ApplicationCall.autocommit(
+public suspend fun <G : Catalog, R> ApplicationCall.autocommit(
     db: SuspendDatabase<G>,
     block: suspend SuspendScope<G>.() -> R,
 ): R = db.suspendAutocommit(block)

--- a/kormium-migrate/api/jvm/kormium-migrate.api
+++ b/kormium-migrate/api/jvm/kormium-migrate.api
@@ -1,0 +1,17 @@
+public final class io/github/kormium/migrate/Migration {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun getId ()Ljava/lang/String;
+}
+
+public final class io/github/kormium/migrate/MigrationChecksumException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getCurrent ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getRecorded ()Ljava/lang/String;
+}
+
+public final class io/github/kormium/migrate/MigrationKt {
+	public static final fun migrate (Lio/github/kormium/database/Database;Ljava/util/List;)V
+}
+

--- a/kormium-migrate/api/kormium-migrate.klib.api
+++ b/kormium-migrate/api/kormium-migrate.klib.api
@@ -1,0 +1,28 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64, macosArm64, macosX64, mingwX64, wasmJs, wasmWasi]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-migrate>
+final class <#A: io.github.kormium/Catalog> io.github.kormium.migrate/Migration { // io.github.kormium.migrate/Migration|null[0]
+    constructor <init>(kotlin/String, kotlin.collections/List<kotlin/String>) // io.github.kormium.migrate/Migration.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.String>){}[0]
+    constructor <init>(kotlin/String, kotlin/String) // io.github.kormium.migrate/Migration.<init>|<init>(kotlin.String;kotlin.String){}[0]
+
+    final val id // io.github.kormium.migrate/Migration.id|{}id[0]
+        final fun <get-id>(): kotlin/String // io.github.kormium.migrate/Migration.id.<get-id>|<get-id>(){}[0]
+}
+
+final class io.github.kormium.migrate/MigrationChecksumException : kotlin/RuntimeException { // io.github.kormium.migrate/MigrationChecksumException|null[0]
+    constructor <init>(kotlin/String, kotlin/String, kotlin/String) // io.github.kormium.migrate/MigrationChecksumException.<init>|<init>(kotlin.String;kotlin.String;kotlin.String){}[0]
+
+    final val current // io.github.kormium.migrate/MigrationChecksumException.current|{}current[0]
+        final fun <get-current>(): kotlin/String // io.github.kormium.migrate/MigrationChecksumException.current.<get-current>|<get-current>(){}[0]
+    final val id // io.github.kormium.migrate/MigrationChecksumException.id|{}id[0]
+        final fun <get-id>(): kotlin/String // io.github.kormium.migrate/MigrationChecksumException.id.<get-id>|<get-id>(){}[0]
+    final val recorded // io.github.kormium.migrate/MigrationChecksumException.recorded|{}recorded[0]
+        final fun <get-recorded>(): kotlin/String // io.github.kormium.migrate/MigrationChecksumException.recorded.<get-recorded>|<get-recorded>(){}[0]
+}
+
+final fun <#A: io.github.kormium/Catalog> (io.github.kormium.database/Database<#A>).io.github.kormium.migrate/migrate(kotlin.collections/List<io.github.kormium.migrate/Migration<#A>>) // io.github.kormium.migrate/migrate|migrate@io.github.kormium.database.Database<0:0>(kotlin.collections.List<io.github.kormium.migrate.Migration<0:0>>){0§<io.github.kormium.Catalog>}[0]

--- a/kormium-migrate/build.gradle.kts
+++ b/kormium-migrate/build.gradle.kts
@@ -12,6 +12,8 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm {

--- a/kormium-migrate/src/commonMain/kotlin/Migration.kt
+++ b/kormium-migrate/src/commonMain/kotlin/Migration.kt
@@ -26,8 +26,8 @@ import kotlin.time.Clock
  * For SQL the splitter cannot handle (e.g. a Postgres function body that itself contains `;`),
  * pass the statements explicitly with the `List<String>` constructor.
  */
-class Migration<G : Catalog> private constructor(
-    val id: String,
+public class Migration<G : Catalog> private constructor(
+    public val id: String,
     internal val statements: List<String>,
     internal val checksum: String,
 ) {
@@ -42,10 +42,10 @@ class Migration<G : Catalog> private constructor(
     }
 
     /** A migration written as one SQL string; statements are separated by top-level `;`. */
-    constructor(id: String, sql: String) : this(id, splitStatements(sql), crc32(normalize(sql)))
+    public constructor(id: String, sql: String) : this(id, splitStatements(sql), crc32(normalize(sql)))
 
     /** A migration written as explicit statements; bypasses the SQL splitter. */
-    constructor(id: String, statements: List<String>) :
+    public constructor(id: String, statements: List<String>) :
         this(id, statements, crc32(statements.joinToString("\n;\n") { normalize(it) }))
 }
 
@@ -57,10 +57,10 @@ class Migration<G : Catalog> private constructor(
 private const val MAX_ID_LENGTH = 255
 
 /** Thrown when an already-applied migration's SQL no longer matches the recorded checksum. */
-class MigrationChecksumException(
-    val id: String,
-    val recorded: String,
-    val current: String,
+public class MigrationChecksumException(
+    public val id: String,
+    public val recorded: String,
+    public val current: String,
 ) : RuntimeException(
     "Migration \"$id\" was modified after it was applied " +
         "(recorded checksum $recorded, current $current). " +
@@ -102,7 +102,7 @@ private const val JOURNAL = "kormium_migrations"
  * `migrate(...)` on every startup is fine — typically from a `beforeStart { migrate(appMigrations) }`
  * block on the `createX { }` builder.
  */
-fun <G : Catalog> Database<G>.migrate(migrations: List<Migration<G>>) {
+public fun <G : Catalog> Database<G>.migrate(migrations: List<Migration<G>>) {
     usePinned(transactional = true) { exec ->
         exec.dialect.advisoryLockSql(migrationLockKey)?.let { exec.execute(it) }
 

--- a/kormium-mysql-dialect/api/kormium-mysql-dialect.api
+++ b/kormium-mysql-dialect/api/kormium-mysql-dialect.api
@@ -1,0 +1,17 @@
+public final class io/github/kormium/MySqlDialect : io/github/kormium/Dialect {
+	public static final field INSTANCE Lio/github/kormium/MySqlDialect;
+	public fun advisoryLockSql (J)Ljava/lang/String;
+	public fun getReadOnlyToggle ()Lio/github/kormium/ReadOnlyToggle;
+	public fun getSupportsReturning ()Z
+	public fun getSupportsTransactionIsolation ()Z
+	public fun quoteIdentifier (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderBind (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/String;
+	public fun renderCharLength (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderInsertDefaultValues (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderInsertOrIgnoreSuffix (Ljava/util/List;)Ljava/lang/String;
+	public fun renderLimit-WZ4Q5Ns (I)Ljava/lang/String;
+	public fun renderLimitOffset-feOb9K0 (II)Ljava/lang/String;
+	public fun renderOffset-WZ4Q5Ns (I)Ljava/lang/String;
+	public fun renderUpsertSuffix (Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;
+}
+

--- a/kormium-mysql-dialect/api/kormium-mysql-dialect.klib.api
+++ b/kormium-mysql-dialect/api/kormium-mysql-dialect.klib.api
@@ -1,0 +1,27 @@
+// Klib ABI Dump
+// Targets: [js, linuxX64, macosArm64, macosX64, wasmJs, wasmWasi]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-mysql-dialect>
+final object io.github.kormium/MySqlDialect : io.github.kormium/Dialect { // io.github.kormium/MySqlDialect|null[0]
+    final val readOnlyToggle // io.github.kormium/MySqlDialect.readOnlyToggle|{}readOnlyToggle[0]
+        final fun <get-readOnlyToggle>(): io.github.kormium/ReadOnlyToggle? // io.github.kormium/MySqlDialect.readOnlyToggle.<get-readOnlyToggle>|<get-readOnlyToggle>(){}[0]
+    final val supportsReturning // io.github.kormium/MySqlDialect.supportsReturning|{}supportsReturning[0]
+        final fun <get-supportsReturning>(): kotlin/Boolean // io.github.kormium/MySqlDialect.supportsReturning.<get-supportsReturning>|<get-supportsReturning>(){}[0]
+    final val supportsTransactionIsolation // io.github.kormium/MySqlDialect.supportsTransactionIsolation|{}supportsTransactionIsolation[0]
+        final fun <get-supportsTransactionIsolation>(): kotlin/Boolean // io.github.kormium/MySqlDialect.supportsTransactionIsolation.<get-supportsTransactionIsolation>|<get-supportsTransactionIsolation>(){}[0]
+
+    final fun advisoryLockSql(kotlin/Long): kotlin/String? // io.github.kormium/MySqlDialect.advisoryLockSql|advisoryLockSql(kotlin.Long){}[0]
+    final fun quoteIdentifier(kotlin/String): kotlin/String // io.github.kormium/MySqlDialect.quoteIdentifier|quoteIdentifier(kotlin.String){}[0]
+    final fun renderBind(kotlin/String, kotlin/Any?): kotlin/String // io.github.kormium/MySqlDialect.renderBind|renderBind(kotlin.String;kotlin.Any?){}[0]
+    final fun renderCharLength(kotlin/String): kotlin/String // io.github.kormium/MySqlDialect.renderCharLength|renderCharLength(kotlin.String){}[0]
+    final fun renderInsertDefaultValues(kotlin/String): kotlin/String // io.github.kormium/MySqlDialect.renderInsertDefaultValues|renderInsertDefaultValues(kotlin.String){}[0]
+    final fun renderInsertOrIgnoreSuffix(kotlin.collections/List<kotlin/String>): kotlin/String // io.github.kormium/MySqlDialect.renderInsertOrIgnoreSuffix|renderInsertOrIgnoreSuffix(kotlin.collections.List<kotlin.String>){}[0]
+    final fun renderLimit(kotlin/UInt): kotlin/String // io.github.kormium/MySqlDialect.renderLimit|renderLimit(kotlin.UInt){}[0]
+    final fun renderLimitOffset(kotlin/UInt, kotlin/UInt): kotlin/String // io.github.kormium/MySqlDialect.renderLimitOffset|renderLimitOffset(kotlin.UInt;kotlin.UInt){}[0]
+    final fun renderOffset(kotlin/UInt): kotlin/String // io.github.kormium/MySqlDialect.renderOffset|renderOffset(kotlin.UInt){}[0]
+    final fun renderUpsertSuffix(kotlin.collections/List<kotlin/String>, kotlin/String): kotlin/String // io.github.kormium/MySqlDialect.renderUpsertSuffix|renderUpsertSuffix(kotlin.collections.List<kotlin.String>;kotlin.String){}[0]
+}

--- a/kormium-mysql-dialect/build.gradle.kts
+++ b/kormium-mysql-dialect/build.gradle.kts
@@ -12,6 +12,8 @@ repositories {
 // driver's reach (jvm + the three unix native targets; no mingw — Windows uses the JVM driver)
 // plus the web stack.
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm()

--- a/kormium-mysql-dialect/src/commonMain/kotlin/MySqlDialect.kt
+++ b/kormium-mysql-dialect/src/commonMain/kotlin/MySqlDialect.kt
@@ -13,7 +13,7 @@ package io.github.kormium
  * [Uuid] is stored as text (`CHAR(36)`) and a [kotlinx.serialization.json.JsonElement] binds as a
  * string literal into a `JSON` column — both handled by `MySqlJvmTypeMapper`, not the dialect.
  */
-object MySqlDialect : Dialect by StandardDialect {
+public object MySqlDialect : Dialect by StandardDialect {
     override fun quoteIdentifier(name: String): String =
         "`${name.replace("`", "``")}`"
 

--- a/kormium-mysql-node/api/kormium-mysql-node.klib.api
+++ b/kormium-mysql-node/api/kormium-mysql-node.klib.api
@@ -1,0 +1,23 @@
+// Klib ABI Dump
+// Targets: [wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-mysql-node>
+final class io.github.kormium.mysql.node/MySqlDatabase : io.github.kormium.database/SuspendDatabase<kotlin/Nothing> { // io.github.kormium.mysql.node/MySqlDatabase|null[0]
+    final val config // io.github.kormium.mysql.node/MySqlDatabase.config|{}config[0]
+        final fun <get-config>(): io.github.kormium/KormiumConfig // io.github.kormium.mysql.node/MySqlDatabase.config.<get-config>|<get-config>(){}[0]
+    final val dialect // io.github.kormium.mysql.node/MySqlDatabase.dialect|{}dialect[0]
+        final fun <get-dialect>(): io.github.kormium/MySqlDialect // io.github.kormium.mysql.node/MySqlDatabase.dialect.<get-dialect>|<get-dialect>(){}[0]
+    final val isClosed // io.github.kormium.mysql.node/MySqlDatabase.isClosed|{}isClosed[0]
+        final fun <get-isClosed>(): kotlin/Boolean // io.github.kormium.mysql.node/MySqlDatabase.isClosed.<get-isClosed>|<get-isClosed>(){}[0]
+    final val writeListeners // io.github.kormium.mysql.node/MySqlDatabase.writeListeners|{}writeListeners[0]
+        final fun <get-writeListeners>(): io.github.kormium/WriteListeners // io.github.kormium.mysql.node/MySqlDatabase.writeListeners.<get-writeListeners>|<get-writeListeners>(){}[0]
+
+    final fun close() // io.github.kormium.mysql.node/MySqlDatabase.close|close(){}[0]
+    final suspend fun <#A1: kotlin/Any?> useConnection(kotlin/Boolean, io.github.kormium/TransactionIsolation?, kotlin/Boolean, kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendSqlExecutor, #A1>): #A1 // io.github.kormium.mysql.node/MySqlDatabase.useConnection|useConnection(kotlin.Boolean;io.github.kormium.TransactionIsolation?;kotlin.Boolean;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendSqlExecutor,0:0>){0§<kotlin.Any?>}[0]
+}
+
+final fun io.github.kormium.mysql.node/createNodeMysqlDatabase(kotlin/String, kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, kotlin/Int = ..., io.github.kormium/KormiumConfig = ...): io.github.kormium.mysql.node/MySqlDatabase // io.github.kormium.mysql.node/createNodeMysqlDatabase|createNodeMysqlDatabase(kotlin.String;kotlin.Int;kotlin.String;kotlin.String;kotlin.String;kotlin.Int;io.github.kormium.KormiumConfig){}[0]

--- a/kormium-mysql-node/build.gradle.kts
+++ b/kormium-mysql-node/build.gradle.kts
@@ -7,6 +7,8 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
+
     // A MySQL/MariaDB engine for Kotlin running on Node, over the async mysql2 package talking to a
     // real server. Node only.
     compilerOptions {

--- a/kormium-mysql-node/src/wasmJsMain/kotlin/io/github/kormium/mysql/node/MySqlDatabase.kt
+++ b/kormium-mysql-node/src/wasmJsMain/kotlin/io/github/kormium/mysql/node/MySqlDatabase.kt
@@ -17,13 +17,13 @@ import kotlinx.coroutines.withContext
  * [useConnection] borrows a [PoolConnection] for the block and returns it after — independent calls
  * run on independent connections (real concurrency, no Mutex). Suspend-only.
  */
-class MySqlDatabase internal constructor(
+public class MySqlDatabase internal constructor(
     private val pool: MyPool,
     override val config: KormiumConfig,
 ) : SuspendDatabase<Nothing> {
 
     override val writeListeners: WriteListeners = WriteListeners()
-    override val dialect = MySqlDialect
+    override val dialect: MySqlDialect = MySqlDialect
 
     private val lifecycle = DatabaseLifecycle { pool.end() }
 
@@ -55,7 +55,7 @@ class MySqlDatabase internal constructor(
         }
     }
 
-    override fun close() = lifecycle.close()
+    override fun close(): Unit = lifecycle.close()
 }
 
 private val TransactionIsolation.sql: String
@@ -70,7 +70,7 @@ private val TransactionIsolation.sql: String
  * Opens a MySQL/MariaDB database over a mysql2 connection pool of [poolSize] connections. Tagged
  * [Nothing]; pin the catalog at the call site.
  */
-fun createNodeMysqlDatabase(
+public fun createNodeMysqlDatabase(
     host: String,
     port: Int = 3306,
     database: String,

--- a/kormium-mysql/api/kormium-mysql.api
+++ b/kormium-mysql/api/kormium-mysql.api
@@ -1,0 +1,49 @@
+public abstract interface class io/github/kormium/MySqlDriver : io/github/kormium/database/Database, io/github/kormium/database/SuspendDatabase, java/lang/AutoCloseable {
+	public abstract fun getConfig ()Lio/github/kormium/KormiumConfig;
+	public abstract fun getDialect ()Lio/github/kormium/Dialect;
+	public abstract fun getWriteListeners ()Lio/github/kormium/WriteListeners;
+	public abstract fun isClosed ()Z
+}
+
+public final class io/github/kormium/MySqlErrorsKt {
+	public static final fun mysqlVendorException (Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;)Lio/github/kormium/QueryException;
+	public static synthetic fun mysqlVendorException$default (Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)Lio/github/kormium/QueryException;
+}
+
+public final class io/github/kormium/MySqlExceptionTranslatorKt {
+	public static final fun getMySqlExceptionTranslator ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class io/github/kormium/MySqlJvmTypeMapper : io/github/kormium/TypeMapper {
+	public static final field INSTANCE Lio/github/kormium/MySqlJvmTypeMapper;
+	public fun toParameter (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/MySqlResultSetWrapper : io/github/kormium/resultset/ResultSet {
+	public fun <init> (Ljava/sql/ResultSet;)V
+	public fun getBoolean (I)Ljava/lang/Boolean;
+	public fun getBytes (I)[B
+	public fun getColumns ()[Ljava/lang/String;
+	public fun getDate (I)Lkotlinx/datetime/LocalDate;
+	public fun getDouble (I)Ljava/lang/Double;
+	public fun getFloat (I)Ljava/lang/Float;
+	public fun getInstant (I)Lkotlin/time/Instant;
+	public fun getInt (I)Ljava/lang/Integer;
+	public fun getLocalDateTime (I)Lkotlinx/datetime/LocalDateTime;
+	public fun getLong (I)Ljava/lang/Long;
+	public fun getShort (I)Ljava/lang/Short;
+	public fun getString (I)Ljava/lang/String;
+	public fun getTime (I)Lkotlinx/datetime/LocalTime;
+	public fun next ()Z
+}
+
+public final class io/github/kormium/database/CreateDatabaseKt {
+	public static final fun createDatabase (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/functions/Function1;)Lio/github/kormium/MySqlDriver;
+	public static synthetic fun createDatabase$default (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/github/kormium/MySqlDriver;
+}
+
+public final class io/github/kormium/database/Database_jvmKt {
+	public static final fun createDatabase (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILio/github/kormium/KormiumConfig;)Lio/github/kormium/MySqlDriver;
+	public static synthetic fun createDatabase$default (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILio/github/kormium/KormiumConfig;ILjava/lang/Object;)Lio/github/kormium/MySqlDriver;
+}
+

--- a/kormium-mysql/api/kormium-mysql.klib.api
+++ b/kormium-mysql/api/kormium-mysql.klib.api
@@ -1,0 +1,35 @@
+// Klib ABI Dump
+// Targets: [linuxX64, macosArm64, macosX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-mysql>
+abstract interface io.github.kormium/MySqlDriver : io.github.kormium.database/Database<kotlin/Nothing>, io.github.kormium.database/SuspendDatabase<kotlin/Nothing>, kotlin/AutoCloseable { // io.github.kormium/MySqlDriver|null[0]
+    abstract val config // io.github.kormium/MySqlDriver.config|{}config[0]
+        abstract fun <get-config>(): io.github.kormium/KormiumConfig // io.github.kormium/MySqlDriver.config.<get-config>|<get-config>(){}[0]
+    abstract val dialect // io.github.kormium/MySqlDriver.dialect|{}dialect[0]
+        abstract fun <get-dialect>(): io.github.kormium/Dialect // io.github.kormium/MySqlDriver.dialect.<get-dialect>|<get-dialect>(){}[0]
+    abstract val isClosed // io.github.kormium/MySqlDriver.isClosed|{}isClosed[0]
+        abstract fun <get-isClosed>(): kotlin/Boolean // io.github.kormium/MySqlDriver.isClosed.<get-isClosed>|<get-isClosed>(){}[0]
+    abstract val writeListeners // io.github.kormium/MySqlDriver.writeListeners|{}writeListeners[0]
+        abstract fun <get-writeListeners>(): io.github.kormium/WriteListeners // io.github.kormium/MySqlDriver.writeListeners.<get-writeListeners>|<get-writeListeners>(){}[0]
+}
+
+final class io.github.kormium.mysql.exception/ConnectionClosedException : io.github.kormium/KormiumException { // io.github.kormium.mysql.exception/ConnectionClosedException|null[0]
+    constructor <init>() // io.github.kormium.mysql.exception/ConnectionClosedException.<init>|<init>(){}[0]
+}
+
+final class io.github.kormium.mysql.exception/QueryExecutionException : io.github.kormium/KormiumException { // io.github.kormium.mysql.exception/QueryExecutionException|null[0]
+    constructor <init>(kotlin/String, kotlin/Throwable? = ...) // io.github.kormium.mysql.exception/QueryExecutionException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
+}
+
+final object io.github.kormium.mysql/MySqlNativeTypeMapper : io.github.kormium/TypeMapper { // io.github.kormium.mysql/MySqlNativeTypeMapper|null[0]
+    final fun toParameter(kotlin/Any?): kotlin/Any? // io.github.kormium.mysql/MySqlNativeTypeMapper.toParameter|toParameter(kotlin.Any?){}[0]
+}
+
+final fun io.github.kormium.database/createDatabase(kotlin/String, kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, kotlin/Int = ..., io.github.kormium/KormiumConfig = ...): io.github.kormium/MySqlDriver // io.github.kormium.database/createDatabase|createDatabase(kotlin.String;kotlin.Int;kotlin.String;kotlin.String;kotlin.String;kotlin.Int;io.github.kormium.KormiumConfig){}[0]
+final fun io.github.kormium.database/createDatabase(kotlin/String, kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, kotlin/Int = ..., kotlin/Function1<io.github.kormium/KormiumBuilder, kotlin/Unit>): io.github.kormium/MySqlDriver // io.github.kormium.database/createDatabase|createDatabase(kotlin.String;kotlin.Int;kotlin.String;kotlin.String;kotlin.String;kotlin.Int;kotlin.Function1<io.github.kormium.KormiumBuilder,kotlin.Unit>){}[0]
+final fun io.github.kormium.mysql.exception/mysqlException(kotlin/String, kotlin/UInt, kotlin/String? = ...): io.github.kormium/QueryException // io.github.kormium.mysql.exception/mysqlException|mysqlException(kotlin.String;kotlin.UInt;kotlin.String?){}[0]
+final fun io.github.kormium/mysqlVendorException(kotlin/String, kotlin/Int, kotlin/String? = ..., kotlin/Throwable? = ...): io.github.kormium/QueryException // io.github.kormium/mysqlVendorException|mysqlVendorException(kotlin.String;kotlin.Int;kotlin.String?;kotlin.Throwable?){}[0]

--- a/kormium-mysql/build.gradle.kts
+++ b/kormium-mysql/build.gradle.kts
@@ -96,3 +96,15 @@ kotlin {
         }
     }
 }
+
+// BCV's klib ABI inference for host-unsupported targets fails for this module's degenerate
+// case: after filtering on a Linux host exactly ONE supported target remains (linuxX64 —
+// mingw is deliberately absent, Windows is served by the JDBC driver), and the extracted
+// golden dump keeps the full macOS target list in its header while the fresh merge lists
+// only linuxX64. Validate the klib ABI where every declared target is buildable (macOS);
+// CI runs this in the macOS job. The JVM ABI check runs on every host regardless.
+tasks.matching { it.name == "klibApiCheck" }.configureEach {
+    onlyIf("kormium-mysql klib targets are only all-buildable on macOS") {
+        org.jetbrains.kotlin.konan.target.HostManager.hostIsMac
+    }
+}

--- a/kormium-mysql/build.gradle.kts
+++ b/kormium-mysql/build.gradle.kts
@@ -7,6 +7,8 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm {

--- a/kormium-mysql/build.gradle.kts
+++ b/kormium-mysql/build.gradle.kts
@@ -97,14 +97,3 @@ kotlin {
     }
 }
 
-// BCV's klib ABI inference for host-unsupported targets fails for this module's degenerate
-// case: after filtering on a Linux host exactly ONE supported target remains (linuxX64 —
-// mingw is deliberately absent, Windows is served by the JDBC driver), and the extracted
-// golden dump keeps the full macOS target list in its header while the fresh merge lists
-// only linuxX64. Validate the klib ABI where every declared target is buildable (macOS);
-// CI runs this in the macOS job. The JVM ABI check runs on every host regardless.
-tasks.matching { it.name == "klibApiCheck" }.configureEach {
-    onlyIf("kormium-mysql klib targets are only all-buildable on macOS") {
-        org.jetbrains.kotlin.konan.target.HostManager.hostIsMac
-    }
-}

--- a/kormium-mysql/src/commonMain/kotlin/MySqlDriver.kt
+++ b/kormium-mysql/src/commonMain/kotlin/MySqlDriver.kt
@@ -9,7 +9,7 @@ import io.github.kormium.database.SuspendDatabase
  * (or used via a `use { }` block). Blocking query methods come from [Database]; the suspend path
  * (suspendTransaction/suspendAutocommit) comes from [SuspendDatabase]. Mirrors [PostgresDriver].
  */
-interface MySqlDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoCloseable {
+public interface MySqlDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoCloseable {
     // Resolves the config default inherited from both Database and SuspendDatabase; concrete
     // drivers supply it (from the createDatabase config argument).
     override val config: KormiumConfig

--- a/kormium-mysql/src/commonMain/kotlin/MySqlErrors.kt
+++ b/kormium-mysql/src/commonMain/kotlin/MySqlErrors.kt
@@ -12,7 +12,7 @@ package io.github.kormium
  * 1048/1364 NOT NULL (column cannot be null / has no default), 3819 CHECK (MySQL 8.0.16+ /
  * MariaDB 10.2+). Unknown codes fall back to the standard SQLSTATE mapping.
  */
-fun mysqlVendorException(
+public fun mysqlVendorException(
     message: String,
     vendorCode: Int,
     sqlState: String? = null,

--- a/kormium-mysql/src/commonMain/kotlin/database/CreateDatabase.kt
+++ b/kormium-mysql/src/commonMain/kotlin/database/CreateDatabase.kt
@@ -4,7 +4,7 @@ import io.github.kormium.KormiumBuilder
 import io.github.kormium.KormiumConfig
 import io.github.kormium.MySqlDriver
 
-expect fun createDatabase(
+public expect fun createDatabase(
     host: String,
     port: Int = 3306,
     database: String,
@@ -18,7 +18,7 @@ expect fun createDatabase(
  * Opens a MySQL/MariaDB database with a configuration block: `createDatabase(host = …, …) {`
  * `config { … }; beforeStart { migrate(appMigrations) } }`. See [KormiumBuilder].
  */
-fun createDatabase(
+public fun createDatabase(
     host: String,
     port: Int = 3306,
     database: String,

--- a/kormium-mysql/src/jvmMain/kotlin/MySqlExceptionTranslator.kt
+++ b/kormium-mysql/src/jvmMain/kotlin/MySqlExceptionTranslator.kt
@@ -8,6 +8,6 @@ import io.github.kormium.jdbc.SqlExceptionTranslator
  * branch on the vendor error code (`SQLException.getErrorCode`) via the shared [mysqlVendorException]
  * table.
  */
-val MySqlExceptionTranslator: SqlExceptionTranslator = { e ->
+public val MySqlExceptionTranslator: SqlExceptionTranslator = { e ->
     mysqlVendorException(e.message ?: "SQL error", e.errorCode, e.sqlState, e)
 }

--- a/kormium-mysql/src/jvmMain/kotlin/MySqlJvmTypeMapper.kt
+++ b/kormium-mysql/src/jvmMain/kotlin/MySqlJvmTypeMapper.kt
@@ -21,7 +21,7 @@ import kotlin.uuid.Uuid
  * binds as an `OffsetDateTime` at UTC (a `TIMESTAMP` is stored/compared in UTC); the connection
  * URL pins the session zone to UTC so the value round-trips unchanged.
  */
-object MySqlJvmTypeMapper : TypeMapper {
+public object MySqlJvmTypeMapper : TypeMapper {
     override fun toParameter(value: Any?): Any? = when (value) {
         // StandardTypeMapper would toString() these; pass them through so they bind as real types.
         is Float, is Short -> value

--- a/kormium-mysql/src/jvmMain/kotlin/MySqlResultSetWrapper.kt
+++ b/kormium-mysql/src/jvmMain/kotlin/MySqlResultSetWrapper.kt
@@ -21,7 +21,7 @@ import java.time.OffsetDateTime
  * correct [Instant]. UUID (`CHAR(36)`) and `JSON` columns are plain text via [getString], which
  * lines up with korm's text-based column reading.
  */
-class MySqlResultSetWrapper(private val rs: java.sql.ResultSet) : ResultSet {
+public class MySqlResultSetWrapper(private val rs: java.sql.ResultSet) : ResultSet {
     // Lazy: the hot read path maps columns positionally and never touches this.
     override val columns: Array<String> by lazy { internalGetColumns() }
 

--- a/kormium-mysql/src/jvmMain/kotlin/database/Database.jvm.kt
+++ b/kormium-mysql/src/jvmMain/kotlin/database/Database.jvm.kt
@@ -44,7 +44,7 @@ private class MySqlJdbcDriver(
     config = config,
 ), MySqlDriver
 
-actual fun createDatabase(
+public actual fun createDatabase(
     host: String,
     port: Int,
     database: String,

--- a/kormium-mysql/src/nativeMain/kotlin/database/Database.native.kt
+++ b/kormium-mysql/src/nativeMain/kotlin/database/Database.native.kt
@@ -10,7 +10,7 @@ import io.github.kormium.mysql.MySqlNativeDriver
  * (useConnection) offloads each blocking call to the IO dispatcher — there is no portable
  * non-blocking MySQL client API, so this is the same strategy the Postgres driver uses on Windows.
  */
-actual fun createDatabase(
+public actual fun createDatabase(
     host: String,
     port: Int,
     database: String,

--- a/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/MySqlNativeTypeMapper.kt
+++ b/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/MySqlNativeTypeMapper.kt
@@ -19,7 +19,7 @@ import kotlinx.datetime.toLocalDateTime
  * Everything else (UUID, JsonElement, Decimal, primitives, LocalDate/LocalTime) is handled by
  * [StandardTypeMapper] — their `toString()` is already a valid MySQL literal.
  */
-object MySqlNativeTypeMapper : TypeMapper {
+public object MySqlNativeTypeMapper : TypeMapper {
     override fun toParameter(value: Any?): Any? = when (value) {
         is Instant -> value.toLocalDateTime(TimeZone.UTC).toMysqlText()
         is LocalDateTime -> value.toMysqlText()

--- a/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/exception/Exceptions.kt
+++ b/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/exception/Exceptions.kt
@@ -5,15 +5,15 @@ import io.github.kormium.QueryException
 import io.github.kormium.mysqlVendorException
 
 /** Raised when a statement (or the initial connection) fails on the server. */
-class QueryExecutionException(message: String, cause: Throwable? = null) : KormiumException(message, cause)
+public class QueryExecutionException(message: String, cause: Throwable? = null) : KormiumException(message, cause)
 
 /** Raised when the native driver is used after it was closed. */
-class ConnectionClosedException : KormiumException("MySqlDriver is closed")
+public class ConnectionClosedException : KormiumException("MySqlDriver is closed")
 
 /**
  * Maps a MySQL/MariaDB vendor error number (`mysql_stmt_errno`) to the most specific core
  * [QueryException] subtype via the shared [mysqlVendorException] table. [sqlState] is the server's
  * 5-character SQLSTATE (`mysql_stmt_sqlstate`) when known.
  */
-fun mysqlException(message: String, errno: UInt, sqlState: String? = null): QueryException =
+public fun mysqlException(message: String, errno: UInt, sqlState: String? = null): QueryException =
     mysqlVendorException(message, errno.toInt(), sqlState)

--- a/kormium-observe/api/jvm/kormium-observe.api
+++ b/kormium-observe/api/jvm/kormium-observe.api
@@ -1,0 +1,6 @@
+public final class io/github/kormium/observe/ObserveKt {
+	public static final fun observe (Lio/github/kormium/Table;Lio/github/kormium/database/SuspendDatabase;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun observe (Lio/github/kormium/database/SuspendDatabase;Ljava/util/Set;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun observe$default (Lio/github/kormium/Table;Lio/github/kormium/database/SuspendDatabase;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+

--- a/kormium-observe/api/kormium-observe.klib.api
+++ b/kormium-observe/api/kormium-observe.klib.api
@@ -1,0 +1,10 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64, macosArm64, macosX64, mingwX64, wasmJs, wasmWasi]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-observe>
+final fun <#A: io.github.kormium/Catalog, #B: io.github.kormium/Entity> (io.github.kormium/Table<#A, #B>).io.github.kormium.observe/observe(io.github.kormium.database/SuspendDatabase<#A>, kotlin/Function1<io.github.kormium/QueryBuilder, kotlin/Unit> = ...): kotlinx.coroutines.flow/Flow<kotlin.collections/List<#B>> // io.github.kormium.observe/observe|observe@io.github.kormium.Table<0:0,0:1>(io.github.kormium.database.SuspendDatabase<0:0>;kotlin.Function1<io.github.kormium.QueryBuilder,kotlin.Unit>){0§<io.github.kormium.Catalog>;1§<io.github.kormium.Entity>}[0]
+final fun <#A: io.github.kormium/Catalog, #B: kotlin/Any?> (io.github.kormium.database/SuspendDatabase<#A>).io.github.kormium.observe/observe(kotlin.collections/Set<kotlin/String>, kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendScope<#A>, #B>): kotlinx.coroutines.flow/Flow<#B> // io.github.kormium.observe/observe|observe@io.github.kormium.database.SuspendDatabase<0:0>(kotlin.collections.Set<kotlin.String>;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendScope<0:0>,0:1>){0§<io.github.kormium.Catalog>;1§<kotlin.Any?>}[0]

--- a/kormium-observe/build.gradle.kts
+++ b/kormium-observe/build.gradle.kts
@@ -12,6 +12,8 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm {

--- a/kormium-observe/src/commonMain/kotlin/Observe.kt
+++ b/kormium-observe/src/commonMain/kotlin/Observe.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.flow.channelFlow
  * Observation only fires on backends whose driver enables it (all shipped drivers do); on a
  * backend with notification disabled the flow emits the initial value and nothing more.
  */
-fun <G : Catalog, R> SuspendDatabase<G>.observe(
+public fun <G : Catalog, R> SuspendDatabase<G>.observe(
     tables: Set<String>,
     fetch: suspend SuspendScope<G>.() -> R,
 ): Flow<R> = channelFlow {
@@ -50,7 +50,7 @@ fun <G : Catalog, R> SuspendDatabase<G>.observe(
  * the table. `Users.observe(db) { where { Users.age gtEq 18 } }` emits the matching users now
  * and again whenever the `users` table changes. With no [query] block it observes every row.
  */
-fun <G : Catalog, T : Entity> Table<G, T>.observe(
+public fun <G : Catalog, T : Entity> Table<G, T>.observe(
     db: SuspendDatabase<G>,
     query: QueryBuilder.() -> Unit = {},
 ): Flow<List<T>> {

--- a/kormium-postgres-dialect/api/kormium-postgres-dialect.api
+++ b/kormium-postgres-dialect/api/kormium-postgres-dialect.api
@@ -1,0 +1,70 @@
+public final class io/github/kormium/PostgresDialect : io/github/kormium/Dialect {
+	public static final field INSTANCE Lio/github/kormium/PostgresDialect;
+	public fun advisoryLockSql (J)Ljava/lang/String;
+	public fun getReadOnlyToggle ()Lio/github/kormium/ReadOnlyToggle;
+	public fun getSupportsReturning ()Z
+	public fun getSupportsTransactionIsolation ()Z
+	public fun quoteIdentifier (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderBind (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/String;
+	public fun renderCharLength (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderInsertDefaultValues (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderInsertOrIgnoreSuffix (Ljava/util/List;)Ljava/lang/String;
+	public fun renderLimit-WZ4Q5Ns (I)Ljava/lang/String;
+	public fun renderLimitOffset-feOb9K0 (II)Ljava/lang/String;
+	public fun renderOffset-WZ4Q5Ns (I)Ljava/lang/String;
+	public fun renderUpsertSuffix (Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class io/github/kormium/Vector {
+	public static final field Companion Lio/github/kormium/Vector$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> ([F)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun get (I)F
+	public final fun getData ()[F
+	public final fun getSize ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kormium/Vector$Companion {
+	public final fun of ([F)Lio/github/kormium/Vector;
+	public final fun parse (Ljava/lang/String;)Lio/github/kormium/Vector;
+}
+
+public final class io/github/kormium/VectorColumnType : io/github/kormium/ColumnType {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getDescription ()Ljava/lang/String;
+	public final fun getDimensions ()Ljava/lang/Integer;
+	public fun read (Lio/github/kormium/resultset/ResultSet;I)Lio/github/kormium/Vector;
+	public synthetic fun read (Lio/github/kormium/resultset/ResultSet;I)Ljava/lang/Object;
+	public fun toParam (Lio/github/kormium/Vector;)Ljava/lang/Object;
+	public synthetic fun toParam (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/VectorKt {
+	public static final fun Vector (Lio/github/kormium/Column$Companion;Ljava/lang/Integer;Ljava/lang/String;)Lio/github/kormium/Column$Spec;
+	public static synthetic fun Vector$default (Lio/github/kormium/Column$Companion;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kormium/Column$Spec;
+	public static final fun cosineDistance (Lio/github/kormium/Operand;Lio/github/kormium/Operand;)Lio/github/kormium/NumericExpr;
+	public static final fun cosineDistance (Lio/github/kormium/Operand;Lio/github/kormium/Vector;)Lio/github/kormium/NumericExpr;
+	public static final fun distance (Lio/github/kormium/Operand;Lio/github/kormium/Operand;Lio/github/kormium/VectorMetric;)Lio/github/kormium/NumericExpr;
+	public static final fun distance (Lio/github/kormium/Operand;Lio/github/kormium/Vector;Lio/github/kormium/VectorMetric;)Lio/github/kormium/NumericExpr;
+	public static synthetic fun distance$default (Lio/github/kormium/Operand;Lio/github/kormium/Operand;Lio/github/kormium/VectorMetric;ILjava/lang/Object;)Lio/github/kormium/NumericExpr;
+	public static synthetic fun distance$default (Lio/github/kormium/Operand;Lio/github/kormium/Vector;Lio/github/kormium/VectorMetric;ILjava/lang/Object;)Lio/github/kormium/NumericExpr;
+	public static final fun euclideanDistance (Lio/github/kormium/Operand;Lio/github/kormium/Operand;)Lio/github/kormium/NumericExpr;
+	public static final fun euclideanDistance (Lio/github/kormium/Operand;Lio/github/kormium/Vector;)Lio/github/kormium/NumericExpr;
+	public static final fun innerProduct (Lio/github/kormium/Operand;Lio/github/kormium/Operand;)Lio/github/kormium/NumericExpr;
+	public static final fun innerProduct (Lio/github/kormium/Operand;Lio/github/kormium/Vector;)Lio/github/kormium/NumericExpr;
+}
+
+public final class io/github/kormium/VectorMetric : java/lang/Enum {
+	public static final field COSINE Lio/github/kormium/VectorMetric;
+	public static final field DOT Lio/github/kormium/VectorMetric;
+	public static final field EUCLIDEAN Lio/github/kormium/VectorMetric;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/kormium/VectorMetric;
+	public static fun values ()[Lio/github/kormium/VectorMetric;
+}
+

--- a/kormium-postgres-dialect/api/kormium-postgres-dialect.klib.api
+++ b/kormium-postgres-dialect/api/kormium-postgres-dialect.klib.api
@@ -1,0 +1,81 @@
+// Klib ABI Dump
+// Targets: [js, linuxX64, macosArm64, macosX64, mingwX64, wasmJs, wasmWasi]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-postgres-dialect>
+final enum class io.github.kormium/VectorMetric : kotlin/Enum<io.github.kormium/VectorMetric> { // io.github.kormium/VectorMetric|null[0]
+    enum entry COSINE // io.github.kormium/VectorMetric.COSINE|null[0]
+    enum entry DOT // io.github.kormium/VectorMetric.DOT|null[0]
+    enum entry EUCLIDEAN // io.github.kormium/VectorMetric.EUCLIDEAN|null[0]
+
+    final val entries // io.github.kormium/VectorMetric.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<io.github.kormium/VectorMetric> // io.github.kormium/VectorMetric.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): io.github.kormium/VectorMetric // io.github.kormium/VectorMetric.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<io.github.kormium/VectorMetric> // io.github.kormium/VectorMetric.values|values#static(){}[0]
+}
+
+final class io.github.kormium/Vector { // io.github.kormium/Vector|null[0]
+    constructor <init>(kotlin.collections/List<kotlin/Float>) // io.github.kormium/Vector.<init>|<init>(kotlin.collections.List<kotlin.Float>){}[0]
+    constructor <init>(kotlin/FloatArray) // io.github.kormium/Vector.<init>|<init>(kotlin.FloatArray){}[0]
+
+    final val data // io.github.kormium/Vector.data|{}data[0]
+        final fun <get-data>(): kotlin/FloatArray // io.github.kormium/Vector.data.<get-data>|<get-data>(){}[0]
+    final val size // io.github.kormium/Vector.size|{}size[0]
+        final fun <get-size>(): kotlin/Int // io.github.kormium/Vector.size.<get-size>|<get-size>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // io.github.kormium/Vector.equals|equals(kotlin.Any?){}[0]
+    final fun get(kotlin/Int): kotlin/Float // io.github.kormium/Vector.get|get(kotlin.Int){}[0]
+    final fun hashCode(): kotlin/Int // io.github.kormium/Vector.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // io.github.kormium/Vector.toString|toString(){}[0]
+
+    final object Companion { // io.github.kormium/Vector.Companion|null[0]
+        final fun of(kotlin/FloatArray...): io.github.kormium/Vector // io.github.kormium/Vector.Companion.of|of(kotlin.FloatArray...){}[0]
+        final fun parse(kotlin/String): io.github.kormium/Vector // io.github.kormium/Vector.Companion.parse|parse(kotlin.String){}[0]
+    }
+}
+
+final class io.github.kormium/VectorColumnType : io.github.kormium/ColumnType<io.github.kormium/Vector> { // io.github.kormium/VectorColumnType|null[0]
+    constructor <init>(kotlin/Int? = ...) // io.github.kormium/VectorColumnType.<init>|<init>(kotlin.Int?){}[0]
+
+    final val description // io.github.kormium/VectorColumnType.description|{}description[0]
+        final fun <get-description>(): kotlin/String // io.github.kormium/VectorColumnType.description.<get-description>|<get-description>(){}[0]
+    final val dimensions // io.github.kormium/VectorColumnType.dimensions|{}dimensions[0]
+        final fun <get-dimensions>(): kotlin/Int? // io.github.kormium/VectorColumnType.dimensions.<get-dimensions>|<get-dimensions>(){}[0]
+
+    final fun read(io.github.kormium.resultset/ResultSet, kotlin/Int): io.github.kormium/Vector? // io.github.kormium/VectorColumnType.read|read(io.github.kormium.resultset.ResultSet;kotlin.Int){}[0]
+    final fun toParam(io.github.kormium/Vector): kotlin/Any? // io.github.kormium/VectorColumnType.toParam|toParam(io.github.kormium.Vector){}[0]
+}
+
+final object io.github.kormium/PostgresDialect : io.github.kormium/Dialect { // io.github.kormium/PostgresDialect|null[0]
+    final val readOnlyToggle // io.github.kormium/PostgresDialect.readOnlyToggle|{}readOnlyToggle[0]
+        final fun <get-readOnlyToggle>(): io.github.kormium/ReadOnlyToggle? // io.github.kormium/PostgresDialect.readOnlyToggle.<get-readOnlyToggle>|<get-readOnlyToggle>(){}[0]
+    final val supportsReturning // io.github.kormium/PostgresDialect.supportsReturning|{}supportsReturning[0]
+        final fun <get-supportsReturning>(): kotlin/Boolean // io.github.kormium/PostgresDialect.supportsReturning.<get-supportsReturning>|<get-supportsReturning>(){}[0]
+    final val supportsTransactionIsolation // io.github.kormium/PostgresDialect.supportsTransactionIsolation|{}supportsTransactionIsolation[0]
+        final fun <get-supportsTransactionIsolation>(): kotlin/Boolean // io.github.kormium/PostgresDialect.supportsTransactionIsolation.<get-supportsTransactionIsolation>|<get-supportsTransactionIsolation>(){}[0]
+
+    final fun advisoryLockSql(kotlin/Long): kotlin/String // io.github.kormium/PostgresDialect.advisoryLockSql|advisoryLockSql(kotlin.Long){}[0]
+    final fun quoteIdentifier(kotlin/String): kotlin/String // io.github.kormium/PostgresDialect.quoteIdentifier|quoteIdentifier(kotlin.String){}[0]
+    final fun renderBind(kotlin/String, kotlin/Any?): kotlin/String // io.github.kormium/PostgresDialect.renderBind|renderBind(kotlin.String;kotlin.Any?){}[0]
+    final fun renderCharLength(kotlin/String): kotlin/String // io.github.kormium/PostgresDialect.renderCharLength|renderCharLength(kotlin.String){}[0]
+    final fun renderInsertDefaultValues(kotlin/String): kotlin/String // io.github.kormium/PostgresDialect.renderInsertDefaultValues|renderInsertDefaultValues(kotlin.String){}[0]
+    final fun renderInsertOrIgnoreSuffix(kotlin.collections/List<kotlin/String>): kotlin/String // io.github.kormium/PostgresDialect.renderInsertOrIgnoreSuffix|renderInsertOrIgnoreSuffix(kotlin.collections.List<kotlin.String>){}[0]
+    final fun renderLimit(kotlin/UInt): kotlin/String // io.github.kormium/PostgresDialect.renderLimit|renderLimit(kotlin.UInt){}[0]
+    final fun renderLimitOffset(kotlin/UInt, kotlin/UInt): kotlin/String // io.github.kormium/PostgresDialect.renderLimitOffset|renderLimitOffset(kotlin.UInt;kotlin.UInt){}[0]
+    final fun renderOffset(kotlin/UInt): kotlin/String // io.github.kormium/PostgresDialect.renderOffset|renderOffset(kotlin.UInt){}[0]
+    final fun renderUpsertSuffix(kotlin.collections/List<kotlin/String>, kotlin/String): kotlin/String // io.github.kormium/PostgresDialect.renderUpsertSuffix|renderUpsertSuffix(kotlin.collections.List<kotlin.String>;kotlin.String){}[0]
+}
+
+final fun (io.github.kormium/Column.Companion).io.github.kormium/Vector(kotlin/Int? = ..., kotlin/String? = ...): io.github.kormium/Column.Spec<io.github.kormium/Vector> // io.github.kormium/Vector|Vector@io.github.kormium.Column.Companion(kotlin.Int?;kotlin.String?){}[0]
+final fun (io.github.kormium/Operand<io.github.kormium/Vector>).io.github.kormium/cosineDistance(io.github.kormium/Operand<io.github.kormium/Vector>): io.github.kormium/NumericExpr<kotlin/Double> // io.github.kormium/cosineDistance|cosineDistance@io.github.kormium.Operand<io.github.kormium.Vector>(io.github.kormium.Operand<io.github.kormium.Vector>){}[0]
+final fun (io.github.kormium/Operand<io.github.kormium/Vector>).io.github.kormium/cosineDistance(io.github.kormium/Vector): io.github.kormium/NumericExpr<kotlin/Double> // io.github.kormium/cosineDistance|cosineDistance@io.github.kormium.Operand<io.github.kormium.Vector>(io.github.kormium.Vector){}[0]
+final fun (io.github.kormium/Operand<io.github.kormium/Vector>).io.github.kormium/distance(io.github.kormium/Operand<io.github.kormium/Vector>, io.github.kormium/VectorMetric = ...): io.github.kormium/NumericExpr<kotlin/Double> // io.github.kormium/distance|distance@io.github.kormium.Operand<io.github.kormium.Vector>(io.github.kormium.Operand<io.github.kormium.Vector>;io.github.kormium.VectorMetric){}[0]
+final fun (io.github.kormium/Operand<io.github.kormium/Vector>).io.github.kormium/distance(io.github.kormium/Vector, io.github.kormium/VectorMetric = ...): io.github.kormium/NumericExpr<kotlin/Double> // io.github.kormium/distance|distance@io.github.kormium.Operand<io.github.kormium.Vector>(io.github.kormium.Vector;io.github.kormium.VectorMetric){}[0]
+final fun (io.github.kormium/Operand<io.github.kormium/Vector>).io.github.kormium/euclideanDistance(io.github.kormium/Operand<io.github.kormium/Vector>): io.github.kormium/NumericExpr<kotlin/Double> // io.github.kormium/euclideanDistance|euclideanDistance@io.github.kormium.Operand<io.github.kormium.Vector>(io.github.kormium.Operand<io.github.kormium.Vector>){}[0]
+final fun (io.github.kormium/Operand<io.github.kormium/Vector>).io.github.kormium/euclideanDistance(io.github.kormium/Vector): io.github.kormium/NumericExpr<kotlin/Double> // io.github.kormium/euclideanDistance|euclideanDistance@io.github.kormium.Operand<io.github.kormium.Vector>(io.github.kormium.Vector){}[0]
+final fun (io.github.kormium/Operand<io.github.kormium/Vector>).io.github.kormium/innerProduct(io.github.kormium/Operand<io.github.kormium/Vector>): io.github.kormium/NumericExpr<kotlin/Double> // io.github.kormium/innerProduct|innerProduct@io.github.kormium.Operand<io.github.kormium.Vector>(io.github.kormium.Operand<io.github.kormium.Vector>){}[0]
+final fun (io.github.kormium/Operand<io.github.kormium/Vector>).io.github.kormium/innerProduct(io.github.kormium/Vector): io.github.kormium/NumericExpr<kotlin/Double> // io.github.kormium/innerProduct|innerProduct@io.github.kormium.Operand<io.github.kormium.Vector>(io.github.kormium.Vector){}[0]

--- a/kormium-postgres-dialect/build.gradle.kts
+++ b/kormium-postgres-dialect/build.gradle.kts
@@ -12,6 +12,8 @@ repositories {
 // any web engine (PGlite, node-postgres) reuse this one copy. Targets mirror the driver's reach
 // (jvm + the four native targets) plus the web stack.
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm()

--- a/kormium-postgres-dialect/src/commonMain/kotlin/PostgresDialect.kt
+++ b/kormium-postgres-dialect/src/commonMain/kotlin/PostgresDialect.kt
@@ -9,7 +9,7 @@ import kotlin.uuid.Uuid
  * The casts are explicit (not reliant on `stringtype=unspecified`), so they're correct
  * for the truly-typed r2dbc driver as well as the text-based JDBC/libpq paths.
  */
-object PostgresDialect : Dialect by StandardDialect {
+public object PostgresDialect : Dialect by StandardDialect {
     override fun renderBind(name: String, value: Any?): String = when (value) {
         is Uuid -> ":$name::uuid"
         is JsonElement -> ":$name::jsonb"

--- a/kormium-postgres-dialect/src/commonMain/kotlin/Vector.kt
+++ b/kormium-postgres-dialect/src/commonMain/kotlin/Vector.kt
@@ -15,15 +15,15 @@ import io.github.kormium.resultset.ResultSet
  * Kormium does not own DDL, so the SQL column (`CREATE EXTENSION vector; ... embedding vector(1536)`)
  * is declared in raw SQL / a migration; [Column.Companion.Vector] only describes how a value round-trips.
  */
-class Vector(val data: FloatArray) {
+public class Vector(public val data: FloatArray) {
     /** The number of dimensions (array length). */
-    val size: Int get() = data.size
+    public val size: Int get() = data.size
 
     /** Builds a vector from a list of floats (e.g. the output of an embedding library). */
-    constructor(values: List<Float>) : this(values.toFloatArray())
+    public constructor(values: List<Float>) : this(values.toFloatArray())
 
     /** The i-th component. */
-    operator fun get(index: Int): Float = data[index]
+    public operator fun get(index: Int): Float = data[index]
 
     override fun equals(other: Any?): Boolean = this === other || (other is Vector && data.contentEquals(other.data))
 
@@ -32,12 +32,12 @@ class Vector(val data: FloatArray) {
     /** The pgvector text form `[1.0,2.0,3.0]` — also the value bound as a parameter. */
     override fun toString(): String = data.joinToString(separator = ",", prefix = "[", postfix = "]")
 
-    companion object {
+    public companion object {
         /** `Vector.of(0.1f, 0.2f, 0.3f)` — a vector from its components. */
-        fun of(vararg values: Float): Vector = Vector(values)
+        public fun of(vararg values: Float): Vector = Vector(values)
 
         /** Parses the pgvector text form `[1,2,3]` (as read back from a row) into a [Vector]. */
-        fun parse(text: String): Vector {
+        public fun parse(text: String): Vector {
             val trimmed = text.trim()
             require(trimmed.length >= 2 && trimmed.first() == '[' && trimmed.last() == ']') {
                 "not a pgvector value: '$text'"
@@ -56,7 +56,7 @@ class Vector(val data: FloatArray) {
  * to `::vector`. An optional [dimensions] is validated on write — a mismatched length fails fast with
  * a clear message rather than as an opaque server error.
  */
-class VectorColumnType(val dimensions: Int? = null) : ColumnType<Vector> {
+public class VectorColumnType(public val dimensions: Int? = null) : ColumnType<Vector> {
     override fun read(rs: ResultSet, index: Int): Vector? = rs.getString(index)?.let(Vector::parse)
 
     override fun toParam(value: Vector): Any? {
@@ -81,14 +81,14 @@ class VectorColumnType(val dimensions: Int? = null) : ColumnType<Vector> {
  *
  * [dimensions], when given, is validated on every write. Refine with `.nullable()` as usual.
  */
-fun Column.Companion.Vector(dimensions: Int? = null, name: String? = null): Column.Spec<Vector> =
+public fun Column.Companion.Vector(dimensions: Int? = null, name: String? = null): Column.Spec<Vector> =
     Column.of(VectorColumnType(dimensions), name)
 
 /**
  * A vector similarity metric. Maps to a pgvector distance operator via [distance]. For all three,
  * **smaller is more similar**, so nearest-neighbour search is an ascending `orderBy`.
  */
-enum class VectorMetric {
+public enum class VectorMetric {
     /** Euclidean (L2) distance — straight-line distance; accounts for magnitude. pgvector `<->`. */
     EUCLIDEAN,
 
@@ -138,30 +138,30 @@ internal class VectorDistanceOp(
  * the usual choice for text embeddings. The named aliases below ([euclideanDistance] / [cosineDistance] /
  * [innerProduct]) are sugar over this.
  */
-fun Operand<Vector>.distance(query: Vector, metric: VectorMetric = VectorMetric.COSINE): NumericExpr<Double> =
+public fun Operand<Vector>.distance(query: Vector, metric: VectorMetric = VectorMetric.COSINE): NumericExpr<Double> =
     VectorDistanceOp(this, Value(query), metric, query.toString())
 
 /** pgvector distance between two vector operands (e.g. two columns), over the given [metric]. */
-fun Operand<Vector>.distance(other: Operand<Vector>, metric: VectorMetric = VectorMetric.COSINE): NumericExpr<Double> =
+public fun Operand<Vector>.distance(other: Operand<Vector>, metric: VectorMetric = VectorMetric.COSINE): NumericExpr<Double> =
     VectorDistanceOp(this, other, metric, other.resultKey())
 
 /** Euclidean (L2) distance `<->` to a query vector. Alias for `distance(query, VectorMetric.EUCLIDEAN)`. */
-fun Operand<Vector>.euclideanDistance(query: Vector): NumericExpr<Double> = distance(query, VectorMetric.EUCLIDEAN)
+public fun Operand<Vector>.euclideanDistance(query: Vector): NumericExpr<Double> = distance(query, VectorMetric.EUCLIDEAN)
 
 /** Euclidean (L2) distance `<->` between two vector operands. */
-fun Operand<Vector>.euclideanDistance(other: Operand<Vector>): NumericExpr<Double> = distance(other, VectorMetric.EUCLIDEAN)
+public fun Operand<Vector>.euclideanDistance(other: Operand<Vector>): NumericExpr<Double> = distance(other, VectorMetric.EUCLIDEAN)
 
 /** Cosine distance `<=>` (`1 - similarity`) to a query vector. Alias for `distance(query, VectorMetric.COSINE)`. */
-fun Operand<Vector>.cosineDistance(query: Vector): NumericExpr<Double> = distance(query, VectorMetric.COSINE)
+public fun Operand<Vector>.cosineDistance(query: Vector): NumericExpr<Double> = distance(query, VectorMetric.COSINE)
 
 /** Cosine distance `<=>` between two vector operands. */
-fun Operand<Vector>.cosineDistance(other: Operand<Vector>): NumericExpr<Double> = distance(other, VectorMetric.COSINE)
+public fun Operand<Vector>.cosineDistance(other: Operand<Vector>): NumericExpr<Double> = distance(other, VectorMetric.COSINE)
 
 /**
  * Negative inner product `<#>` to a query vector. Alias for `distance(query, VectorMetric.DOT)`. pgvector
  * negates the dot product, so the value is ≤ 0 and, like the others, smaller means more similar.
  */
-fun Operand<Vector>.innerProduct(query: Vector): NumericExpr<Double> = distance(query, VectorMetric.DOT)
+public fun Operand<Vector>.innerProduct(query: Vector): NumericExpr<Double> = distance(query, VectorMetric.DOT)
 
 /** Negative inner product `<#>` between two vector operands. */
-fun Operand<Vector>.innerProduct(other: Operand<Vector>): NumericExpr<Double> = distance(other, VectorMetric.DOT)
+public fun Operand<Vector>.innerProduct(other: Operand<Vector>): NumericExpr<Double> = distance(other, VectorMetric.DOT)

--- a/kormium-postgres-node/api/kormium-postgres-node.klib.api
+++ b/kormium-postgres-node/api/kormium-postgres-node.klib.api
@@ -1,0 +1,23 @@
+// Klib ABI Dump
+// Targets: [wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-postgres-node>
+final class io.github.kormium.postgres.node/PgDatabase : io.github.kormium.database/SuspendDatabase<kotlin/Nothing> { // io.github.kormium.postgres.node/PgDatabase|null[0]
+    final val config // io.github.kormium.postgres.node/PgDatabase.config|{}config[0]
+        final fun <get-config>(): io.github.kormium/KormiumConfig // io.github.kormium.postgres.node/PgDatabase.config.<get-config>|<get-config>(){}[0]
+    final val dialect // io.github.kormium.postgres.node/PgDatabase.dialect|{}dialect[0]
+        final fun <get-dialect>(): io.github.kormium/PostgresDialect // io.github.kormium.postgres.node/PgDatabase.dialect.<get-dialect>|<get-dialect>(){}[0]
+    final val isClosed // io.github.kormium.postgres.node/PgDatabase.isClosed|{}isClosed[0]
+        final fun <get-isClosed>(): kotlin/Boolean // io.github.kormium.postgres.node/PgDatabase.isClosed.<get-isClosed>|<get-isClosed>(){}[0]
+    final val writeListeners // io.github.kormium.postgres.node/PgDatabase.writeListeners|{}writeListeners[0]
+        final fun <get-writeListeners>(): io.github.kormium/WriteListeners // io.github.kormium.postgres.node/PgDatabase.writeListeners.<get-writeListeners>|<get-writeListeners>(){}[0]
+
+    final fun close() // io.github.kormium.postgres.node/PgDatabase.close|close(){}[0]
+    final suspend fun <#A1: kotlin/Any?> useConnection(kotlin/Boolean, io.github.kormium/TransactionIsolation?, kotlin/Boolean, kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendSqlExecutor, #A1>): #A1 // io.github.kormium.postgres.node/PgDatabase.useConnection|useConnection(kotlin.Boolean;io.github.kormium.TransactionIsolation?;kotlin.Boolean;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendSqlExecutor,0:0>){0§<kotlin.Any?>}[0]
+}
+
+final fun io.github.kormium.postgres.node/createNodePostgresDatabase(kotlin/String, kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, kotlin/Int = ..., io.github.kormium/KormiumConfig = ...): io.github.kormium.postgres.node/PgDatabase // io.github.kormium.postgres.node/createNodePostgresDatabase|createNodePostgresDatabase(kotlin.String;kotlin.Int;kotlin.String;kotlin.String;kotlin.String;kotlin.Int;io.github.kormium.KormiumConfig){}[0]

--- a/kormium-postgres-node/build.gradle.kts
+++ b/kormium-postgres-node/build.gradle.kts
@@ -7,6 +7,8 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
+
     // A Postgres engine for Kotlin running on Node, over the async node-postgres (`pg`) package
     // talking to a real Postgres server. Node only.
     compilerOptions {

--- a/kormium-postgres-node/src/wasmJsMain/kotlin/io/github/kormium/postgres/node/PgDatabase.kt
+++ b/kormium-postgres-node/src/wasmJsMain/kotlin/io/github/kormium/postgres/node/PgDatabase.kt
@@ -18,13 +18,13 @@ import kotlinx.coroutines.withContext
  * independent calls run on independent connections — real concurrency, no Mutex. Suspend-only (a JS
  * event loop can't be blocked).
  */
-class PgDatabase internal constructor(
+public class PgDatabase internal constructor(
     private val pool: Pool,
     override val config: KormiumConfig,
 ) : SuspendDatabase<Nothing> {
 
     override val writeListeners: WriteListeners = WriteListeners()
-    override val dialect = PostgresDialect
+    override val dialect: PostgresDialect = PostgresDialect
 
     private val lifecycle = DatabaseLifecycle { pool.end() }
 
@@ -56,7 +56,7 @@ class PgDatabase internal constructor(
         }
     }
 
-    override fun close() = lifecycle.close()
+    override fun close(): Unit = lifecycle.close()
 }
 
 private val TransactionIsolation.sql: String
@@ -71,7 +71,7 @@ private val TransactionIsolation.sql: String
  * Opens a Postgres database over a node-postgres connection pool of [poolSize] connections. Returns
  * the handle tagged [Nothing], so by covariance it pins to any `SuspendDatabase<MyCatalog>`.
  */
-fun createNodePostgresDatabase(
+public fun createNodePostgresDatabase(
     host: String,
     port: Int = 5432,
     database: String,

--- a/kormium-postgres/api/kormium-postgres.api
+++ b/kormium-postgres/api/kormium-postgres.api
@@ -1,0 +1,45 @@
+public final class io/github/kormium/PgNotificationTransportKt {
+	public static final fun postgresListenNotifyTransport (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kormium/NotificationTransport;
+	public static synthetic fun postgresListenNotifyTransport$default (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kormium/NotificationTransport;
+}
+
+public final class io/github/kormium/PgResultSetWrapper : io/github/kormium/resultset/ResultSet {
+	public fun <init> (Ljava/sql/ResultSet;)V
+	public fun getBoolean (I)Ljava/lang/Boolean;
+	public fun getBytes (I)[B
+	public fun getColumns ()[Ljava/lang/String;
+	public fun getDate (I)Lkotlinx/datetime/LocalDate;
+	public fun getDouble (I)Ljava/lang/Double;
+	public fun getFloat (I)Ljava/lang/Float;
+	public fun getInstant (I)Lkotlin/time/Instant;
+	public fun getInt (I)Ljava/lang/Integer;
+	public fun getLocalDateTime (I)Lkotlinx/datetime/LocalDateTime;
+	public fun getLong (I)Ljava/lang/Long;
+	public fun getShort (I)Ljava/lang/Short;
+	public fun getString (I)Ljava/lang/String;
+	public fun getTime (I)Lkotlinx/datetime/LocalTime;
+	public fun next ()Z
+}
+
+public abstract interface class io/github/kormium/PostgresDriver : io/github/kormium/database/Database, io/github/kormium/database/SuspendDatabase, java/lang/AutoCloseable {
+	public abstract fun getConfig ()Lio/github/kormium/KormiumConfig;
+	public abstract fun getDialect ()Lio/github/kormium/Dialect;
+	public abstract fun getWriteListeners ()Lio/github/kormium/WriteListeners;
+	public abstract fun isClosed ()Z
+}
+
+public final class io/github/kormium/PostgresJvmTypeMapper : io/github/kormium/TypeMapper {
+	public static final field INSTANCE Lio/github/kormium/PostgresJvmTypeMapper;
+	public fun toParameter (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/database/CreateDatabaseKt {
+	public static final fun createDatabase (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/functions/Function1;)Lio/github/kormium/PostgresDriver;
+	public static synthetic fun createDatabase$default (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/github/kormium/PostgresDriver;
+}
+
+public final class io/github/kormium/database/Database_jvmKt {
+	public static final fun createDatabase (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILio/github/kormium/KormiumConfig;)Lio/github/kormium/PostgresDriver;
+	public static synthetic fun createDatabase$default (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILio/github/kormium/KormiumConfig;ILjava/lang/Object;)Lio/github/kormium/PostgresDriver;
+}
+

--- a/kormium-postgres/api/kormium-postgres.klib.api
+++ b/kormium-postgres/api/kormium-postgres.klib.api
@@ -1,0 +1,143 @@
+// Klib ABI Dump
+// Targets: [linuxX64, macosArm64, macosX64, mingwX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-postgres>
+final enum class io.github.kormium.postgres/Oid : kotlin/Enum<io.github.kormium.postgres/Oid> { // io.github.kormium.postgres/Oid|null[0]
+    enum entry BIT // io.github.kormium.postgres/Oid.BIT|null[0]
+    enum entry BIT_ARRAY // io.github.kormium.postgres/Oid.BIT_ARRAY|null[0]
+    enum entry BOOL // io.github.kormium.postgres/Oid.BOOL|null[0]
+    enum entry BOOL_ARRAY // io.github.kormium.postgres/Oid.BOOL_ARRAY|null[0]
+    enum entry BOX // io.github.kormium.postgres/Oid.BOX|null[0]
+    enum entry BPCHAR // io.github.kormium.postgres/Oid.BPCHAR|null[0]
+    enum entry BPCHAR_ARRAY // io.github.kormium.postgres/Oid.BPCHAR_ARRAY|null[0]
+    enum entry BYTEA // io.github.kormium.postgres/Oid.BYTEA|null[0]
+    enum entry BYTEA_ARRAY // io.github.kormium.postgres/Oid.BYTEA_ARRAY|null[0]
+    enum entry CHAR // io.github.kormium.postgres/Oid.CHAR|null[0]
+    enum entry CHAR_ARRAY // io.github.kormium.postgres/Oid.CHAR_ARRAY|null[0]
+    enum entry DATE // io.github.kormium.postgres/Oid.DATE|null[0]
+    enum entry DATE_ARRAY // io.github.kormium.postgres/Oid.DATE_ARRAY|null[0]
+    enum entry FLOAT4 // io.github.kormium.postgres/Oid.FLOAT4|null[0]
+    enum entry FLOAT4_ARRAY // io.github.kormium.postgres/Oid.FLOAT4_ARRAY|null[0]
+    enum entry FLOAT8 // io.github.kormium.postgres/Oid.FLOAT8|null[0]
+    enum entry FLOAT8_ARRAY // io.github.kormium.postgres/Oid.FLOAT8_ARRAY|null[0]
+    enum entry INT2 // io.github.kormium.postgres/Oid.INT2|null[0]
+    enum entry INT2_ARRAY // io.github.kormium.postgres/Oid.INT2_ARRAY|null[0]
+    enum entry INT4 // io.github.kormium.postgres/Oid.INT4|null[0]
+    enum entry INT4_ARRAY // io.github.kormium.postgres/Oid.INT4_ARRAY|null[0]
+    enum entry INT8 // io.github.kormium.postgres/Oid.INT8|null[0]
+    enum entry INT8_ARRAY // io.github.kormium.postgres/Oid.INT8_ARRAY|null[0]
+    enum entry INTERVAL // io.github.kormium.postgres/Oid.INTERVAL|null[0]
+    enum entry INTERVAL_ARRAY // io.github.kormium.postgres/Oid.INTERVAL_ARRAY|null[0]
+    enum entry JSON // io.github.kormium.postgres/Oid.JSON|null[0]
+    enum entry JSONB // io.github.kormium.postgres/Oid.JSONB|null[0]
+    enum entry JSONB_ARRAY // io.github.kormium.postgres/Oid.JSONB_ARRAY|null[0]
+    enum entry JSON_ARRAY // io.github.kormium.postgres/Oid.JSON_ARRAY|null[0]
+    enum entry MONEY // io.github.kormium.postgres/Oid.MONEY|null[0]
+    enum entry MONEY_ARRAY // io.github.kormium.postgres/Oid.MONEY_ARRAY|null[0]
+    enum entry NAME // io.github.kormium.postgres/Oid.NAME|null[0]
+    enum entry NAME_ARRAY // io.github.kormium.postgres/Oid.NAME_ARRAY|null[0]
+    enum entry NUMERIC // io.github.kormium.postgres/Oid.NUMERIC|null[0]
+    enum entry NUMERIC_ARRAY // io.github.kormium.postgres/Oid.NUMERIC_ARRAY|null[0]
+    enum entry OID // io.github.kormium.postgres/Oid.OID|null[0]
+    enum entry OID_ARRAY // io.github.kormium.postgres/Oid.OID_ARRAY|null[0]
+    enum entry POINT // io.github.kormium.postgres/Oid.POINT|null[0]
+    enum entry POINT_ARRAY // io.github.kormium.postgres/Oid.POINT_ARRAY|null[0]
+    enum entry REF_CURSOR // io.github.kormium.postgres/Oid.REF_CURSOR|null[0]
+    enum entry REF_CURSOR_ARRAY // io.github.kormium.postgres/Oid.REF_CURSOR_ARRAY|null[0]
+    enum entry TEXT // io.github.kormium.postgres/Oid.TEXT|null[0]
+    enum entry TEXT_ARRAY // io.github.kormium.postgres/Oid.TEXT_ARRAY|null[0]
+    enum entry TIME // io.github.kormium.postgres/Oid.TIME|null[0]
+    enum entry TIMESTAMP // io.github.kormium.postgres/Oid.TIMESTAMP|null[0]
+    enum entry TIMESTAMPTZ // io.github.kormium.postgres/Oid.TIMESTAMPTZ|null[0]
+    enum entry TIMESTAMPTZ_ARRAY // io.github.kormium.postgres/Oid.TIMESTAMPTZ_ARRAY|null[0]
+    enum entry TIMESTAMP_ARRAY // io.github.kormium.postgres/Oid.TIMESTAMP_ARRAY|null[0]
+    enum entry TIMETZ // io.github.kormium.postgres/Oid.TIMETZ|null[0]
+    enum entry TIMETZ_ARRAY // io.github.kormium.postgres/Oid.TIMETZ_ARRAY|null[0]
+    enum entry TIME_ARRAY // io.github.kormium.postgres/Oid.TIME_ARRAY|null[0]
+    enum entry UNSPECIFIED // io.github.kormium.postgres/Oid.UNSPECIFIED|null[0]
+    enum entry UUID // io.github.kormium.postgres/Oid.UUID|null[0]
+    enum entry UUID_ARRAY // io.github.kormium.postgres/Oid.UUID_ARRAY|null[0]
+    enum entry VARBIT // io.github.kormium.postgres/Oid.VARBIT|null[0]
+    enum entry VARBIT_ARRAY // io.github.kormium.postgres/Oid.VARBIT_ARRAY|null[0]
+    enum entry VARCHAR // io.github.kormium.postgres/Oid.VARCHAR|null[0]
+    enum entry VARCHAR_ARRAY // io.github.kormium.postgres/Oid.VARCHAR_ARRAY|null[0]
+    enum entry VOID // io.github.kormium.postgres/Oid.VOID|null[0]
+    enum entry XML // io.github.kormium.postgres/Oid.XML|null[0]
+    enum entry XML_ARRAY // io.github.kormium.postgres/Oid.XML_ARRAY|null[0]
+
+    final val entries // io.github.kormium.postgres/Oid.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<io.github.kormium.postgres/Oid> // io.github.kormium.postgres/Oid.entries.<get-entries>|<get-entries>#static(){}[0]
+    final val value // io.github.kormium.postgres/Oid.value|{}value[0]
+        final fun <get-value>(): kotlin/Int // io.github.kormium.postgres/Oid.value.<get-value>|<get-value>(){}[0]
+
+    final fun valueOf(kotlin/String): io.github.kormium.postgres/Oid // io.github.kormium.postgres/Oid.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<io.github.kormium.postgres/Oid> // io.github.kormium.postgres/Oid.values|values#static(){}[0]
+}
+
+abstract interface io.github.kormium/PostgresDriver : io.github.kormium.database/Database<kotlin/Nothing>, io.github.kormium.database/SuspendDatabase<kotlin/Nothing>, kotlin/AutoCloseable { // io.github.kormium/PostgresDriver|null[0]
+    abstract val config // io.github.kormium/PostgresDriver.config|{}config[0]
+        abstract fun <get-config>(): io.github.kormium/KormiumConfig // io.github.kormium/PostgresDriver.config.<get-config>|<get-config>(){}[0]
+    abstract val dialect // io.github.kormium/PostgresDriver.dialect|{}dialect[0]
+        abstract fun <get-dialect>(): io.github.kormium/Dialect // io.github.kormium/PostgresDriver.dialect.<get-dialect>|<get-dialect>(){}[0]
+    abstract val isClosed // io.github.kormium/PostgresDriver.isClosed|{}isClosed[0]
+        abstract fun <get-isClosed>(): kotlin/Boolean // io.github.kormium/PostgresDriver.isClosed.<get-isClosed>|<get-isClosed>(){}[0]
+    abstract val writeListeners // io.github.kormium/PostgresDriver.writeListeners|{}writeListeners[0]
+        abstract fun <get-writeListeners>(): io.github.kormium/WriteListeners // io.github.kormium/PostgresDriver.writeListeners.<get-writeListeners>|<get-writeListeners>(){}[0]
+}
+
+abstract class io.github.kormium.postgres.paramsource/AbstractSqlParameterSource : io.github.kormium/SqlParameterSource { // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource|null[0]
+    constructor <init>() // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.<init>|<init>(){}[0]
+
+    final fun getTypeName(kotlin/String): kotlin/String? // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.getTypeName|getTypeName(kotlin.String){}[0]
+    final fun registerSqlType(kotlin/String, kotlin/Any?) // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.registerSqlType|registerSqlType(kotlin.String;kotlin.Any?){}[0]
+    final fun registerSqlType(kotlin/String, kotlin/UInt) // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.registerSqlType|registerSqlType(kotlin.String;kotlin.UInt){}[0]
+    final fun registerTypeName(kotlin/String, kotlin/String) // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.registerTypeName|registerTypeName(kotlin.String;kotlin.String){}[0]
+    open fun getSqlType(kotlin/String): kotlin/UInt // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.getSqlType|getSqlType(kotlin.String){}[0]
+    open fun toString(): kotlin/String // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.toString|toString(){}[0]
+}
+
+final class io.github.kormium.postgres.exception/AnonymousClassException : io.github.kormium.postgres.exception/SQLException { // io.github.kormium.postgres.exception/AnonymousClassException|null[0]
+    constructor <init>() // io.github.kormium.postgres.exception/AnonymousClassException.<init>|<init>(){}[0]
+}
+
+final class io.github.kormium.postgres.exception/ConnectionClosedException : io.github.kormium.postgres.exception/SQLException { // io.github.kormium.postgres.exception/ConnectionClosedException|null[0]
+    constructor <init>() // io.github.kormium.postgres.exception/ConnectionClosedException.<init>|<init>(){}[0]
+}
+
+final class io.github.kormium.postgres.exception/GetColumnValueException : io.github.kormium.postgres.exception/SQLException { // io.github.kormium.postgres.exception/GetColumnValueException|null[0]
+    constructor <init>(kotlin/Int) // io.github.kormium.postgres.exception/GetColumnValueException.<init>|<init>(kotlin.Int){}[0]
+}
+
+final class io.github.kormium.postgres.exception/InvalidDataAccessApiUsageException : io.github.kormium.postgres.exception/SQLException { // io.github.kormium.postgres.exception/InvalidDataAccessApiUsageException|null[0]
+    constructor <init>(kotlin/String, kotlin/Throwable? = ...) // io.github.kormium.postgres.exception/InvalidDataAccessApiUsageException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
+}
+
+final class io.github.kormium.postgres.exception/QueryExecutionException : io.github.kormium.postgres.exception/SQLException { // io.github.kormium.postgres.exception/QueryExecutionException|null[0]
+    constructor <init>(kotlin/String, kotlin/Throwable? = ...) // io.github.kormium.postgres.exception/QueryExecutionException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
+}
+
+final class io.github.kormium.postgres.paramsource/MapSqlParameterSource : io.github.kormium.postgres.paramsource/AbstractSqlParameterSource { // io.github.kormium.postgres.paramsource/MapSqlParameterSource|null[0]
+    constructor <init>(kotlin.collections/Map<kotlin/String, kotlin/Any?>?) // io.github.kormium.postgres.paramsource/MapSqlParameterSource.<init>|<init>(kotlin.collections.Map<kotlin.String,kotlin.Any?>?){}[0]
+
+    final val parameterNames // io.github.kormium.postgres.paramsource/MapSqlParameterSource.parameterNames|{}parameterNames[0]
+        final fun <get-parameterNames>(): kotlin/Array<kotlin/String> // io.github.kormium.postgres.paramsource/MapSqlParameterSource.parameterNames.<get-parameterNames>|<get-parameterNames>(){}[0]
+
+    final fun addValue(kotlin/String, kotlin/Any?): io.github.kormium.postgres.paramsource/MapSqlParameterSource // io.github.kormium.postgres.paramsource/MapSqlParameterSource.addValue|addValue(kotlin.String;kotlin.Any?){}[0]
+    final fun addValue(kotlin/String, kotlin/Any?, kotlin/UInt): io.github.kormium.postgres.paramsource/MapSqlParameterSource // io.github.kormium.postgres.paramsource/MapSqlParameterSource.addValue|addValue(kotlin.String;kotlin.Any?;kotlin.UInt){}[0]
+    final fun addValue(kotlin/String, kotlin/Any?, kotlin/UInt, kotlin/String?): io.github.kormium.postgres.paramsource/MapSqlParameterSource // io.github.kormium.postgres.paramsource/MapSqlParameterSource.addValue|addValue(kotlin.String;kotlin.Any?;kotlin.UInt;kotlin.String?){}[0]
+    final fun addValues(kotlin.collections/Map<kotlin/String, kotlin/Any?>?): io.github.kormium.postgres.paramsource/MapSqlParameterSource // io.github.kormium.postgres.paramsource/MapSqlParameterSource.addValues|addValues(kotlin.collections.Map<kotlin.String,kotlin.Any?>?){}[0]
+    final fun getValue(kotlin/String): kotlin/Any? // io.github.kormium.postgres.paramsource/MapSqlParameterSource.getValue|getValue(kotlin.String){}[0]
+    final fun getValues(): kotlin.collections/Map<kotlin/String, kotlin/Any?> // io.github.kormium.postgres.paramsource/MapSqlParameterSource.getValues|getValues(){}[0]
+    final fun hasValue(kotlin/String): kotlin/Boolean // io.github.kormium.postgres.paramsource/MapSqlParameterSource.hasValue|hasValue(kotlin.String){}[0]
+}
+
+sealed class io.github.kormium.postgres.exception/SQLException : kotlin/Exception // io.github.kormium.postgres.exception/SQLException|null[0]
+
+final fun io.github.kormium.database/createDatabase(kotlin/String, kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, kotlin/Int = ..., io.github.kormium/KormiumConfig = ...): io.github.kormium/PostgresDriver // io.github.kormium.database/createDatabase|createDatabase(kotlin.String;kotlin.Int;kotlin.String;kotlin.String;kotlin.String;kotlin.Int;io.github.kormium.KormiumConfig){}[0]
+final fun io.github.kormium.database/createDatabase(kotlin/String, kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, kotlin/Int = ..., kotlin/Function1<io.github.kormium/KormiumBuilder, kotlin/Unit>): io.github.kormium/PostgresDriver // io.github.kormium.database/createDatabase|createDatabase(kotlin.String;kotlin.Int;kotlin.String;kotlin.String;kotlin.String;kotlin.Int;kotlin.Function1<io.github.kormium.KormiumBuilder,kotlin.Unit>){}[0]
+final fun io.github.kormium.postgres/FPostgresDriver(kotlin/String, kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, kotlin/Int = ..., io.github.kormium/KormiumConfig = ...): io.github.kormium/PostgresDriver // io.github.kormium.postgres/FPostgresDriver|FPostgresDriver(kotlin.String;kotlin.Int;kotlin.String;kotlin.String;kotlin.String;kotlin.Int;io.github.kormium.KormiumConfig){}[0]
+final fun io.github.kormium/postgresListenNotifyTransport(kotlin/String, kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, kotlin/String = ...): io.github.kormium/NotificationTransport // io.github.kormium/postgresListenNotifyTransport|postgresListenNotifyTransport(kotlin.String;kotlin.Int;kotlin.String;kotlin.String;kotlin.String;kotlin.String){}[0]

--- a/kormium-postgres/build.gradle.kts
+++ b/kormium-postgres/build.gradle.kts
@@ -7,6 +7,8 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm {

--- a/kormium-postgres/src/commonMain/kotlin/PostgresDriver.kt
+++ b/kormium-postgres/src/commonMain/kotlin/PostgresDriver.kt
@@ -10,7 +10,7 @@ import io.github.kormium.WriteListeners
  * released (or used via a `use { }` block). Blocking query methods come from [Database];
  * the suspend path (suspendTransaction/suspendAutocommit) comes from [SuspendDatabase].
  */
-interface PostgresDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoCloseable {
+public interface PostgresDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoCloseable {
     // Resolves the config default inherited from both Database and SuspendDatabase; concrete
     // drivers supply it (from the createDatabase config argument).
     override val config: KormiumConfig

--- a/kormium-postgres/src/commonMain/kotlin/database/CreateDatabase.kt
+++ b/kormium-postgres/src/commonMain/kotlin/database/CreateDatabase.kt
@@ -4,7 +4,7 @@ import io.github.kormium.KormiumBuilder
 import io.github.kormium.KormiumConfig
 import io.github.kormium.PostgresDriver
 
-expect fun createDatabase(
+public expect fun createDatabase(
     host: String,
     port: Int = 5432,
     database: String,
@@ -18,7 +18,7 @@ expect fun createDatabase(
  * Opens a PostgreSQL database with a configuration block: `createDatabase(host = …, …) {`
  * `config { … }; beforeStart { migrate(appMigrations) } }`. See [KormiumBuilder].
  */
-fun createDatabase(
+public fun createDatabase(
     host: String,
     port: Int = 5432,
     database: String,

--- a/kormium-postgres/src/jvmMain/kotlin/PgNotificationTransport.kt
+++ b/kormium-postgres/src/jvmMain/kotlin/PgNotificationTransport.kt
@@ -22,7 +22,7 @@ import java.sql.DriverManager
  *
  * [channel] must be a valid SQL identifier; the default is fine.
  */
-fun postgresListenNotifyTransport(
+public fun postgresListenNotifyTransport(
     host: String,
     port: Int = 5432,
     database: String,

--- a/kormium-postgres/src/jvmMain/kotlin/PgResultSetWrapper.kt
+++ b/kormium-postgres/src/jvmMain/kotlin/PgResultSetWrapper.kt
@@ -5,7 +5,7 @@ import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import java.sql.ResultSetMetaData
 
-class PgResultSetWrapper(private val pgResultSet: java.sql.ResultSet) : ResultSet {
+public class PgResultSetWrapper(private val pgResultSet: java.sql.ResultSet) : ResultSet {
     // Lazy: the hot read path maps columns positionally and never touches this, so don't
     // read ResultSetMetaData on every query.
     override val columns: Array<String> by lazy { internalGetColumns() }

--- a/kormium-postgres/src/jvmMain/kotlin/PostgresJvmTypeMapper.kt
+++ b/kormium-postgres/src/jvmMain/kotlin/PostgresJvmTypeMapper.kt
@@ -26,7 +26,7 @@ import kotlin.uuid.toJavaUuid
  * explicit `::type` casts from [PostgresDialect] where inference needs help; r2dbc is
  * natively typed already.
  */
-object PostgresJvmTypeMapper : TypeMapper {
+public object PostgresJvmTypeMapper : TypeMapper {
     override fun toParameter(value: Any?): Any? = when (value) {
         // StandardTypeMapper would toString() these (text is fine for libpq, wrong here):
         // pass them through so they bind as real float4 / int2.

--- a/kormium-postgres/src/jvmMain/kotlin/database/Database.jvm.kt
+++ b/kormium-postgres/src/jvmMain/kotlin/database/Database.jvm.kt
@@ -39,7 +39,7 @@ private class PostgresJdbcDriver(
     config = config,
 ), PostgresDriver
 
-actual fun createDatabase(
+public actual fun createDatabase(
     host: String,
     port: Int,
     database: String,

--- a/kormium-postgres/src/nativeMain/kotlin/PgNotificationTransport.native.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/PgNotificationTransport.native.kt
@@ -35,7 +35,7 @@ import libpq.PQstatus
  *
  * Note: the socket reactor is unavailable on Windows native (mingwX64); [subscribe] there fails.
  */
-fun postgresListenNotifyTransport(
+public fun postgresListenNotifyTransport(
     host: String,
     port: Int = 5432,
     database: String,

--- a/kormium-postgres/src/nativeMain/kotlin/database/Database.native.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/database/Database.native.kt
@@ -2,7 +2,7 @@ package io.github.kormium.database
 
 import io.github.kormium.KormiumConfig
 
-actual fun createDatabase(
+public actual fun createDatabase(
     host: String,
     port: Int,
     database: String,
@@ -10,4 +10,4 @@ actual fun createDatabase(
     password: String,
     poolSize: Int,
     config: KormiumConfig,
-) = io.github.kormium.postgres.FPostgresDriver(host, port, database, user, password, poolSize, config)
+): io.github.kormium.PostgresDriver = io.github.kormium.postgres.FPostgresDriver(host, port, database, user, password, poolSize, config)

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/Oid.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/Oid.kt
@@ -35,7 +35,7 @@ private val supportedBinaryOids = hashSetOf(
 
 
 @Suppress("MagicNumber")
-enum class Oid(val value: Int) {
+public enum class Oid(public val value: Int) {
     UNSPECIFIED(0),
     INT2(21),
     INT2_ARRAY(1005),

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/PostgresDriver.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/PostgresDriver.kt
@@ -50,7 +50,7 @@ private fun pgBeginSql(isolation: TransactionIsolation?, readOnly: Boolean): Str
 }
 
 @OptIn(ExperimentalForeignApi::class)
-fun FPostgresDriver(
+public fun FPostgresDriver(
     host: String,
     port: Int = 5432,
     database: String,

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/exception/PgKnException.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/exception/PgKnException.kt
@@ -1,15 +1,15 @@
 package io.github.kormium.postgres.exception
 
-sealed class SQLException(message: String? = null, cause: Throwable? = null) : Exception(message, cause)
+public sealed class SQLException(message: String? = null, cause: Throwable? = null) : Exception(message, cause)
 
-class InvalidDataAccessApiUsageException(message: String, cause: Throwable? = null) : SQLException(message, cause)
+public class InvalidDataAccessApiUsageException(message: String, cause: Throwable? = null) : SQLException(message, cause)
 
-class AnonymousClassException : SQLException("Class must not be anonymous", null)
+public class AnonymousClassException : SQLException("Class must not be anonymous", null)
 
-class GetColumnValueException(columnIndex: Int) : SQLException("Error getting column $columnIndex value", null)
+public class GetColumnValueException(columnIndex: Int) : SQLException("Error getting column $columnIndex value", null)
 
 /** Raised when a statement (or the initial connection) fails on the server. */
-class QueryExecutionException(message: String, cause: Throwable? = null) : SQLException(message, cause)
+public class QueryExecutionException(message: String, cause: Throwable? = null) : SQLException(message, cause)
 
 /** Raised when the driver is used after [io.github.kormium.postgres.PostgresDriver] was closed. */
-class ConnectionClosedException : SQLException("PostgresDriver is closed", null)
+public class ConnectionClosedException : SQLException("PostgresDriver is closed", null)

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/paramsource/AbstractSqlParameterSource.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/paramsource/AbstractSqlParameterSource.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.KClass
  * [toString] representation.
  * Concrete subclasses must implement [hasValue] and [getValue].
  */
-abstract class AbstractSqlParameterSource : SqlParameterSource {
+public abstract class AbstractSqlParameterSource : SqlParameterSource {
     private val sqlTypes: MutableMap<String, UInt> = HashMap()
     private val typeNames: MutableMap<String, String> = HashMap()
 
@@ -24,11 +24,11 @@ abstract class AbstractSqlParameterSource : SqlParameterSource {
      * @param paramName the name of the parameter
      * @param sqlType the SQL type of the parameter
      */
-    fun registerSqlType(paramName: String, sqlType: UInt) {
+    public fun registerSqlType(paramName: String, sqlType: UInt) {
         sqlTypes[paramName] = sqlType
     }
 
-    fun registerSqlType(paramName: String, value: Any?) {
+    public fun registerSqlType(paramName: String, value: Any?) {
         registerSqlType(
             paramName = paramName,
             sqlType = value?.let { oidMap[it::class.simpleName ?: throw AnonymousClassException()] }
@@ -41,7 +41,7 @@ abstract class AbstractSqlParameterSource : SqlParameterSource {
      * @param paramName the name of the parameter
      * @param typeName the type name of the parameter
      */
-    fun registerTypeName(paramName: String, typeName: String) {
+    public fun registerTypeName(paramName: String, typeName: String) {
         typeNames[paramName] = typeName
     }
 
@@ -51,7 +51,7 @@ abstract class AbstractSqlParameterSource : SqlParameterSource {
      * @return the SQL type of the parameter,
      * or `TYPE_UNKNOWN` if not registered
      */
-    override fun getSqlType(paramName: String) = sqlTypes[paramName] ?: SqlParameterSource.TYPE_UNKNOWN
+    override fun getSqlType(paramName: String): UInt = sqlTypes[paramName] ?: SqlParameterSource.TYPE_UNKNOWN
 
     /**
      * Return the type name for the given parameter, if registered.
@@ -59,7 +59,7 @@ abstract class AbstractSqlParameterSource : SqlParameterSource {
      * @return the type name of the parameter,
      * or `null` if not registered
      */
-    fun getTypeName(paramName: String) = typeNames[paramName]
+    public fun getTypeName(paramName: String): String? = typeNames[paramName]
 
     /**
      * Enumerate the parameter names and values with their corresponding SQL type if available,

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/paramsource/MapSqlParameterSource.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/paramsource/MapSqlParameterSource.kt
@@ -8,14 +8,14 @@ package io.github.kormium.postgres.paramsource
  * easier. The methods return a reference to the [MapSqlParameterSource]
  * itself, so you can chain several method calls together within a single statement.
  */
-class MapSqlParameterSource : AbstractSqlParameterSource {
+public class MapSqlParameterSource : AbstractSqlParameterSource {
     private val values: MutableMap<String, Any?> = LinkedHashMap()
 
     /**
      * Create a new MapSqlParameterSource based on a Map.
      * @param values a Map holding existing parameter values (can be `null`)
      */
-    constructor(values: Map<String, Any?>?) {
+    public constructor(values: Map<String, Any?>?) {
         addValues(values)
     }
 
@@ -26,7 +26,7 @@ class MapSqlParameterSource : AbstractSqlParameterSource {
      * @return a reference to this parameter source,
      * so it's possible to chain several calls together
      */
-    fun addValue(paramName: String, value: Any?): MapSqlParameterSource {
+    public fun addValue(paramName: String, value: Any?): MapSqlParameterSource {
         this.values[paramName] = value
         registerSqlType(paramName, value)
         return this
@@ -40,7 +40,7 @@ class MapSqlParameterSource : AbstractSqlParameterSource {
      * @return a reference to this parameter source,
      * so it's possible to chain several calls together
      */
-    fun addValue(paramName: String, value: Any?, sqlType: UInt): MapSqlParameterSource {
+    public fun addValue(paramName: String, value: Any?, sqlType: UInt): MapSqlParameterSource {
         this.values[paramName] = value
         registerSqlType(paramName = paramName, sqlType = sqlType)
         return this
@@ -55,7 +55,7 @@ class MapSqlParameterSource : AbstractSqlParameterSource {
      * @return a reference to this parameter source,
      * so it's possible to chain several calls together
      */
-    fun addValue(paramName: String, value: Any?, sqlType: UInt, typeName: String?): MapSqlParameterSource {
+    public fun addValue(paramName: String, value: Any?, sqlType: UInt, typeName: String?): MapSqlParameterSource {
         this.values[paramName] = value
         registerSqlType(paramName = paramName, sqlType = sqlType)
         registerTypeName(paramName, typeName!!)
@@ -68,7 +68,7 @@ class MapSqlParameterSource : AbstractSqlParameterSource {
      * @return a reference to this parameter source,
      * so it's possible to chain several calls together
      */
-    fun addValues(values: Map<String, Any?>?): MapSqlParameterSource {
+    public fun addValues(values: Map<String, Any?>?): MapSqlParameterSource {
         values?.forEach { (key, value) ->
             this.values[key] = value
             registerSqlType(paramName = key, value = value)
@@ -79,9 +79,9 @@ class MapSqlParameterSource : AbstractSqlParameterSource {
     /**
      * Expose the current parameter values as read-only Map.
      */
-    fun getValues(): Map<String, Any?> = this.values
+    public fun getValues(): Map<String, Any?> = this.values
 
-    override fun hasValue(paramName: String) = this.values.containsKey(paramName)
+    override fun hasValue(paramName: String): Boolean = this.values.containsKey(paramName)
 
     @Suppress("UseRequire")
     override fun getValue(paramName: String): Any? {

--- a/kormium-r2dbc/api/kormium-r2dbc.api
+++ b/kormium-r2dbc/api/kormium-r2dbc.api
@@ -1,0 +1,24 @@
+public final class io/github/kormium/r2dbc/MySqlR2dbcKt {
+	public static final fun createMySqlR2dbcDatabase (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILio/github/kormium/KormiumConfig;)Lio/github/kormium/r2dbc/R2dbcDatabase;
+	public static synthetic fun createMySqlR2dbcDatabase$default (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILio/github/kormium/KormiumConfig;ILjava/lang/Object;)Lio/github/kormium/r2dbc/R2dbcDatabase;
+}
+
+public final class io/github/kormium/r2dbc/R2dbcDatabase : io/github/kormium/database/SuspendDatabase {
+	public fun close ()V
+	public fun getConfig ()Lio/github/kormium/KormiumConfig;
+	public fun getDialect ()Lio/github/kormium/Dialect;
+	public fun getWriteListeners ()Lio/github/kormium/WriteListeners;
+	public fun isClosed ()Z
+	public fun useConnection (ZLio/github/kormium/TransactionIsolation;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kormium/r2dbc/R2dbcDatabaseKt {
+	public static final fun createR2dbcDatabase (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILio/github/kormium/KormiumConfig;)Lio/github/kormium/r2dbc/R2dbcDatabase;
+	public static synthetic fun createR2dbcDatabase$default (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILio/github/kormium/KormiumConfig;ILjava/lang/Object;)Lio/github/kormium/r2dbc/R2dbcDatabase;
+}
+
+public final class io/github/kormium/r2dbc/R2dbcNotificationTransportKt {
+	public static final fun r2dbcListenNotifyTransport (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kormium/NotificationTransport;
+	public static synthetic fun r2dbcListenNotifyTransport$default (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kormium/NotificationTransport;
+}
+

--- a/kormium-r2dbc/build.gradle.kts
+++ b/kormium-r2dbc/build.gradle.kts
@@ -7,6 +7,8 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm {

--- a/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/MySqlR2dbc.kt
+++ b/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/MySqlR2dbc.kt
@@ -22,7 +22,7 @@ import io.r2dbc.pool.ConnectionPoolConfiguration
  *
  * Returns it tagged [Nothing] (covariance pins the catalog at the call site).
  */
-fun createMySqlR2dbcDatabase(
+public fun createMySqlR2dbcDatabase(
     host: String,
     port: Int = 3306,
     database: String,

--- a/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/R2dbcDatabase.kt
+++ b/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/R2dbcDatabase.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.withContext
  * The phantom catalog tag is [Nothing], so by covariance it fits any
  * `SuspendDatabase<G>`; pin the tag at the call site (`val db: SuspendDatabase<MyCatalog>`).
  */
-class R2dbcDatabase internal constructor(
+public class R2dbcDatabase internal constructor(
     private val pool: ConnectionPool,
     override val dialect: Dialect,
     private val typeMapper: TypeMapper,
@@ -78,7 +78,7 @@ class R2dbcDatabase internal constructor(
         }
     }
 
-    override fun close() = lifecycle.close()
+    override fun close(): Unit = lifecycle.close()
 }
 
 /**
@@ -110,7 +110,7 @@ private val TransactionIsolation.r2dbcLevel: IsolationLevel
  * Opens an async Postgres database over r2dbc with a reactive connection pool of
  * [poolSize]. Returns it tagged [Nothing] (covariance pins the catalog at the call site).
  */
-fun createR2dbcDatabase(
+public fun createR2dbcDatabase(
     host: String,
     port: Int = 5432,
     database: String,

--- a/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/R2dbcNotificationTransport.kt
+++ b/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/R2dbcNotificationTransport.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.reactive.awaitSingle
  * connection per call to `NOTIFY`. The wire format is shared with the JDBC/libpq transports, so an
  * r2dbc instance interoperates with them on the same [channel].
  */
-fun r2dbcListenNotifyTransport(
+public fun r2dbcListenNotifyTransport(
     host: String,
     port: Int = 5432,
     database: String,

--- a/kormium-sqlite-dialect/api/jvm/kormium-sqlite-dialect.api
+++ b/kormium-sqlite-dialect/api/jvm/kormium-sqlite-dialect.api
@@ -1,0 +1,17 @@
+public final class io/github/kormium/SqliteDialect : io/github/kormium/Dialect {
+	public static final field INSTANCE Lio/github/kormium/SqliteDialect;
+	public fun advisoryLockSql (J)Ljava/lang/String;
+	public fun getReadOnlyToggle ()Lio/github/kormium/ReadOnlyToggle;
+	public fun getSupportsReturning ()Z
+	public fun getSupportsTransactionIsolation ()Z
+	public fun quoteIdentifier (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderBind (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/String;
+	public fun renderCharLength (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderInsertDefaultValues (Ljava/lang/String;)Ljava/lang/String;
+	public fun renderInsertOrIgnoreSuffix (Ljava/util/List;)Ljava/lang/String;
+	public fun renderLimit-WZ4Q5Ns (I)Ljava/lang/String;
+	public fun renderLimitOffset-feOb9K0 (II)Ljava/lang/String;
+	public fun renderOffset-WZ4Q5Ns (I)Ljava/lang/String;
+	public fun renderUpsertSuffix (Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;
+}
+

--- a/kormium-sqlite-dialect/api/kormium-sqlite-dialect.klib.api
+++ b/kormium-sqlite-dialect/api/kormium-sqlite-dialect.klib.api
@@ -1,0 +1,27 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64, macosArm64, macosX64, mingwX64, wasmJs, wasmWasi]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-sqlite-dialect>
+final object io.github.kormium/SqliteDialect : io.github.kormium/Dialect { // io.github.kormium/SqliteDialect|null[0]
+    final val readOnlyToggle // io.github.kormium/SqliteDialect.readOnlyToggle|{}readOnlyToggle[0]
+        final fun <get-readOnlyToggle>(): io.github.kormium/ReadOnlyToggle // io.github.kormium/SqliteDialect.readOnlyToggle.<get-readOnlyToggle>|<get-readOnlyToggle>(){}[0]
+    final val supportsReturning // io.github.kormium/SqliteDialect.supportsReturning|{}supportsReturning[0]
+        final fun <get-supportsReturning>(): kotlin/Boolean // io.github.kormium/SqliteDialect.supportsReturning.<get-supportsReturning>|<get-supportsReturning>(){}[0]
+    final val supportsTransactionIsolation // io.github.kormium/SqliteDialect.supportsTransactionIsolation|{}supportsTransactionIsolation[0]
+        final fun <get-supportsTransactionIsolation>(): kotlin/Boolean // io.github.kormium/SqliteDialect.supportsTransactionIsolation.<get-supportsTransactionIsolation>|<get-supportsTransactionIsolation>(){}[0]
+
+    final fun advisoryLockSql(kotlin/Long): kotlin/String? // io.github.kormium/SqliteDialect.advisoryLockSql|advisoryLockSql(kotlin.Long){}[0]
+    final fun quoteIdentifier(kotlin/String): kotlin/String // io.github.kormium/SqliteDialect.quoteIdentifier|quoteIdentifier(kotlin.String){}[0]
+    final fun renderBind(kotlin/String, kotlin/Any?): kotlin/String // io.github.kormium/SqliteDialect.renderBind|renderBind(kotlin.String;kotlin.Any?){}[0]
+    final fun renderCharLength(kotlin/String): kotlin/String // io.github.kormium/SqliteDialect.renderCharLength|renderCharLength(kotlin.String){}[0]
+    final fun renderInsertDefaultValues(kotlin/String): kotlin/String // io.github.kormium/SqliteDialect.renderInsertDefaultValues|renderInsertDefaultValues(kotlin.String){}[0]
+    final fun renderInsertOrIgnoreSuffix(kotlin.collections/List<kotlin/String>): kotlin/String // io.github.kormium/SqliteDialect.renderInsertOrIgnoreSuffix|renderInsertOrIgnoreSuffix(kotlin.collections.List<kotlin.String>){}[0]
+    final fun renderLimit(kotlin/UInt): kotlin/String // io.github.kormium/SqliteDialect.renderLimit|renderLimit(kotlin.UInt){}[0]
+    final fun renderLimitOffset(kotlin/UInt, kotlin/UInt): kotlin/String // io.github.kormium/SqliteDialect.renderLimitOffset|renderLimitOffset(kotlin.UInt;kotlin.UInt){}[0]
+    final fun renderOffset(kotlin/UInt): kotlin/String // io.github.kormium/SqliteDialect.renderOffset|renderOffset(kotlin.UInt){}[0]
+    final fun renderUpsertSuffix(kotlin.collections/List<kotlin/String>, kotlin/String): kotlin/String // io.github.kormium/SqliteDialect.renderUpsertSuffix|renderUpsertSuffix(kotlin.collections.List<kotlin.String>;kotlin.String){}[0]
+}

--- a/kormium-sqlite-dialect/build.gradle.kts
+++ b/kormium-sqlite-dialect/build.gradle.kts
@@ -13,6 +13,8 @@ repositories {
 // driver (and its `expect createSqliteDatabase`) cannot go. Both the platform driver
 // (kormium-sqlite) and any web engine (wa-sqlite, node:sqlite) reuse this one copy.
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm()

--- a/kormium-sqlite-dialect/src/commonMain/kotlin/SqliteDialect.kt
+++ b/kormium-sqlite-dialect/src/commonMain/kotlin/SqliteDialect.kt
@@ -7,7 +7,7 @@ package io.github.kormium
  * `TEXT` and parsed back by the result-set wrapper. Kormium does not own schema DDL, so
  * the dialect carries no column-type mapping.
  */
-object SqliteDialect : Dialect by StandardDialect {
+public object SqliteDialect : Dialect by StandardDialect {
     // SQLite has a single isolation level (effectively SERIALIZABLE), so a requested level is ignored.
     override val supportsTransactionIsolation: Boolean get() = false
 

--- a/kormium-sqlite-node/api/kormium-sqlite-node.klib.api
+++ b/kormium-sqlite-node/api/kormium-sqlite-node.klib.api
@@ -1,0 +1,30 @@
+// Klib ABI Dump
+// Targets: [wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-sqlite-node>
+final class io.github.kormium.sqlite.node/Database : kotlin.js/JsAny { // io.github.kormium.sqlite.node/Database|null[0]
+    constructor <init>(kotlin/String) // io.github.kormium.sqlite.node/Database.<init>|<init>(kotlin.String){}[0]
+
+    final fun close() // io.github.kormium.sqlite.node/Database.close|close(){}[0]
+    final fun exec(kotlin/String) // io.github.kormium.sqlite.node/Database.exec|exec(kotlin.String){}[0]
+}
+
+final class io.github.kormium.sqlite.node/NodeSqliteDatabase : io.github.kormium.database/SuspendDatabase<kotlin/Nothing> { // io.github.kormium.sqlite.node/NodeSqliteDatabase|null[0]
+    final val config // io.github.kormium.sqlite.node/NodeSqliteDatabase.config|{}config[0]
+        final fun <get-config>(): io.github.kormium/KormiumConfig // io.github.kormium.sqlite.node/NodeSqliteDatabase.config.<get-config>|<get-config>(){}[0]
+    final val dialect // io.github.kormium.sqlite.node/NodeSqliteDatabase.dialect|{}dialect[0]
+        final fun <get-dialect>(): io.github.kormium/SqliteDialect // io.github.kormium.sqlite.node/NodeSqliteDatabase.dialect.<get-dialect>|<get-dialect>(){}[0]
+    final val isClosed // io.github.kormium.sqlite.node/NodeSqliteDatabase.isClosed|{}isClosed[0]
+        final fun <get-isClosed>(): kotlin/Boolean // io.github.kormium.sqlite.node/NodeSqliteDatabase.isClosed.<get-isClosed>|<get-isClosed>(){}[0]
+    final val writeListeners // io.github.kormium.sqlite.node/NodeSqliteDatabase.writeListeners|{}writeListeners[0]
+        final fun <get-writeListeners>(): io.github.kormium/WriteListeners // io.github.kormium.sqlite.node/NodeSqliteDatabase.writeListeners.<get-writeListeners>|<get-writeListeners>(){}[0]
+
+    final fun close() // io.github.kormium.sqlite.node/NodeSqliteDatabase.close|close(){}[0]
+    final suspend fun <#A1: kotlin/Any?> useConnection(kotlin/Boolean, io.github.kormium/TransactionIsolation?, kotlin/Boolean, kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendSqlExecutor, #A1>): #A1 // io.github.kormium.sqlite.node/NodeSqliteDatabase.useConnection|useConnection(kotlin.Boolean;io.github.kormium.TransactionIsolation?;kotlin.Boolean;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendSqlExecutor,0:0>){0§<kotlin.Any?>}[0]
+}
+
+final fun io.github.kormium.sqlite.node/createNodeSqliteDatabase(kotlin/String = ..., io.github.kormium/KormiumConfig = ...): io.github.kormium.sqlite.node/NodeSqliteDatabase // io.github.kormium.sqlite.node/createNodeSqliteDatabase|createNodeSqliteDatabase(kotlin.String;io.github.kormium.KormiumConfig){}[0]

--- a/kormium-sqlite-node/build.gradle.kts
+++ b/kormium-sqlite-node/build.gradle.kts
@@ -7,6 +7,8 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
+
     // A SQLite engine for Kotlin running on Node, over the synchronous better-sqlite3 package.
     // Node only (no browser); nodejs() also runs the tests against a real on-disk/in-memory SQLite.
     compilerOptions {

--- a/kormium-sqlite-node/src/wasmJsMain/kotlin/io/github/kormium/sqlite/node/BetterSqlite.kt
+++ b/kormium-sqlite-node/src/wasmJsMain/kotlin/io/github/kormium/sqlite/node/BetterSqlite.kt
@@ -7,10 +7,10 @@ package io.github.kormium.sqlite.node
  * from `kormium-wasm-driver`.
  */
 @JsModule("better-sqlite3")
-external class Database(filename: String) : JsAny {
+public external class Database(filename: String) : JsAny {
     /** Runs one or more statements without parameters (DDL / scripts). */
-    fun exec(sql: String)
-    fun close()
+    public fun exec(sql: String)
+    public fun close()
 }
 
 /** Prepares [sql], binds [params] positionally and returns all result rows (SELECT / RETURNING). */

--- a/kormium-sqlite-node/src/wasmJsMain/kotlin/io/github/kormium/sqlite/node/NodeSqliteDatabase.kt
+++ b/kormium-sqlite-node/src/wasmJsMain/kotlin/io/github/kormium/sqlite/node/NodeSqliteDatabase.kt
@@ -20,13 +20,13 @@ import kotlinx.coroutines.withContext
  * can't interleave with another's. SQLite has a single effective isolation level, so a requested
  * [TransactionIsolation] is ignored (as SqliteDialect declares).
  */
-class NodeSqliteDatabase internal constructor(
+public class NodeSqliteDatabase internal constructor(
     private val db: Database,
     override val config: KormiumConfig,
 ) : SuspendDatabase<Nothing> {
 
     override val writeListeners: WriteListeners = WriteListeners()
-    override val dialect = SqliteDialect
+    override val dialect: SqliteDialect = SqliteDialect
 
     private val lifecycle = DatabaseLifecycle { db.close() }
     private val connectionLock = Mutex()
@@ -57,7 +57,7 @@ class NodeSqliteDatabase internal constructor(
         }
     }
 
-    override fun close() = lifecycle.close()
+    override fun close(): Unit = lifecycle.close()
 }
 
 /**
@@ -65,7 +65,7 @@ class NodeSqliteDatabase internal constructor(
  *
  * @param path `":memory:"` (default) for an in-memory database, or a filesystem path to persist.
  */
-fun createNodeSqliteDatabase(
+public fun createNodeSqliteDatabase(
     path: String = ":memory:",
     config: KormiumConfig = KormiumConfig(),
 ): NodeSqliteDatabase = NodeSqliteDatabase(Database(path), config)

--- a/kormium-sqlite-wasm/api/kormium-sqlite-wasm.klib.api
+++ b/kormium-sqlite-wasm/api/kormium-sqlite-wasm.klib.api
@@ -1,0 +1,28 @@
+// Klib ABI Dump
+// Targets: [wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-sqlite-wasm>
+final class io.github.kormium.sqlite.wasm/IDBBatchAtomicVFS : kotlin.js/JsAny { // io.github.kormium.sqlite.wasm/IDBBatchAtomicVFS|null[0]
+    constructor <init>(kotlin/String) // io.github.kormium.sqlite.wasm/IDBBatchAtomicVFS.<init>|<init>(kotlin.String){}[0]
+}
+
+final class io.github.kormium.sqlite.wasm/SqliteWasmDatabase : io.github.kormium.database/SuspendDatabase<kotlin/Nothing> { // io.github.kormium.sqlite.wasm/SqliteWasmDatabase|null[0]
+    final val config // io.github.kormium.sqlite.wasm/SqliteWasmDatabase.config|{}config[0]
+        final fun <get-config>(): io.github.kormium/KormiumConfig // io.github.kormium.sqlite.wasm/SqliteWasmDatabase.config.<get-config>|<get-config>(){}[0]
+    final val dialect // io.github.kormium.sqlite.wasm/SqliteWasmDatabase.dialect|{}dialect[0]
+        final fun <get-dialect>(): io.github.kormium/SqliteDialect // io.github.kormium.sqlite.wasm/SqliteWasmDatabase.dialect.<get-dialect>|<get-dialect>(){}[0]
+    final val isClosed // io.github.kormium.sqlite.wasm/SqliteWasmDatabase.isClosed|{}isClosed[0]
+        final fun <get-isClosed>(): kotlin/Boolean // io.github.kormium.sqlite.wasm/SqliteWasmDatabase.isClosed.<get-isClosed>|<get-isClosed>(){}[0]
+    final val writeListeners // io.github.kormium.sqlite.wasm/SqliteWasmDatabase.writeListeners|{}writeListeners[0]
+        final fun <get-writeListeners>(): io.github.kormium/WriteListeners // io.github.kormium.sqlite.wasm/SqliteWasmDatabase.writeListeners.<get-writeListeners>|<get-writeListeners>(){}[0]
+
+    final fun close() // io.github.kormium.sqlite.wasm/SqliteWasmDatabase.close|close(){}[0]
+    final suspend fun <#A1: kotlin/Any?> useConnection(kotlin/Boolean, io.github.kormium/TransactionIsolation?, kotlin/Boolean, kotlin.coroutines/SuspendFunction1<io.github.kormium/SuspendSqlExecutor, #A1>): #A1 // io.github.kormium.sqlite.wasm/SqliteWasmDatabase.useConnection|useConnection(kotlin.Boolean;io.github.kormium.TransactionIsolation?;kotlin.Boolean;kotlin.coroutines.SuspendFunction1<io.github.kormium.SuspendSqlExecutor,0:0>){0§<kotlin.Any?>}[0]
+}
+
+final fun io.github.kormium.sqlite.wasm/SQLiteESMFactory(kotlin.js/JsAny? = ...): kotlin.js/Promise<kotlin.js/JsAny> // io.github.kormium.sqlite.wasm/SQLiteESMFactory|SQLiteESMFactory(kotlin.js.JsAny?){}[0]
+final suspend fun io.github.kormium.sqlite.wasm/createSqliteWasmDatabase(kotlin/String? = ..., io.github.kormium/KormiumConfig = ..., kotlin.js/JsAny? = ...): io.github.kormium.sqlite.wasm/SqliteWasmDatabase // io.github.kormium.sqlite.wasm/createSqliteWasmDatabase|createSqliteWasmDatabase(kotlin.String?;io.github.kormium.KormiumConfig;kotlin.js.JsAny?){}[0]

--- a/kormium-sqlite-wasm/build.gradle.kts
+++ b/kormium-sqlite-wasm/build.gradle.kts
@@ -7,6 +7,8 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
+
     // wa-sqlite is SQLite compiled to WASM, reached through JS interop, so this engine is
     // Kotlin/Wasm (JS) only. nodejs() runs the tests against an in-memory database (`:memory:`);
     // the browser uses the IndexedDB VFS for persistence (see the todo sample).

--- a/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/SqliteWasmDatabase.kt
+++ b/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/SqliteWasmDatabase.kt
@@ -23,14 +23,14 @@ import kotlinx.coroutines.withContext
  * single effective isolation level, so a requested [TransactionIsolation] is ignored (as the
  * SqliteDialect already declares).
  */
-class SqliteWasmDatabase internal constructor(
+public class SqliteWasmDatabase internal constructor(
     private val api: SQLiteAPI,
     private val db: JsNumber,
     override val config: KormiumConfig,
 ) : SuspendDatabase<Nothing> {
 
     override val writeListeners: WriteListeners = WriteListeners()
-    override val dialect = SqliteDialect
+    override val dialect: SqliteDialect = SqliteDialect
 
     private val lifecycle = DatabaseLifecycle { api.close(db) }
     private val connectionLock = Mutex()
@@ -61,7 +61,7 @@ class SqliteWasmDatabase internal constructor(
         }
     }
 
-    override fun close() = lifecycle.close()
+    override fun close(): Unit = lifecycle.close()
 }
 
 /**
@@ -71,7 +71,7 @@ class SqliteWasmDatabase internal constructor(
  *   database persisted to IndexedDB under that name (browser only) via wa-sqlite's
  *   `IDBBatchAtomicVFS`, so data survives a page reload.
  */
-suspend fun createSqliteWasmDatabase(
+public suspend fun createSqliteWasmDatabase(
     dataDir: String? = null,
     config: KormiumConfig = KormiumConfig(),
     // Advanced/Node: Emscripten module overrides passed to the wa-sqlite factory. In the browser the

--- a/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/WaSqliteFactory.kt
+++ b/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/WaSqliteFactory.kt
@@ -9,4 +9,4 @@ import kotlin.js.Promise
  * [Factory] to get the [SQLiteAPI].
  */
 @JsModule("wa-sqlite/dist/wa-sqlite-async.mjs")
-external fun SQLiteESMFactory(config: JsAny? = definedExternally): Promise<JsAny>
+public external fun SQLiteESMFactory(config: JsAny? = definedExternally): Promise<JsAny>

--- a/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/WaSqliteIdbVfs.kt
+++ b/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/WaSqliteIdbVfs.kt
@@ -8,4 +8,4 @@ package io.github.kormium.sqlite.wasm
  * uses). Construct it with the IndexedDB database name, then register it via
  * [SQLiteAPI.vfs_register] and pass its name to `open_v2` to persist a database to the browser.
  */
-external class IDBBatchAtomicVFS(idbDatabaseName: String) : JsAny
+public external class IDBBatchAtomicVFS(idbDatabaseName: String) : JsAny

--- a/kormium-sqlite/api/jvm/kormium-sqlite.api
+++ b/kormium-sqlite/api/jvm/kormium-sqlite.api
@@ -1,0 +1,40 @@
+public final class io/github/kormium/CreateSqliteDatabaseKt {
+	public static final fun createSqliteDatabase (Ljava/lang/String;ILkotlin/jvm/functions/Function1;)Lio/github/kormium/SqliteDriver;
+	public static synthetic fun createSqliteDatabase$default (Ljava/lang/String;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/github/kormium/SqliteDriver;
+}
+
+public final class io/github/kormium/CreateSqliteDatabase_jvmKt {
+	public static final fun createSqliteDatabase (Ljava/lang/String;ILio/github/kormium/KormiumConfig;)Lio/github/kormium/SqliteDriver;
+	public static synthetic fun createSqliteDatabase$default (Ljava/lang/String;ILio/github/kormium/KormiumConfig;ILjava/lang/Object;)Lio/github/kormium/SqliteDriver;
+}
+
+public abstract interface class io/github/kormium/SqliteDriver : io/github/kormium/database/Database, io/github/kormium/database/SuspendDatabase, java/lang/AutoCloseable {
+	public abstract fun getConfig ()Lio/github/kormium/KormiumConfig;
+	public abstract fun getDialect ()Lio/github/kormium/Dialect;
+	public abstract fun getWriteListeners ()Lio/github/kormium/WriteListeners;
+	public abstract fun isClosed ()Z
+}
+
+public final class io/github/kormium/SqliteExceptionsKt {
+	public static final fun sqliteException (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Throwable;)Lio/github/kormium/QueryException;
+	public static synthetic fun sqliteException$default (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Throwable;ILjava/lang/Object;)Lio/github/kormium/QueryException;
+}
+
+public final class io/github/kormium/SqliteResultSetWrapper : io/github/kormium/resultset/ResultSet {
+	public fun <init> (Ljava/sql/ResultSet;)V
+	public fun getBoolean (I)Ljava/lang/Boolean;
+	public fun getBytes (I)[B
+	public fun getColumns ()[Ljava/lang/String;
+	public fun getDate (I)Lkotlinx/datetime/LocalDate;
+	public fun getDouble (I)Ljava/lang/Double;
+	public fun getFloat (I)Ljava/lang/Float;
+	public fun getInstant (I)Lkotlin/time/Instant;
+	public fun getInt (I)Ljava/lang/Integer;
+	public fun getLocalDateTime (I)Lkotlinx/datetime/LocalDateTime;
+	public fun getLong (I)Ljava/lang/Long;
+	public fun getShort (I)Ljava/lang/Short;
+	public fun getString (I)Ljava/lang/String;
+	public fun getTime (I)Lkotlinx/datetime/LocalTime;
+	public fun next ()Z
+}
+

--- a/kormium-sqlite/api/kormium-sqlite.klib.api
+++ b/kormium-sqlite/api/kormium-sqlite.klib.api
@@ -1,0 +1,22 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, linuxX64, macosArm64, macosX64, mingwX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-sqlite>
+abstract interface io.github.kormium/SqliteDriver : io.github.kormium.database/Database<kotlin/Nothing>, io.github.kormium.database/SuspendDatabase<kotlin/Nothing>, kotlin/AutoCloseable { // io.github.kormium/SqliteDriver|null[0]
+    abstract val config // io.github.kormium/SqliteDriver.config|{}config[0]
+        abstract fun <get-config>(): io.github.kormium/KormiumConfig // io.github.kormium/SqliteDriver.config.<get-config>|<get-config>(){}[0]
+    abstract val dialect // io.github.kormium/SqliteDriver.dialect|{}dialect[0]
+        abstract fun <get-dialect>(): io.github.kormium/Dialect // io.github.kormium/SqliteDriver.dialect.<get-dialect>|<get-dialect>(){}[0]
+    abstract val isClosed // io.github.kormium/SqliteDriver.isClosed|{}isClosed[0]
+        abstract fun <get-isClosed>(): kotlin/Boolean // io.github.kormium/SqliteDriver.isClosed.<get-isClosed>|<get-isClosed>(){}[0]
+    abstract val writeListeners // io.github.kormium/SqliteDriver.writeListeners|{}writeListeners[0]
+        abstract fun <get-writeListeners>(): io.github.kormium/WriteListeners // io.github.kormium/SqliteDriver.writeListeners.<get-writeListeners>|<get-writeListeners>(){}[0]
+}
+
+final fun io.github.kormium/createSqliteDatabase(kotlin/String = ..., kotlin/Int = ..., io.github.kormium/KormiumConfig = ...): io.github.kormium/SqliteDriver // io.github.kormium/createSqliteDatabase|createSqliteDatabase(kotlin.String;kotlin.Int;io.github.kormium.KormiumConfig){}[0]
+final fun io.github.kormium/createSqliteDatabase(kotlin/String = ..., kotlin/Int = ..., kotlin/Function1<io.github.kormium/KormiumBuilder, kotlin/Unit>): io.github.kormium/SqliteDriver // io.github.kormium/createSqliteDatabase|createSqliteDatabase(kotlin.String;kotlin.Int;kotlin.Function1<io.github.kormium.KormiumBuilder,kotlin.Unit>){}[0]
+final fun io.github.kormium/sqliteException(kotlin/String, kotlin/Int? = ..., kotlin/Throwable? = ...): io.github.kormium/QueryException // io.github.kormium/sqliteException|sqliteException(kotlin.String;kotlin.Int?;kotlin.Throwable?){}[0]

--- a/kormium-sqlite/build.gradle.kts
+++ b/kormium-sqlite/build.gradle.kts
@@ -9,6 +9,8 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
+
     jvmToolchain(21)
 
     jvm {

--- a/kormium-sqlite/src/androidMain/kotlin/CreateSqliteDatabase.android.kt
+++ b/kormium-sqlite/src/androidMain/kotlin/CreateSqliteDatabase.android.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.runBlocking
 
-actual fun createSqliteDatabase(path: String, poolSize: Int, config: KormiumConfig): SqliteDriver =
+public actual fun createSqliteDatabase(path: String, poolSize: Int, config: KormiumConfig): SqliteDriver =
     SqliteAndroidDriver(path, poolSize, config)
 
 // Android can't use the Kotlin/Native sqlite3 cinterop (it runs on the JVM/ART), so it

--- a/kormium-sqlite/src/commonMain/kotlin/CreateSqliteDatabase.kt
+++ b/kormium-sqlite/src/commonMain/kotlin/CreateSqliteDatabase.kt
@@ -14,7 +14,7 @@ package io.github.kormium
  *   default is 1 (everything serialised, no `database is locked`); raise it for
  *   concurrent reads (WAL permits many readers alongside one writer).
  */
-expect fun createSqliteDatabase(
+public expect fun createSqliteDatabase(
     path: String = ":memory:",
     poolSize: Int = 1,
     config: KormiumConfig = KormiumConfig(),
@@ -24,7 +24,7 @@ expect fun createSqliteDatabase(
  * Opens a SQLite database with a configuration block: `createSqliteDatabase("app.db") {`
  * `config { … }; beforeStart { migrate(appMigrations) } }`. See [KormiumBuilder].
  */
-fun createSqliteDatabase(
+public fun createSqliteDatabase(
     path: String = ":memory:",
     poolSize: Int = 1,
     block: KormiumBuilder.() -> Unit,

--- a/kormium-sqlite/src/commonMain/kotlin/SqliteDriver.kt
+++ b/kormium-sqlite/src/commonMain/kotlin/SqliteDriver.kt
@@ -10,7 +10,7 @@ import io.github.kormium.WriteListeners
  * released (or used via a `use { }` block). Blocking query methods come from [Database];
  * the suspend path (suspendTransaction/suspendAutocommit) comes from [SuspendDatabase].
  */
-interface SqliteDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoCloseable {
+public interface SqliteDriver : Database<Nothing>, SuspendDatabase<Nothing>, AutoCloseable {
     // Resolves the config default inherited from both Database and SuspendDatabase; concrete
     // drivers supply it (from the createSqliteDatabase config argument).
     override val config: KormiumConfig

--- a/kormium-sqlite/src/commonMain/kotlin/SqliteExceptions.kt
+++ b/kormium-sqlite/src/commonMain/kotlin/SqliteExceptions.kt
@@ -14,7 +14,7 @@ private const val SQLITE_CONSTRAINT_UNIQUE = 2067
  * message text (stable across the JDBC and native drivers, e.g. "UNIQUE constraint
  * failed"). The extended code (when known) is carried in [QueryException.sqlState].
  */
-fun sqliteException(message: String, extendedCode: Int? = null, cause: Throwable? = null): QueryException {
+public fun sqliteException(message: String, extendedCode: Int? = null, cause: Throwable? = null): QueryException {
     val state = extendedCode?.toString()
     return when {
         extendedCode == SQLITE_CONSTRAINT_UNIQUE || extendedCode == SQLITE_CONSTRAINT_PRIMARYKEY ||

--- a/kormium-sqlite/src/jvmMain/kotlin/CreateSqliteDatabase.jvm.kt
+++ b/kormium-sqlite/src/jvmMain/kotlin/CreateSqliteDatabase.jvm.kt
@@ -30,5 +30,5 @@ private class SqliteJdbcDriver(path: String, poolSize: Int, config: KormiumConfi
     config = config,
 ), SqliteDriver
 
-actual fun createSqliteDatabase(path: String, poolSize: Int, config: KormiumConfig): SqliteDriver =
+public actual fun createSqliteDatabase(path: String, poolSize: Int, config: KormiumConfig): SqliteDriver =
     SqliteJdbcDriver(path, poolSize, config)

--- a/kormium-sqlite/src/jvmMain/kotlin/SqliteResultSetWrapper.kt
+++ b/kormium-sqlite/src/jvmMain/kotlin/SqliteResultSetWrapper.kt
@@ -14,7 +14,7 @@ import java.sql.ResultSetMetaData
  * (`Instant.toString()` etc., already ISO-8601 with a 'T'), so dates/times are parsed
  * as-is — no space→'T' fix-up.
  */
-class SqliteResultSetWrapper(private val rs: java.sql.ResultSet) : ResultSet {
+public class SqliteResultSetWrapper(private val rs: java.sql.ResultSet) : ResultSet {
     // Lazy: the hot read path maps columns positionally and never touches this.
     override val columns: Array<String> by lazy { internalGetColumns() }
 

--- a/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
+++ b/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
@@ -30,7 +30,7 @@ import csqlite.*
 private val SQLITE_TRANSIENT: CPointer<CFunction<(COpaquePointer?) -> Unit>>? = (-1L).toCPointer()
 
 @OptIn(ExperimentalForeignApi::class)
-actual fun createSqliteDatabase(path: String, poolSize: Int, config: KormiumConfig): SqliteDriver =
+public actual fun createSqliteDatabase(path: String, poolSize: Int, config: KormiumConfig): SqliteDriver =
     SqliteNativeDriver(path, poolSize, config)
 
 @OptIn(ExperimentalForeignApi::class)

--- a/kormium-wasm-driver/api/kormium-wasm-driver.klib.api
+++ b/kormium-wasm-driver/api/kormium-wasm-driver.klib.api
@@ -1,0 +1,48 @@
+// Klib ABI Dump
+// Targets: [wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.kormium:kormium-wasm-driver>
+final class io.github.kormium.wasm.driver/ParsedSql { // io.github.kormium.wasm.driver/ParsedSql|null[0]
+    constructor <init>(kotlin/String, kotlin.collections/List<kotlin/String>) // io.github.kormium.wasm.driver/ParsedSql.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.String>){}[0]
+
+    final val names // io.github.kormium.wasm.driver/ParsedSql.names|{}names[0]
+        final fun <get-names>(): kotlin.collections/List<kotlin/String> // io.github.kormium.wasm.driver/ParsedSql.names.<get-names>|<get-names>(){}[0]
+    final val sql // io.github.kormium.wasm.driver/ParsedSql.sql|{}sql[0]
+        final fun <get-sql>(): kotlin/String // io.github.kormium.wasm.driver/ParsedSql.sql.<get-sql>|<get-sql>(){}[0]
+}
+
+final class io.github.kormium.wasm.driver/TextResultSet : io.github.kormium.resultset/ResultSet { // io.github.kormium.wasm.driver/TextResultSet|null[0]
+    constructor <init>(kotlin.js/JsArray<kotlin.js/JsAny?>, kotlin/Array<kotlin/String>) // io.github.kormium.wasm.driver/TextResultSet.<init>|<init>(kotlin.js.JsArray<kotlin.js.JsAny?>;kotlin.Array<kotlin.String>){}[0]
+
+    final val columns // io.github.kormium.wasm.driver/TextResultSet.columns|{}columns[0]
+        final fun <get-columns>(): kotlin/Array<kotlin/String> // io.github.kormium.wasm.driver/TextResultSet.columns.<get-columns>|<get-columns>(){}[0]
+
+    final fun getBoolean(kotlin/Int): kotlin/Boolean? // io.github.kormium.wasm.driver/TextResultSet.getBoolean|getBoolean(kotlin.Int){}[0]
+    final fun getBytes(kotlin/Int): kotlin/ByteArray? // io.github.kormium.wasm.driver/TextResultSet.getBytes|getBytes(kotlin.Int){}[0]
+    final fun getDate(kotlin/Int): kotlinx.datetime/LocalDate? // io.github.kormium.wasm.driver/TextResultSet.getDate|getDate(kotlin.Int){}[0]
+    final fun getDouble(kotlin/Int): kotlin/Double? // io.github.kormium.wasm.driver/TextResultSet.getDouble|getDouble(kotlin.Int){}[0]
+    final fun getFloat(kotlin/Int): kotlin/Float? // io.github.kormium.wasm.driver/TextResultSet.getFloat|getFloat(kotlin.Int){}[0]
+    final fun getInstant(kotlin/Int): kotlin.time/Instant? // io.github.kormium.wasm.driver/TextResultSet.getInstant|getInstant(kotlin.Int){}[0]
+    final fun getInt(kotlin/Int): kotlin/Int? // io.github.kormium.wasm.driver/TextResultSet.getInt|getInt(kotlin.Int){}[0]
+    final fun getLocalDateTime(kotlin/Int): kotlinx.datetime/LocalDateTime? // io.github.kormium.wasm.driver/TextResultSet.getLocalDateTime|getLocalDateTime(kotlin.Int){}[0]
+    final fun getLong(kotlin/Int): kotlin/Long? // io.github.kormium.wasm.driver/TextResultSet.getLong|getLong(kotlin.Int){}[0]
+    final fun getShort(kotlin/Int): kotlin/Short? // io.github.kormium.wasm.driver/TextResultSet.getShort|getShort(kotlin.Int){}[0]
+    final fun getString(kotlin/Int): kotlin/String? // io.github.kormium.wasm.driver/TextResultSet.getString|getString(kotlin.Int){}[0]
+    final fun getTime(kotlin/Int): kotlinx.datetime/LocalTime? // io.github.kormium.wasm.driver/TextResultSet.getTime|getTime(kotlin.Int){}[0]
+    final fun next(): kotlin/Boolean // io.github.kormium.wasm.driver/TextResultSet.next|next(){}[0]
+}
+
+final val io.github.kormium.wasm.driver/DollarMarker // io.github.kormium.wasm.driver/DollarMarker|{}DollarMarker[0]
+    final fun <get-DollarMarker>(): kotlin/Function1<kotlin/Int, kotlin/String> // io.github.kormium.wasm.driver/DollarMarker.<get-DollarMarker>|<get-DollarMarker>(){}[0]
+final val io.github.kormium.wasm.driver/QuestionMarker // io.github.kormium.wasm.driver/QuestionMarker|{}QuestionMarker[0]
+    final fun <get-QuestionMarker>(): kotlin/Function1<kotlin/Int, kotlin/String> // io.github.kormium.wasm.driver/QuestionMarker.<get-QuestionMarker>|<get-QuestionMarker>(){}[0]
+
+final fun io.github.kormium.wasm.driver/bindTextParams(kotlin.collections/List<kotlin/String>, kotlin.collections/Map<kotlin/String, kotlin/Any?>, io.github.kormium/TypeMapper): kotlin.js/JsArray<kotlin.js/JsAny?> // io.github.kormium.wasm.driver/bindTextParams|bindTextParams(kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.String,kotlin.Any?>;io.github.kormium.TypeMapper){}[0]
+final fun io.github.kormium.wasm.driver/byteArrayToBinary(kotlin/ByteArray): kotlin.js/JsAny // io.github.kormium.wasm.driver/byteArrayToBinary|byteArrayToBinary(kotlin.ByteArray){}[0]
+final fun io.github.kormium.wasm.driver/cellText(kotlin.js/JsAny?): kotlin/String? // io.github.kormium.wasm.driver/cellText|cellText(kotlin.js.JsAny?){}[0]
+final fun io.github.kormium.wasm.driver/jsToByteArray(kotlin.js/JsAny?): kotlin/ByteArray? // io.github.kormium.wasm.driver/jsToByteArray|jsToByteArray(kotlin.js.JsAny?){}[0]
+final fun io.github.kormium.wasm.driver/parseNamedParams(kotlin/String, kotlin/Function1<kotlin/Int, kotlin/String>): io.github.kormium.wasm.driver/ParsedSql // io.github.kormium.wasm.driver/parseNamedParams|parseNamedParams(kotlin.String;kotlin.Function1<kotlin.Int,kotlin.String>){}[0]

--- a/kormium-wasm-driver/build.gradle.kts
+++ b/kormium-wasm-driver/build.gradle.kts
@@ -11,6 +11,8 @@ repositories {
 // param-binding helper. Driver-specific externals stay in each engine; this is the common layer
 // so that one fix lands everywhere instead of in four copies.
 kotlin {
+    explicitApi()
+
     compilerOptions {
         optIn.add("kotlin.js.ExperimentalWasmJsInterop")
     }


### PR DESCRIPTION
Closes #10.

Two commits:
1. **BCV baseline** — binary-compatibility-validator 0.18.1 at the root, klib validation enabled, benchmarks/samples/BOM ignored; the current ABI of all 20 published modules dumped into `<module>/api/` (JVM + klib).
2. **explicitApi() everywhere** — strict mode in every published module; ~530 declarations got explicit `public`, inferred public return types spelled out. One genuine catch: `SqlParameterSource.getSqlType` was returning `UInt` by inference — kept as `UInt` (libpq OIDs are unsigned), now explicit.

**Zero ABI drift is proven**: `apiCheck` passes against the baseline dumps byte-identically, so this PR changes no behavior and no surface — it only locks the door. CI now fails fast on any API change without a reviewed `./gradlew apiDump`; the workflow is documented in AGENTS.md.

Deliberate narrowing of accidentally-public internals (drivers' wrappers, render helpers) is the follow-up — it will land as reviewable `.api` diffs against these dumps.

Verified locally: all 20 modules compile on JVM + macosArm64 + wasmJs where applicable; core/decimal/sqlite/migrate JVM tests, sqlite native tests, ktor assemble; apiCheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)