### PR TITLE
BOM: pin all 20 published artifacts, derived from publishableModules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,15 @@ All notable changes to Kormium are documented here. The format is based on
     (`io.github.kormium:sqlite-wasm-kt` + npm `@kormium/sqlite-wasm-worker`) over the official
     `@sqlite.org/sqlite-wasm`.
 
+### Fixed
+- **The BOM now pins every published artifact** (#8). Ten modules had drifted out of
+  `kormium-bom` — `kormium-r2dbc`, `kormium-observe`, the three dialect modules, `kormium-wasm-driver`
+  and the four web/Node engines — so the documented BOM setup still required explicit versions for
+  them. The BOM's constraints are now derived from the same `publishableModules` set that decides
+  what gets published (the exact drift class 0.9.1 fixed for publishing), so they cannot diverge
+  again. The per-artifact POM `name`/`description` were also refreshed (they still described
+  Kormium as "Postgres + SQLite, JVM + Native").
+
 ## [0.9.1] — Publish the 0.9.0 web/Node modules
 
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,6 +122,9 @@ val publishableModules = setOf(
     "kormium-ktor-koin",
     "kormium-bom",
 )
+// The BOM derives its constraints from this same set (see kormium-bom/build.gradle.kts), so a
+// module added here is pinned by the BOM automatically — they cannot drift apart (issue #8).
+extra["publishableModules"] = publishableModules
 
 subprojects {
     if (name !in publishableModules) return@subprojects
@@ -134,8 +137,12 @@ subprojects {
         coordinates(group.toString(), name, version.toString())
 
         pom {
-            name.set("kormium")
-            description.set("Kormium — a simple Kotlin Multiplatform ORM (Postgres + SQLite, JVM + Native).")
+            name.set(this@subprojects.name)
+            description.set(
+                "Kormium — a type-safe, reflection-free Kotlin Multiplatform ORM / SQL DSL for " +
+                    "server and client: one schema and query model for PostgreSQL, MySQL and SQLite " +
+                    "on JVM, Android, iOS, Native, R2DBC, Node and the browser (Wasm).",
+            )
             inceptionYear.set("2024")
             url.set("https://github.com/kormium/kormium")
             licenses {

--- a/kormium-bom/build.gradle.kts
+++ b/kormium-bom/build.gradle.kts
@@ -2,21 +2,18 @@ plugins {
     `java-platform`
 }
 
-// Bill of Materials: pins the versions of every published korm artifact so consumers can
+// Bill of Materials: pins the versions of every published Kormium artifact so consumers can
 // depend on `platform("io.github.kormium:kormium-bom:<v>")` and omit versions elsewhere.
+//
+// The constraint list is derived from the root build's `publishableModules` — the same set that
+// decides what gets published at all — rather than maintained by hand, so a newly published
+// module cannot be forgotten here (issue #8: kormium-r2dbc and nine others had drifted out).
 dependencies {
     constraints {
-        listOf(
-            "kormium-core",
-            "kormium-decimal",
-            "kormium-postgres",
-            "kormium-mysql",
-            "kormium-jdbc",
-            "kormium-sqlite",
-            "kormium-migrate",
-            "kormium-ktor",
-            "kormium-ktor-di",
-            "kormium-ktor-koin",
-        ).forEach { api("${project.group}:$it:${project.version}") }
+        @Suppress("UNCHECKED_CAST")
+        val publishableModules = rootProject.extra["publishableModules"] as Set<String>
+        (publishableModules - project.name).sorted().forEach {
+            api("${project.group}:$it:${project.version}")
+        }
     }
 }


### PR DESCRIPTION
Closes #8, generalized: not just `kormium-r2dbc` — **ten** modules had drifted out of the BOM (`kormium-r2dbc`, `kormium-observe`, `kormium-postgres-dialect`, `kormium-mysql-dialect`, `kormium-sqlite-dialect`, `kormium-wasm-driver`, `kormium-sqlite-wasm`, `kormium-sqlite-node`, `kormium-postgres-node`, `kormium-mysql-node`), so the documented `platform(...)` setup still required explicit versions for them.

Instead of adding the ten and a CI check (the issue's suggested fix), the BOM now **derives its constraints from the root build's `publishableModules`** — the same set that decides what gets published at all. A module added there is pinned by the BOM automatically; the two lists cannot diverge, which satisfies the issue's acceptance criterion structurally (this is the same drift class 0.9.1 fixed for publishing). Verified: the generated BOM POM contains exactly the 20 published artifacts.

Also refreshes the shared POM metadata every artifact ships to Central:
- `<name>` — per-module (`kormium-core`, …) instead of a uniform `kormium`;
- `<description>` — was "a simple Kotlin Multiplatform ORM (Postgres + SQLite, JVM + Native)", now matches the actual product: type-safe reflection-free KMP ORM/SQL DSL, PostgreSQL/MySQL/SQLite, JVM/Android/iOS/Native/R2DBC/Node/browser (Wasm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)