### PR TITLE
Narrow accidentally-public driver internals (stacked on #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Kormium are documented here. The format is based on
 
 ## [Unreleased]
 
+### Changed (breaking, pre-1.0)
+- **Accidentally-public driver internals are now `internal`.** None of these appeared in
+  any documentation or were usable without reaching into implementation packages:
+  the native PostgreSQL plumbing inherited from pgkn (`AbstractSqlParameterSource`,
+  `MapSqlParameterSource`, `Oid`, `AnonymousClassException`, `GetColumnValueException`,
+  `InvalidDataAccessApiUsageException`), the per-backend JDBC `ResultSet` wrappers
+  (`PgResultSetWrapper`, `MySqlResultSetWrapper`, `SqliteResultSetWrapper`),
+  `JdbcExecutor`, `MySqlNativeTypeMapper` and the `sqliteException` helper. The exact
+  removals are the `.api` dump diffs in this change (−186 ABI lines). Everything the
+  docs, samples or sibling modules use is untouched.
+
 ### Added
 - **API surface is now locked.** Every published module compiles in Kotlin's
   `explicitApi()` strict mode (all public declarations carry explicit visibility and

--- a/kormium-jdbc/api/kormium-jdbc.api
+++ b/kormium-jdbc/api/kormium-jdbc.api
@@ -14,18 +14,6 @@ public final class io/github/kormium/jdbc/JdbcDatabaseKt {
 	public static final fun getStandardSqlExceptionTranslator ()Lkotlin/jvm/functions/Function1;
 }
 
-public final class io/github/kormium/jdbc/JdbcExecutor : io/github/kormium/SqlExecutor {
-	public fun <init> (Ljava/sql/Connection;Lio/github/kormium/Dialect;Lio/github/kormium/TypeMapper;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/sql/Connection;Lio/github/kormium/Dialect;Lio/github/kormium/TypeMapper;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun execute (Ljava/lang/String;Lio/github/kormium/SqlParameterSource;)J
-	public fun execute (Ljava/lang/String;Lio/github/kormium/SqlParameterSource;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
-	public fun execute (Ljava/lang/String;Ljava/util/Map;)J
-	public fun execute (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
-	public fun executeUpdate (Ljava/lang/String;Ljava/util/Map;)J
-	public fun getDialect ()Lio/github/kormium/Dialect;
-	public fun getTypeMapper ()Lio/github/kormium/TypeMapper;
-}
-
 public final class io/github/kormium/jdbc/NamedParamStatement : java/lang/AutoCloseable {
 	public static final field Companion Lio/github/kormium/jdbc/NamedParamStatement$Companion;
 	public fun <init> (Ljava/sql/Connection;Ljava/lang/String;)V

--- a/kormium-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/JdbcDatabase.kt
+++ b/kormium-jdbc/src/jvmMain/kotlin/io/github/kormium/jdbc/JdbcDatabase.kt
@@ -178,7 +178,7 @@ private val TransactionIsolation.jdbcLevel: Int
     }
 
 /** An [SqlExecutor] bound to one already-open JDBC connection. */
-public class JdbcExecutor(
+internal class JdbcExecutor(
     private val conn: Connection,
     override val dialect: Dialect,
     override val typeMapper: TypeMapper,

--- a/kormium-mysql/api/kormium-mysql.api
+++ b/kormium-mysql/api/kormium-mysql.api
@@ -19,24 +19,6 @@ public final class io/github/kormium/MySqlJvmTypeMapper : io/github/kormium/Type
 	public fun toParameter (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class io/github/kormium/MySqlResultSetWrapper : io/github/kormium/resultset/ResultSet {
-	public fun <init> (Ljava/sql/ResultSet;)V
-	public fun getBoolean (I)Ljava/lang/Boolean;
-	public fun getBytes (I)[B
-	public fun getColumns ()[Ljava/lang/String;
-	public fun getDate (I)Lkotlinx/datetime/LocalDate;
-	public fun getDouble (I)Ljava/lang/Double;
-	public fun getFloat (I)Ljava/lang/Float;
-	public fun getInstant (I)Lkotlin/time/Instant;
-	public fun getInt (I)Ljava/lang/Integer;
-	public fun getLocalDateTime (I)Lkotlinx/datetime/LocalDateTime;
-	public fun getLong (I)Ljava/lang/Long;
-	public fun getShort (I)Ljava/lang/Short;
-	public fun getString (I)Ljava/lang/String;
-	public fun getTime (I)Lkotlinx/datetime/LocalTime;
-	public fun next ()Z
-}
-
 public final class io/github/kormium/database/CreateDatabaseKt {
 	public static final fun createDatabase (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/functions/Function1;)Lio/github/kormium/MySqlDriver;
 	public static synthetic fun createDatabase$default (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/github/kormium/MySqlDriver;

--- a/kormium-mysql/api/kormium-mysql.klib.api
+++ b/kormium-mysql/api/kormium-mysql.klib.api
@@ -25,10 +25,6 @@ final class io.github.kormium.mysql.exception/QueryExecutionException : io.githu
     constructor <init>(kotlin/String, kotlin/Throwable? = ...) // io.github.kormium.mysql.exception/QueryExecutionException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
 }
 
-final object io.github.kormium.mysql/MySqlNativeTypeMapper : io.github.kormium/TypeMapper { // io.github.kormium.mysql/MySqlNativeTypeMapper|null[0]
-    final fun toParameter(kotlin/Any?): kotlin/Any? // io.github.kormium.mysql/MySqlNativeTypeMapper.toParameter|toParameter(kotlin.Any?){}[0]
-}
-
 final fun io.github.kormium.database/createDatabase(kotlin/String, kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, kotlin/Int = ..., io.github.kormium/KormiumConfig = ...): io.github.kormium/MySqlDriver // io.github.kormium.database/createDatabase|createDatabase(kotlin.String;kotlin.Int;kotlin.String;kotlin.String;kotlin.String;kotlin.Int;io.github.kormium.KormiumConfig){}[0]
 final fun io.github.kormium.database/createDatabase(kotlin/String, kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, kotlin/Int = ..., kotlin/Function1<io.github.kormium/KormiumBuilder, kotlin/Unit>): io.github.kormium/MySqlDriver // io.github.kormium.database/createDatabase|createDatabase(kotlin.String;kotlin.Int;kotlin.String;kotlin.String;kotlin.String;kotlin.Int;kotlin.Function1<io.github.kormium.KormiumBuilder,kotlin.Unit>){}[0]
 final fun io.github.kormium.mysql.exception/mysqlException(kotlin/String, kotlin/UInt, kotlin/String? = ...): io.github.kormium/QueryException // io.github.kormium.mysql.exception/mysqlException|mysqlException(kotlin.String;kotlin.UInt;kotlin.String?){}[0]

--- a/kormium-mysql/src/jvmMain/kotlin/MySqlResultSetWrapper.kt
+++ b/kormium-mysql/src/jvmMain/kotlin/MySqlResultSetWrapper.kt
@@ -21,7 +21,7 @@ import java.time.OffsetDateTime
  * correct [Instant]. UUID (`CHAR(36)`) and `JSON` columns are plain text via [getString], which
  * lines up with korm's text-based column reading.
  */
-public class MySqlResultSetWrapper(private val rs: java.sql.ResultSet) : ResultSet {
+internal class MySqlResultSetWrapper(private val rs: java.sql.ResultSet) : ResultSet {
     // Lazy: the hot read path maps columns positionally and never touches this.
     override val columns: Array<String> by lazy { internalGetColumns() }
 

--- a/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/MySqlNativeTypeMapper.kt
+++ b/kormium-mysql/src/nativeMain/kotlin/io/github/kormium/mysql/MySqlNativeTypeMapper.kt
@@ -19,7 +19,7 @@ import kotlinx.datetime.toLocalDateTime
  * Everything else (UUID, JsonElement, Decimal, primitives, LocalDate/LocalTime) is handled by
  * [StandardTypeMapper] — their `toString()` is already a valid MySQL literal.
  */
-public object MySqlNativeTypeMapper : TypeMapper {
+internal object MySqlNativeTypeMapper : TypeMapper {
     override fun toParameter(value: Any?): Any? = when (value) {
         is Instant -> value.toLocalDateTime(TimeZone.UTC).toMysqlText()
         is LocalDateTime -> value.toMysqlText()

--- a/kormium-postgres/api/kormium-postgres.api
+++ b/kormium-postgres/api/kormium-postgres.api
@@ -3,24 +3,6 @@ public final class io/github/kormium/PgNotificationTransportKt {
 	public static synthetic fun postgresListenNotifyTransport$default (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kormium/NotificationTransport;
 }
 
-public final class io/github/kormium/PgResultSetWrapper : io/github/kormium/resultset/ResultSet {
-	public fun <init> (Ljava/sql/ResultSet;)V
-	public fun getBoolean (I)Ljava/lang/Boolean;
-	public fun getBytes (I)[B
-	public fun getColumns ()[Ljava/lang/String;
-	public fun getDate (I)Lkotlinx/datetime/LocalDate;
-	public fun getDouble (I)Ljava/lang/Double;
-	public fun getFloat (I)Ljava/lang/Float;
-	public fun getInstant (I)Lkotlin/time/Instant;
-	public fun getInt (I)Ljava/lang/Integer;
-	public fun getLocalDateTime (I)Lkotlinx/datetime/LocalDateTime;
-	public fun getLong (I)Ljava/lang/Long;
-	public fun getShort (I)Ljava/lang/Short;
-	public fun getString (I)Ljava/lang/String;
-	public fun getTime (I)Lkotlinx/datetime/LocalTime;
-	public fun next ()Z
-}
-
 public abstract interface class io/github/kormium/PostgresDriver : io/github/kormium/database/Database, io/github/kormium/database/SuspendDatabase, java/lang/AutoCloseable {
 	public abstract fun getConfig ()Lio/github/kormium/KormiumConfig;
 	public abstract fun getDialect ()Lio/github/kormium/Dialect;

--- a/kormium-postgres/api/kormium-postgres.klib.api
+++ b/kormium-postgres/api/kormium-postgres.klib.api
@@ -6,78 +6,6 @@
 // - Show declarations: true
 
 // Library unique name: <io.github.kormium:kormium-postgres>
-final enum class io.github.kormium.postgres/Oid : kotlin/Enum<io.github.kormium.postgres/Oid> { // io.github.kormium.postgres/Oid|null[0]
-    enum entry BIT // io.github.kormium.postgres/Oid.BIT|null[0]
-    enum entry BIT_ARRAY // io.github.kormium.postgres/Oid.BIT_ARRAY|null[0]
-    enum entry BOOL // io.github.kormium.postgres/Oid.BOOL|null[0]
-    enum entry BOOL_ARRAY // io.github.kormium.postgres/Oid.BOOL_ARRAY|null[0]
-    enum entry BOX // io.github.kormium.postgres/Oid.BOX|null[0]
-    enum entry BPCHAR // io.github.kormium.postgres/Oid.BPCHAR|null[0]
-    enum entry BPCHAR_ARRAY // io.github.kormium.postgres/Oid.BPCHAR_ARRAY|null[0]
-    enum entry BYTEA // io.github.kormium.postgres/Oid.BYTEA|null[0]
-    enum entry BYTEA_ARRAY // io.github.kormium.postgres/Oid.BYTEA_ARRAY|null[0]
-    enum entry CHAR // io.github.kormium.postgres/Oid.CHAR|null[0]
-    enum entry CHAR_ARRAY // io.github.kormium.postgres/Oid.CHAR_ARRAY|null[0]
-    enum entry DATE // io.github.kormium.postgres/Oid.DATE|null[0]
-    enum entry DATE_ARRAY // io.github.kormium.postgres/Oid.DATE_ARRAY|null[0]
-    enum entry FLOAT4 // io.github.kormium.postgres/Oid.FLOAT4|null[0]
-    enum entry FLOAT4_ARRAY // io.github.kormium.postgres/Oid.FLOAT4_ARRAY|null[0]
-    enum entry FLOAT8 // io.github.kormium.postgres/Oid.FLOAT8|null[0]
-    enum entry FLOAT8_ARRAY // io.github.kormium.postgres/Oid.FLOAT8_ARRAY|null[0]
-    enum entry INT2 // io.github.kormium.postgres/Oid.INT2|null[0]
-    enum entry INT2_ARRAY // io.github.kormium.postgres/Oid.INT2_ARRAY|null[0]
-    enum entry INT4 // io.github.kormium.postgres/Oid.INT4|null[0]
-    enum entry INT4_ARRAY // io.github.kormium.postgres/Oid.INT4_ARRAY|null[0]
-    enum entry INT8 // io.github.kormium.postgres/Oid.INT8|null[0]
-    enum entry INT8_ARRAY // io.github.kormium.postgres/Oid.INT8_ARRAY|null[0]
-    enum entry INTERVAL // io.github.kormium.postgres/Oid.INTERVAL|null[0]
-    enum entry INTERVAL_ARRAY // io.github.kormium.postgres/Oid.INTERVAL_ARRAY|null[0]
-    enum entry JSON // io.github.kormium.postgres/Oid.JSON|null[0]
-    enum entry JSONB // io.github.kormium.postgres/Oid.JSONB|null[0]
-    enum entry JSONB_ARRAY // io.github.kormium.postgres/Oid.JSONB_ARRAY|null[0]
-    enum entry JSON_ARRAY // io.github.kormium.postgres/Oid.JSON_ARRAY|null[0]
-    enum entry MONEY // io.github.kormium.postgres/Oid.MONEY|null[0]
-    enum entry MONEY_ARRAY // io.github.kormium.postgres/Oid.MONEY_ARRAY|null[0]
-    enum entry NAME // io.github.kormium.postgres/Oid.NAME|null[0]
-    enum entry NAME_ARRAY // io.github.kormium.postgres/Oid.NAME_ARRAY|null[0]
-    enum entry NUMERIC // io.github.kormium.postgres/Oid.NUMERIC|null[0]
-    enum entry NUMERIC_ARRAY // io.github.kormium.postgres/Oid.NUMERIC_ARRAY|null[0]
-    enum entry OID // io.github.kormium.postgres/Oid.OID|null[0]
-    enum entry OID_ARRAY // io.github.kormium.postgres/Oid.OID_ARRAY|null[0]
-    enum entry POINT // io.github.kormium.postgres/Oid.POINT|null[0]
-    enum entry POINT_ARRAY // io.github.kormium.postgres/Oid.POINT_ARRAY|null[0]
-    enum entry REF_CURSOR // io.github.kormium.postgres/Oid.REF_CURSOR|null[0]
-    enum entry REF_CURSOR_ARRAY // io.github.kormium.postgres/Oid.REF_CURSOR_ARRAY|null[0]
-    enum entry TEXT // io.github.kormium.postgres/Oid.TEXT|null[0]
-    enum entry TEXT_ARRAY // io.github.kormium.postgres/Oid.TEXT_ARRAY|null[0]
-    enum entry TIME // io.github.kormium.postgres/Oid.TIME|null[0]
-    enum entry TIMESTAMP // io.github.kormium.postgres/Oid.TIMESTAMP|null[0]
-    enum entry TIMESTAMPTZ // io.github.kormium.postgres/Oid.TIMESTAMPTZ|null[0]
-    enum entry TIMESTAMPTZ_ARRAY // io.github.kormium.postgres/Oid.TIMESTAMPTZ_ARRAY|null[0]
-    enum entry TIMESTAMP_ARRAY // io.github.kormium.postgres/Oid.TIMESTAMP_ARRAY|null[0]
-    enum entry TIMETZ // io.github.kormium.postgres/Oid.TIMETZ|null[0]
-    enum entry TIMETZ_ARRAY // io.github.kormium.postgres/Oid.TIMETZ_ARRAY|null[0]
-    enum entry TIME_ARRAY // io.github.kormium.postgres/Oid.TIME_ARRAY|null[0]
-    enum entry UNSPECIFIED // io.github.kormium.postgres/Oid.UNSPECIFIED|null[0]
-    enum entry UUID // io.github.kormium.postgres/Oid.UUID|null[0]
-    enum entry UUID_ARRAY // io.github.kormium.postgres/Oid.UUID_ARRAY|null[0]
-    enum entry VARBIT // io.github.kormium.postgres/Oid.VARBIT|null[0]
-    enum entry VARBIT_ARRAY // io.github.kormium.postgres/Oid.VARBIT_ARRAY|null[0]
-    enum entry VARCHAR // io.github.kormium.postgres/Oid.VARCHAR|null[0]
-    enum entry VARCHAR_ARRAY // io.github.kormium.postgres/Oid.VARCHAR_ARRAY|null[0]
-    enum entry VOID // io.github.kormium.postgres/Oid.VOID|null[0]
-    enum entry XML // io.github.kormium.postgres/Oid.XML|null[0]
-    enum entry XML_ARRAY // io.github.kormium.postgres/Oid.XML_ARRAY|null[0]
-
-    final val entries // io.github.kormium.postgres/Oid.entries|#static{}entries[0]
-        final fun <get-entries>(): kotlin.enums/EnumEntries<io.github.kormium.postgres/Oid> // io.github.kormium.postgres/Oid.entries.<get-entries>|<get-entries>#static(){}[0]
-    final val value // io.github.kormium.postgres/Oid.value|{}value[0]
-        final fun <get-value>(): kotlin/Int // io.github.kormium.postgres/Oid.value.<get-value>|<get-value>(){}[0]
-
-    final fun valueOf(kotlin/String): io.github.kormium.postgres/Oid // io.github.kormium.postgres/Oid.valueOf|valueOf#static(kotlin.String){}[0]
-    final fun values(): kotlin/Array<io.github.kormium.postgres/Oid> // io.github.kormium.postgres/Oid.values|values#static(){}[0]
-}
-
 abstract interface io.github.kormium/PostgresDriver : io.github.kormium.database/Database<kotlin/Nothing>, io.github.kormium.database/SuspendDatabase<kotlin/Nothing>, kotlin/AutoCloseable { // io.github.kormium/PostgresDriver|null[0]
     abstract val config // io.github.kormium/PostgresDriver.config|{}config[0]
         abstract fun <get-config>(): io.github.kormium/KormiumConfig // io.github.kormium/PostgresDriver.config.<get-config>|<get-config>(){}[0]
@@ -89,50 +17,12 @@ abstract interface io.github.kormium/PostgresDriver : io.github.kormium.database
         abstract fun <get-writeListeners>(): io.github.kormium/WriteListeners // io.github.kormium/PostgresDriver.writeListeners.<get-writeListeners>|<get-writeListeners>(){}[0]
 }
 
-abstract class io.github.kormium.postgres.paramsource/AbstractSqlParameterSource : io.github.kormium/SqlParameterSource { // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource|null[0]
-    constructor <init>() // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.<init>|<init>(){}[0]
-
-    final fun getTypeName(kotlin/String): kotlin/String? // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.getTypeName|getTypeName(kotlin.String){}[0]
-    final fun registerSqlType(kotlin/String, kotlin/Any?) // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.registerSqlType|registerSqlType(kotlin.String;kotlin.Any?){}[0]
-    final fun registerSqlType(kotlin/String, kotlin/UInt) // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.registerSqlType|registerSqlType(kotlin.String;kotlin.UInt){}[0]
-    final fun registerTypeName(kotlin/String, kotlin/String) // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.registerTypeName|registerTypeName(kotlin.String;kotlin.String){}[0]
-    open fun getSqlType(kotlin/String): kotlin/UInt // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.getSqlType|getSqlType(kotlin.String){}[0]
-    open fun toString(): kotlin/String // io.github.kormium.postgres.paramsource/AbstractSqlParameterSource.toString|toString(){}[0]
-}
-
-final class io.github.kormium.postgres.exception/AnonymousClassException : io.github.kormium.postgres.exception/SQLException { // io.github.kormium.postgres.exception/AnonymousClassException|null[0]
-    constructor <init>() // io.github.kormium.postgres.exception/AnonymousClassException.<init>|<init>(){}[0]
-}
-
 final class io.github.kormium.postgres.exception/ConnectionClosedException : io.github.kormium.postgres.exception/SQLException { // io.github.kormium.postgres.exception/ConnectionClosedException|null[0]
     constructor <init>() // io.github.kormium.postgres.exception/ConnectionClosedException.<init>|<init>(){}[0]
 }
 
-final class io.github.kormium.postgres.exception/GetColumnValueException : io.github.kormium.postgres.exception/SQLException { // io.github.kormium.postgres.exception/GetColumnValueException|null[0]
-    constructor <init>(kotlin/Int) // io.github.kormium.postgres.exception/GetColumnValueException.<init>|<init>(kotlin.Int){}[0]
-}
-
-final class io.github.kormium.postgres.exception/InvalidDataAccessApiUsageException : io.github.kormium.postgres.exception/SQLException { // io.github.kormium.postgres.exception/InvalidDataAccessApiUsageException|null[0]
-    constructor <init>(kotlin/String, kotlin/Throwable? = ...) // io.github.kormium.postgres.exception/InvalidDataAccessApiUsageException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
-}
-
 final class io.github.kormium.postgres.exception/QueryExecutionException : io.github.kormium.postgres.exception/SQLException { // io.github.kormium.postgres.exception/QueryExecutionException|null[0]
     constructor <init>(kotlin/String, kotlin/Throwable? = ...) // io.github.kormium.postgres.exception/QueryExecutionException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
-}
-
-final class io.github.kormium.postgres.paramsource/MapSqlParameterSource : io.github.kormium.postgres.paramsource/AbstractSqlParameterSource { // io.github.kormium.postgres.paramsource/MapSqlParameterSource|null[0]
-    constructor <init>(kotlin.collections/Map<kotlin/String, kotlin/Any?>?) // io.github.kormium.postgres.paramsource/MapSqlParameterSource.<init>|<init>(kotlin.collections.Map<kotlin.String,kotlin.Any?>?){}[0]
-
-    final val parameterNames // io.github.kormium.postgres.paramsource/MapSqlParameterSource.parameterNames|{}parameterNames[0]
-        final fun <get-parameterNames>(): kotlin/Array<kotlin/String> // io.github.kormium.postgres.paramsource/MapSqlParameterSource.parameterNames.<get-parameterNames>|<get-parameterNames>(){}[0]
-
-    final fun addValue(kotlin/String, kotlin/Any?): io.github.kormium.postgres.paramsource/MapSqlParameterSource // io.github.kormium.postgres.paramsource/MapSqlParameterSource.addValue|addValue(kotlin.String;kotlin.Any?){}[0]
-    final fun addValue(kotlin/String, kotlin/Any?, kotlin/UInt): io.github.kormium.postgres.paramsource/MapSqlParameterSource // io.github.kormium.postgres.paramsource/MapSqlParameterSource.addValue|addValue(kotlin.String;kotlin.Any?;kotlin.UInt){}[0]
-    final fun addValue(kotlin/String, kotlin/Any?, kotlin/UInt, kotlin/String?): io.github.kormium.postgres.paramsource/MapSqlParameterSource // io.github.kormium.postgres.paramsource/MapSqlParameterSource.addValue|addValue(kotlin.String;kotlin.Any?;kotlin.UInt;kotlin.String?){}[0]
-    final fun addValues(kotlin.collections/Map<kotlin/String, kotlin/Any?>?): io.github.kormium.postgres.paramsource/MapSqlParameterSource // io.github.kormium.postgres.paramsource/MapSqlParameterSource.addValues|addValues(kotlin.collections.Map<kotlin.String,kotlin.Any?>?){}[0]
-    final fun getValue(kotlin/String): kotlin/Any? // io.github.kormium.postgres.paramsource/MapSqlParameterSource.getValue|getValue(kotlin.String){}[0]
-    final fun getValues(): kotlin.collections/Map<kotlin/String, kotlin/Any?> // io.github.kormium.postgres.paramsource/MapSqlParameterSource.getValues|getValues(){}[0]
-    final fun hasValue(kotlin/String): kotlin/Boolean // io.github.kormium.postgres.paramsource/MapSqlParameterSource.hasValue|hasValue(kotlin.String){}[0]
 }
 
 sealed class io.github.kormium.postgres.exception/SQLException : kotlin/Exception // io.github.kormium.postgres.exception/SQLException|null[0]

--- a/kormium-postgres/src/jvmMain/kotlin/PgResultSetWrapper.kt
+++ b/kormium-postgres/src/jvmMain/kotlin/PgResultSetWrapper.kt
@@ -5,7 +5,7 @@ import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import java.sql.ResultSetMetaData
 
-public class PgResultSetWrapper(private val pgResultSet: java.sql.ResultSet) : ResultSet {
+internal class PgResultSetWrapper(private val pgResultSet: java.sql.ResultSet) : ResultSet {
     // Lazy: the hot read path maps columns positionally and never touches this, so don't
     // read ResultSetMetaData on every query.
     override val columns: Array<String> by lazy { internalGetColumns() }

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/Oid.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/Oid.kt
@@ -35,7 +35,7 @@ private val supportedBinaryOids = hashSetOf(
 
 
 @Suppress("MagicNumber")
-public enum class Oid(public val value: Int) {
+internal enum class Oid(public val value: Int) {
     UNSPECIFIED(0),
     INT2(21),
     INT2_ARRAY(1005),

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/exception/PgKnException.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/exception/PgKnException.kt
@@ -2,11 +2,11 @@ package io.github.kormium.postgres.exception
 
 public sealed class SQLException(message: String? = null, cause: Throwable? = null) : Exception(message, cause)
 
-public class InvalidDataAccessApiUsageException(message: String, cause: Throwable? = null) : SQLException(message, cause)
+internal class InvalidDataAccessApiUsageException(message: String, cause: Throwable? = null) : SQLException(message, cause)
 
-public class AnonymousClassException : SQLException("Class must not be anonymous", null)
+internal class AnonymousClassException : SQLException("Class must not be anonymous", null)
 
-public class GetColumnValueException(columnIndex: Int) : SQLException("Error getting column $columnIndex value", null)
+internal class GetColumnValueException(columnIndex: Int) : SQLException("Error getting column $columnIndex value", null)
 
 /** Raised when a statement (or the initial connection) fails on the server. */
 public class QueryExecutionException(message: String, cause: Throwable? = null) : SQLException(message, cause)

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/paramsource/AbstractSqlParameterSource.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/paramsource/AbstractSqlParameterSource.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.KClass
  * [toString] representation.
  * Concrete subclasses must implement [hasValue] and [getValue].
  */
-public abstract class AbstractSqlParameterSource : SqlParameterSource {
+internal abstract class AbstractSqlParameterSource : SqlParameterSource {
     private val sqlTypes: MutableMap<String, UInt> = HashMap()
     private val typeNames: MutableMap<String, String> = HashMap()
 

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/paramsource/MapSqlParameterSource.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/paramsource/MapSqlParameterSource.kt
@@ -8,7 +8,7 @@ package io.github.kormium.postgres.paramsource
  * easier. The methods return a reference to the [MapSqlParameterSource]
  * itself, so you can chain several method calls together within a single statement.
  */
-public class MapSqlParameterSource : AbstractSqlParameterSource {
+internal class MapSqlParameterSource : AbstractSqlParameterSource {
     private val values: MutableMap<String, Any?> = LinkedHashMap()
 
     /**

--- a/kormium-sqlite/api/jvm/kormium-sqlite.api
+++ b/kormium-sqlite/api/jvm/kormium-sqlite.api
@@ -15,26 +15,3 @@ public abstract interface class io/github/kormium/SqliteDriver : io/github/kormi
 	public abstract fun isClosed ()Z
 }
 
-public final class io/github/kormium/SqliteExceptionsKt {
-	public static final fun sqliteException (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Throwable;)Lio/github/kormium/QueryException;
-	public static synthetic fun sqliteException$default (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Throwable;ILjava/lang/Object;)Lio/github/kormium/QueryException;
-}
-
-public final class io/github/kormium/SqliteResultSetWrapper : io/github/kormium/resultset/ResultSet {
-	public fun <init> (Ljava/sql/ResultSet;)V
-	public fun getBoolean (I)Ljava/lang/Boolean;
-	public fun getBytes (I)[B
-	public fun getColumns ()[Ljava/lang/String;
-	public fun getDate (I)Lkotlinx/datetime/LocalDate;
-	public fun getDouble (I)Ljava/lang/Double;
-	public fun getFloat (I)Ljava/lang/Float;
-	public fun getInstant (I)Lkotlin/time/Instant;
-	public fun getInt (I)Ljava/lang/Integer;
-	public fun getLocalDateTime (I)Lkotlinx/datetime/LocalDateTime;
-	public fun getLong (I)Ljava/lang/Long;
-	public fun getShort (I)Ljava/lang/Short;
-	public fun getString (I)Ljava/lang/String;
-	public fun getTime (I)Lkotlinx/datetime/LocalTime;
-	public fun next ()Z
-}
-

--- a/kormium-sqlite/api/kormium-sqlite.klib.api
+++ b/kormium-sqlite/api/kormium-sqlite.klib.api
@@ -19,4 +19,3 @@ abstract interface io.github.kormium/SqliteDriver : io.github.kormium.database/D
 
 final fun io.github.kormium/createSqliteDatabase(kotlin/String = ..., kotlin/Int = ..., io.github.kormium/KormiumConfig = ...): io.github.kormium/SqliteDriver // io.github.kormium/createSqliteDatabase|createSqliteDatabase(kotlin.String;kotlin.Int;io.github.kormium.KormiumConfig){}[0]
 final fun io.github.kormium/createSqliteDatabase(kotlin/String = ..., kotlin/Int = ..., kotlin/Function1<io.github.kormium/KormiumBuilder, kotlin/Unit>): io.github.kormium/SqliteDriver // io.github.kormium/createSqliteDatabase|createSqliteDatabase(kotlin.String;kotlin.Int;kotlin.Function1<io.github.kormium.KormiumBuilder,kotlin.Unit>){}[0]
-final fun io.github.kormium/sqliteException(kotlin/String, kotlin/Int? = ..., kotlin/Throwable? = ...): io.github.kormium/QueryException // io.github.kormium/sqliteException|sqliteException(kotlin.String;kotlin.Int?;kotlin.Throwable?){}[0]

--- a/kormium-sqlite/src/commonMain/kotlin/SqliteExceptions.kt
+++ b/kormium-sqlite/src/commonMain/kotlin/SqliteExceptions.kt
@@ -14,7 +14,7 @@ private const val SQLITE_CONSTRAINT_UNIQUE = 2067
  * message text (stable across the JDBC and native drivers, e.g. "UNIQUE constraint
  * failed"). The extended code (when known) is carried in [QueryException.sqlState].
  */
-public fun sqliteException(message: String, extendedCode: Int? = null, cause: Throwable? = null): QueryException {
+internal fun sqliteException(message: String, extendedCode: Int? = null, cause: Throwable? = null): QueryException {
     val state = extendedCode?.toString()
     return when {
         extendedCode == SQLITE_CONSTRAINT_UNIQUE || extendedCode == SQLITE_CONSTRAINT_PRIMARYKEY ||

--- a/kormium-sqlite/src/jvmMain/kotlin/SqliteResultSetWrapper.kt
+++ b/kormium-sqlite/src/jvmMain/kotlin/SqliteResultSetWrapper.kt
@@ -14,7 +14,7 @@ import java.sql.ResultSetMetaData
  * (`Instant.toString()` etc., already ISO-8601 with a 'T'), so dates/times are parsed
  * as-is — no space→'T' fix-up.
  */
-public class SqliteResultSetWrapper(private val rs: java.sql.ResultSet) : ResultSet {
+internal class SqliteResultSetWrapper(private val rs: java.sql.ResultSet) : ResultSet {
     // Lazy: the hot read path maps columns positionally and never touches this.
     override val columns: Array<String> by lazy { internalGetColumns() }
 


### PR DESCRIPTION
Stacked on #123 (rebase the base to `0.10.0` once #123 merges).

The deliberate-narrowing pass the explicitApi PR promised. Method: every public type and facade function from the BCV dumps was cross-referenced against sibling modules, samples, benchmarks and all docs; only symbols with **zero external references** and no presence in public signatures were narrowed — the compiler then confirmed nothing leaked (zero errors on the first full build).

**kormium-core: nothing to narrow** — its surface is all deliberate DSL (flagged candidates turned out to be `@JvmName` overloads, symbolic operators and the ColumnType toolkit).

**Narrowed (−186 ABI lines, the .api diffs are the review artifact):**
- pgkn-inherited native Postgres plumbing: `AbstractSqlParameterSource`, `MapSqlParameterSource`, `Oid`, `AnonymousClassException`, `GetColumnValueException`, `InvalidDataAccessApiUsageException`
- per-backend JDBC ResultSet wrappers: `PgResultSetWrapper`, `MySqlResultSetWrapper`, `SqliteResultSetWrapper`
- `JdbcExecutor`, `MySqlNativeTypeMapper`, `sqliteException`

**Kept public deliberately:** cross-module contracts (`PostgresJvmTypeMapper`/`MySqlJvmTypeMapper`/`mysqlVendorException` — used by r2dbc; render functions — used by drivers), DSL structural types (CaseOp/JoinPair/...), factory return types (`R2dbcDatabase`, `NodeSqliteDatabase`).

Verified: full compile of affected modules (JVM+native+android), jvm+native tests for sqlite, testcontainers suites for postgres/mysql/r2dbc, `apiCheck` green against the regenerated dumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)