### PR TITLE
SQLite: don't share :memory: process-wide at the default poolSize=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Kormium are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **`createSqliteDatabase()` no longer shares `:memory:` across unrelated instances at the
+  default `poolSize = 1`.** JVM and Native always opened `":memory:"` with `cache=shared`, so
+  two independent `createSqliteDatabase()` calls in the same process — e.g. two test fixtures —
+  silently read and wrote the same physical database. The shared cache is now only used when
+  `poolSize > 1` (where a pool's connections genuinely need to see one database); a single
+  connection gets SQLite's own default, a private in-memory database.
+
 ## [0.11.1] — Native bytea fix and Kotlin/Native hot-path speedups
 
 ### Fixed

--- a/kormium-sqlite/src/commonMain/kotlin/CreateSqliteDatabase.kt
+++ b/kormium-sqlite/src/commonMain/kotlin/CreateSqliteDatabase.kt
@@ -7,8 +7,10 @@ import kotlin.time.Duration.Companion.seconds
  * Opens a SQLite database and returns a [SqliteDriver].
  *
  * @param path the database file path, or `":memory:"` (the default) for an in-memory
- *   database. On JVM/native an in-memory database is opened in shared-cache mode so a pool
- *   of connections all see the same database; it lives only while the driver is open. On
+ *   database. On JVM/native, with the default `poolSize = 1` an in-memory database is private
+ *   to that one connection, so separate `createSqliteDatabase()` calls never see each other's
+ *   data; with `poolSize > 1` it is opened in shared-cache mode instead, so the pool's
+ *   connections all see the same database — it lives only while the driver is open. On
  *   Android (androidx.sqlite) an in-memory database is private per connection, so there
  *   [poolSize] must be 1 — a larger pool is rejected; use a file path for a shared pool.
  *   A file-backed database is opened in WAL (write-ahead logging) mode for better

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteMemoryIsolationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteMemoryIsolationTest.kt
@@ -1,0 +1,34 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
+import io.github.kormium.autocommit
+import io.github.kormium.createSqliteDatabase
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * Regression test for the default `:memory:` + `poolSize = 1` case sharing state process-wide
+ * (https://github.com/kormium/kormium/issues/131): two independent [createSqliteDatabase] calls
+ * must not see each other's data, even though both use the same default `":memory:"` path.
+ */
+class SqliteMemoryIsolationTest {
+
+    @Test
+    fun independentInstancesDoNotShareState() {
+        val a = createSqliteDatabase()
+        val b = createSqliteDatabase()
+        try {
+            a.autocommit {
+                executeUpdate("CREATE TABLE t(x INTEGER)", params = emptyMap(), invalidates = emptyList())
+            }
+
+            // b never saw a's CREATE TABLE, so querying it here must fail with "no such table"
+            // rather than see a's (nonexistent) rows.
+            assertFailsWith<Exception> {
+                b.autocommit { executeUpdate("SELECT * FROM t", params = emptyMap(), invalidates = emptyList()) }
+            }
+        } finally {
+            a.close()
+            b.close()
+        }
+    }
+}

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteObserveTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteObserveTest.kt
@@ -22,8 +22,8 @@ import kotlin.uuid.Uuid
  * to re-query and emit the new state. This exercises the whole chain — Scope dirty-table
  * tracking → WriteListeners.fire on commit → the flow's re-fetch.
  *
- * The query is filtered to a unique id so it is robust against the shared-cache `:memory:`
- * database other tests also use.
+ * The query is filtered to a unique id, matching the convention used across the SQLite test
+ * suite (each test class opens its own private in-memory database).
  */
 class SqliteObserveTest {
 

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteSuspendTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteSuspendTest.kt
@@ -16,7 +16,8 @@ import kotlin.uuid.Uuid
  * End-to-end test of the suspend path on a real backend (SQLite, JVM + Native). It
  * exercises [suspendTransaction] / [suspendAutocommit] → SuspendDatabase.useConnection
  * → the offload runner (SuspendExecutorAdapter on the IO dispatcher). Reuses the
- * top-level SqCatalog/Products/Product from SqliteIntegrationTest (shared-cache :memory:).
+ * top-level SqCatalog/Products/Product from SqliteIntegrationTest, but against its own
+ * private in-memory database.
  */
 class SqliteSuspendTest {
 

--- a/kormium-sqlite/src/jvmMain/kotlin/CreateSqliteDatabase.jvm.kt
+++ b/kormium-sqlite/src/jvmMain/kotlin/CreateSqliteDatabase.jvm.kt
@@ -10,11 +10,18 @@ private val sqliteTranslator: SqlExceptionTranslator = { e: SQLException ->
     sqliteException(e.message ?: "SQL error", e.errorCode.takeIf { it != 0 }, e)
 }
 
-private fun sqliteJdbcUrl(path: String): String =
+private fun sqliteJdbcUrl(path: String, poolSize: Int): String =
     if (path == ":memory:") {
-        // Shared cache so a pool of connections all see the same in-memory database.
-        // WAL is meaningless without a file, so it is omitted here.
-        "jdbc:sqlite:file::memory:?cache=shared&foreign_keys=on&busy_timeout=5000"
+        // A single connection (the common case, e.g. tests) gets SQLite's default: a private
+        // in-memory database, so unrelated createSqliteDatabase() calls don't see each other's
+        // data. A pool needs cache=shared so its connections all see the same database — but
+        // that URI is identical across instances, so it would also leak across instances if
+        // poolSize were 1. WAL is meaningless without a file, so it is omitted here.
+        if (poolSize > 1) {
+            "jdbc:sqlite:file::memory:?cache=shared&foreign_keys=on&busy_timeout=5000"
+        } else {
+            "jdbc:sqlite::memory:?foreign_keys=on&busy_timeout=5000"
+        }
     } else {
         // WAL gives concurrent readers alongside one writer; foreign_keys are OFF by
         // default in SQLite, so enable them to surface ForeignKeyViolationException.
@@ -23,7 +30,7 @@ private fun sqliteJdbcUrl(path: String): String =
 
 private class SqliteJdbcDriver(path: String, poolSize: Int, acquireTimeout: Duration, config: KormiumConfig) :
     JdbcDatabase(
-        jdbcUrl = sqliteJdbcUrl(path),
+        jdbcUrl = sqliteJdbcUrl(path, poolSize),
         poolSize = poolSize,
         acquireTimeout = acquireTimeout,
         dialect = SqliteDialect,

--- a/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
+++ b/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
@@ -66,14 +66,18 @@ private class SqliteNativeDriver(
 
     private val isMemory = path == ":memory:"
 
-    // Shared cache so a pool of connections all see the same in-memory database; a URI
-    // filename then requires SQLITE_OPEN_URI.
-    private val filename = if (isMemory) "file::memory:?cache=shared" else path
+    // A single connection (the common case, e.g. tests) gets SQLite's default: a private
+    // in-memory database, so unrelated createSqliteDatabase() calls don't see each other's
+    // data. A pool needs cache=shared so its connections all see the same database — but that
+    // URI is identical across instances, so it would also leak across instances if poolSize
+    // were 1. A shared-cache URI filename then requires SQLITE_OPEN_URI.
+    private val useSharedCache = isMemory && poolSize > 1
+    private val filename = if (useSharedCache) "file::memory:?cache=shared" else path
 
     // A SQLite connection is handed to exactly one caller at a time via a Channel that
     // doubles as a blocking "free connection" queue — mirroring the libpq driver.
     private val connections: List<CPointer<sqlite3>> = List(poolSize) {
-        openConnection(filename, uri = isMemory).also { initPragmas(it, file = !isMemory) }
+        openConnection(filename, uri = useSharedCache).also { initPragmas(it, file = !isMemory) }
     }
 
     private val pool = Channel<CPointer<sqlite3>>(poolSize).also { channel ->


### PR DESCRIPTION
cache=shared was set for every ":memory:" call regardless of poolSize, so independent createSqliteDatabase() instances (e.g. separate test fixtures) silently saw each other's data. Only pool poolSize > 1 needs the shared cache; a single connection now gets SQLite's own default, a private in-memory database.

Fixes #131

<!-- Thanks for the pull request. Keep the change focused; unrelated cleanups belong in their own PR. -->

## What this changes

<!-- One or two sentences. Link the issue it addresses: Fixes #123 -->

## Why

<!-- The problem being solved, if it isn't obvious from the issue. -->

## Checklist

- [x] Tests added or updated (a bug fix has a test that fails without it)
- [x] `./gradlew jvmTest apiCheck` passes locally
- [x] `./gradlew apiDump` run and `.api` diffs committed, if the public API changed
- [x] `CHANGELOG.md` updated under `Unreleased`
- [x] No unrelated reformatting mixed in

## Targets affected

<!-- All, or the specific ones: JVM / Android / iOS / Native / Node / Wasm -->
