### PR TITLE
SQLite: isolate in-memory databases per driver, and keep them alive (#131)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.konan
-          key: konan-windows-kotlin-2.4.0
+          key: konan-windows-kotlin-2.4.10
 
       - name: Install mingw libpq (MSYS2)
         run: C:\msys64\usr\bin\pacman.exe -Sy --noconfirm mingw-w64-x86_64-postgresql
@@ -241,7 +241,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.konan
-          key: konan-macos-kotlin-2.4.0
+          key: konan-macos-kotlin-2.4.10
 
       # The klib cinterops (libpq/libmariadb) resolve their headers from brew, like the
       # publish workflow; macOS cross-compiles every declared target's klib from them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@ val db: Database<App> = createDatabase(
 )
 // MySQL / MariaDB (kormium-mysql): same createDatabase(...), port = 3306.
 // SQLite (kormium-sqlite):   createSqliteDatabase(path = ":memory:")
+// Each ":memory:" call is its OWN database (private to that driver, gone on close()). To share
+// one between drivers: createSqliteDatabase("file:shared?mode=memory&cache=shared") — JVM/native.
 // Async PostgreSQL (kormium-r2dbc):  createR2dbcDatabase(...)
 // Async MySQL (kormium-r2dbc):       createMySqlR2dbcDatabase(...)
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Kormium are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **`createSqliteDatabase()` no longer shares `:memory:` across unrelated instances at the
+  default `poolSize = 1`.** JVM and Native always opened `":memory:"` with `cache=shared`, so
+  two independent `createSqliteDatabase()` calls in the same process — e.g. two test fixtures —
+  silently read and wrote the same physical database. The shared cache is now only used when
+  `poolSize > 1` (where a pool's connections genuinely need to see one database); a single
+  connection gets SQLite's own default, a private in-memory database.
+
 ## [0.11.1] — Native bytea fix and Kotlin/Native hot-path speedups
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,19 @@ All notable changes to Kormium are documented here. The format is based on
 - **SQLite: `journal_mode`, `foreign_keys` and `busy_timeout` written into the path win over
   Kormium's defaults**, on both JVM and Native — `createSqliteDatabase("file:app.db?busy_timeout=60000")`
   now really waits 60 s. Kormium appends only the pragmas the caller left out.
+- **Toolchain and dependency updates.** Kotlin 2.4.0 → 2.4.10 (Kotlin/Native, the Compose
+  compiler plugin and the serialization plugin move with it), Android Gradle plugin 9.2.1 → 9.3.1,
+  kotlinx-coroutines 1.10.2 → 1.11.0, kotlinx-serialization 1.9.0 → 1.11.0, kotlinx-io 0.9.0 →
+  0.9.1, kotlinx-browser 0.3 → 0.5.0, Ktor 3.5.0 → 3.5.2, Koin 4.1.0 → 4.2.2, androidx.sqlite
+  2.6.2 → 2.7.0, sqlite-jdbc 3.47.1.0 → 3.53.2.1, HikariCP 6.x → 7.1.0, pgjdbc 42.7.x → 42.7.13,
+  r2dbc-postgresql 1.0.7 → 1.1.2, r2dbc-mysql 1.3.0 → 1.4.3, SLF4J 2.0.16 → 2.0.18, kotlin-logging
+  7.0.3 → 8.0.4, Testcontainers → 1.21.4, and the publishing / foojay Gradle plugins. Benchmarks
+  only: Exposed 1.0.0-beta-4 → 1.4.0, Hibernate 7.0.2 → 7.4.6.
+
+  Two adaptations came with them, neither visible to callers: r2dbc-postgresql 1.1 declares its
+  API with JSpecify, so `NumericAsTextCodec.decode` now takes (and returns) a nullable value the
+  way the driver always meant it, and the comparison benchmark follows Exposed's move to
+  `kotlin.uuid.Uuid` and top-level expression builders.
 
 ### Migration
 - A driver that created the schema and a second driver that reads it are now two different

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ All notable changes to Kormium are documented here. The format is based on
 ## [Unreleased]
 
 ### Fixed
-- **`createSqliteDatabase()` no longer shares `:memory:` across unrelated instances at the
-  default `poolSize = 1`.** JVM and Native always opened `":memory:"` with `cache=shared`, so
-  two independent `createSqliteDatabase()` calls in the same process — e.g. two test fixtures —
-  silently read and wrote the same physical database. The shared cache is now only used when
-  `poolSize > 1` (where a pool's connections genuinely need to see one database); a single
-  connection gets SQLite's own default, a private in-memory database.
+- **`createSqliteDatabase(":memory:")` is no longer shared process-wide.** JVM and Native opened
+  every `":memory:"` database as `file::memory:?cache=shared` — one URI for every caller — so two
+  independent `createSqliteDatabase()` calls in the same process, e.g. two test fixtures, silently
+  read and wrote the same physical database. Each call now gets a process-unique name
+  (`file:kormium-mem-N?mode=memory&cache=shared`), which keeps one driver's `poolSize` connections
+  on one database while isolating drivers from each other. ([#131](https://github.com/kormium/kormium/issues/131))
+
+### Changed
+- **SQLite: `file:` paths are passed through to SQLite as URIs** (`SQLITE_OPEN_URI` on Native, a
+  `file:` JDBC filename on JVM), with Kormium's pragmas appended rather than overwriting the
+  caller's parameters. This is the way to opt back into one in-memory database shared by several
+  drivers, which `":memory:"` used to do by accident:
+  `createSqliteDatabase("file:shared?mode=memory&cache=shared")`.
 
 ## [0.11.1] — Native bytea fix and Kotlin/Native hot-path speedups
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to Kormium are documented here. The format is based on
 
 ## [Unreleased]
 
+> The SQLite in-memory change below alters the behaviour of a released API, so the next release
+> is **0.12.0**, not a patch. See *Migration* at the end of this section.
+
 ### Fixed
 - **`createSqliteDatabase(":memory:")` is no longer shared process-wide.** JVM and Native opened
   every `":memory:"` database as `file::memory:?cache=shared` — one URI for every caller — so two
@@ -13,13 +16,43 @@ All notable changes to Kormium are documented here. The format is based on
   read and wrote the same physical database. Each call now gets a process-unique name
   (`file:kormium-mem-N?mode=memory&cache=shared`), which keeps one driver's `poolSize` connections
   on one database while isolating drivers from each other. ([#131](https://github.com/kormium/kormium/issues/131))
+- **JVM: an in-memory SQLite database no longer disappears out from under a long-running
+  process.** SQLite frees an in-memory database as soon as its last connection closes, and
+  HikariCP recycles pooled connections on its own schedule (`maxLifetime`, 30 minutes by default;
+  also after a fatal error). At the default `poolSize = 1` that left an instant with no connection
+  at all, so roughly half an hour in, every table silently came back empty. The JVM driver now
+  holds one unpooled connection open for as long as the driver is open. Native was never affected
+  (its connections live as long as the driver), and file-backed databases never were.
+- **Android rejects `file:` paths instead of creating a strangely named file.** androidx.sqlite
+  opens without `SQLITE_OPEN_URI`, so `createSqliteDatabase("file:shared?mode=memory&cache=shared")`
+  quietly created a *file* by that name. It now fails with an explanatory message.
 
 ### Changed
 - **SQLite: `file:` paths are passed through to SQLite as URIs** (`SQLITE_OPEN_URI` on Native, a
-  `file:` JDBC filename on JVM), with Kormium's pragmas appended rather than overwriting the
-  caller's parameters. This is the way to opt back into one in-memory database shared by several
-  drivers, which `":memory:"` used to do by accident:
-  `createSqliteDatabase("file:shared?mode=memory&cache=shared")`.
+  `file:` JDBC filename on JVM). This is the way to opt back into one in-memory database shared by
+  several drivers, which `":memory:"` used to do by accident:
+  `createSqliteDatabase("file:shared?mode=memory&cache=shared")`. Not supported on Android (see
+  above).
+- **SQLite: `journal_mode`, `foreign_keys` and `busy_timeout` written into the path win over
+  Kormium's defaults**, on both JVM and Native — `createSqliteDatabase("file:app.db?busy_timeout=60000")`
+  now really waits 60 s. Kormium appends only the pragmas the caller left out.
+
+### Migration
+- A driver that created the schema and a second driver that reads it are now two different
+  in-memory databases. Test fixtures and sharding setups that relied on the old process-wide
+  sharing keep it by naming the database explicitly:
+
+  ```kotlin
+  // before: both calls happened to land on one database
+  val writer = createSqliteDatabase()
+  val reader = createSqliteDatabase()
+
+  // after: same database, on purpose (JVM/native)
+  val writer = createSqliteDatabase("file:app?mode=memory&cache=shared")
+  val reader = createSqliteDatabase("file:app?mode=memory&cache=shared")
+  ```
+
+  Nothing changes for a single driver, for file-backed databases, or on Android.
 
 ## [0.11.1] — Native bytea fix and Kotlin/Native hot-path speedups
 

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -17,16 +17,16 @@ kotlin {
 
 dependencies {
     jmhImplementation(project(":kormium-postgres"))
-    jmhImplementation("org.testcontainers:postgresql:1.21.3")
-    jmhImplementation("org.postgresql:postgresql:42.7.7")
+    jmhImplementation("org.testcontainers:postgresql:1.21.4")
+    jmhImplementation("org.postgresql:postgresql:42.7.13")
     jmhImplementation(project(":kormium-decimal"))
-    jmhImplementation("com.zaxxer:HikariCP:6.3.0")
+    jmhImplementation("com.zaxxer:HikariCP:7.1.0")
 
     // For the cross-ORM comparison benchmark.
-    jmhImplementation("org.hibernate.orm:hibernate-core:7.0.2.Final")
-    jmhImplementation("org.hibernate.orm:hibernate-hikaricp:7.0.2.Final")
-    jmhImplementation("org.jetbrains.exposed:exposed-core:1.0.0-beta-4")
-    jmhImplementation("org.jetbrains.exposed:exposed-jdbc:1.0.0-beta-4")
+    jmhImplementation("org.hibernate.orm:hibernate-core:7.4.6.Final")
+    jmhImplementation("org.hibernate.orm:hibernate-hikaricp:7.4.6.Final")
+    jmhImplementation("org.jetbrains.exposed:exposed-core:1.4.0")
+    jmhImplementation("org.jetbrains.exposed:exposed-jdbc:1.4.0")
 }
 
 val resultsJson = layout.buildDirectory.file("results/jmh/results.json")

--- a/benchmarks/src/jmh/kotlin/ComparisonBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/ComparisonBenchmark.kt
@@ -19,6 +19,10 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table as JpaTable
 import org.hibernate.SessionFactory
 import org.hibernate.cfg.Configuration
+// Exposed 1.x turned its expression builders into top-level functions (SqlExpressionBuilder is
+// no longer the `where { }` receiver), so `eq` is imported explicitly — under an alias, because
+// this file also uses Kormium's own infix `eq`.
+import org.jetbrains.exposed.v1.core.eq as exposedEq
 import org.jetbrains.exposed.v1.jdbc.batchInsert
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -70,6 +74,8 @@ object CmpTable : Table<Cmp, CmpRow>("cmp_bench", ::CmpRow) {
 }
 
 // --- Exposed mapping ---
+// Exposed 1.x maps `uuid` to kotlin.uuid.Uuid — the same type Kormium uses, so the seeded
+// ids are shared with the Kormium benchmarks instead of being converted per call.
 object ExposedBench : ExposedSqlTable("cmp_bench") {
     val id = uuid("id")
     val name = text("name")
@@ -230,23 +236,23 @@ open class ComparisonBenchmark {
     // --- Exposed ---
     @Benchmark
     fun exposedFindById(): Any? = transaction(exposedDb) {
-        ExposedBench.selectAll().where { ExposedBench.id eq seededJavaId }.firstOrNull()
+        ExposedBench.selectAll().where { ExposedBench.id exposedEq seededKormiumId }.firstOrNull()
     }
 
     @Benchmark
     fun exposedSelectWhere(): Any? = transaction(exposedDb) {
-        ExposedBench.selectAll().where { ExposedBench.name eq "seed" }.toList()
+        ExposedBench.selectAll().where { ExposedBench.name exposedEq "seed" }.toList()
     }
 
     @Benchmark
     fun exposedSelectMany(): Any? = transaction(exposedDb) {
-        ExposedBench.selectAll().where { ExposedBench.name eq "bulk" }.toList()
+        ExposedBench.selectAll().where { ExposedBench.name exposedEq "bulk" }.toList()
     }
 
     @Benchmark
     fun exposedInsert(): Any? = transaction(exposedDb) {
         ExposedBench.insert {
-            it[id] = java.util.UUID.randomUUID()
+            it[id] = KormiumUuid.random()
             it[name] = "x"
             it[amount] = java.math.BigDecimal.ONE
         }
@@ -254,7 +260,7 @@ open class ComparisonBenchmark {
 
     @Benchmark
     fun exposedBatchInsert(): Any? = transaction(exposedDb) {
-        ExposedBench.batchInsert(List(BATCH_SIZE) { java.util.UUID.randomUUID() }, shouldReturnGeneratedValues = false) { rowId ->
+        ExposedBench.batchInsert(List(BATCH_SIZE) { KormiumUuid.random() }, shouldReturnGeneratedValues = false) { rowId ->
             this[ExposedBench.id] = rowId
             this[ExposedBench.name] = "x"
             this[ExposedBench.amount] = java.math.BigDecimal.ONE
@@ -263,8 +269,8 @@ open class ComparisonBenchmark {
 
     @Benchmark
     fun exposedUpdateById(): Any? = transaction(exposedDb) {
-        val rowId = updateJavaIds[randomUpdateIndex()]
-        ExposedBench.update({ ExposedBench.id eq rowId }) { it[amount] = java.math.BigDecimal.TWO }
+        val rowId = updateKormiumIds[randomUpdateIndex()]
+        ExposedBench.update({ ExposedBench.id exposedEq rowId }) { it[amount] = java.math.BigDecimal.TWO }
     }
 
     // --- Hibernate ---

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
     // Applied to the publishable subprojects below (not to the root itself).
-    id("com.vanniktech.maven.publish") version "0.36.0" apply false
+    id("com.vanniktech.maven.publish") version "0.37.0" apply false
     // Applied at the root: validates the public ABI of every published module (JVM + klib).
     // API changes require `./gradlew apiDump` and a review of the .api diffs.
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.18.1"
@@ -35,15 +35,15 @@ buildscript {
     }
     dependencies {
         // Kotlin Gradle plugin for all modules (they apply kotlin("multiplatform") without a version).
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.10")
         // Android Gradle plugin for the modules that declare an androidTarget() (Compose
         // Multiplatform support). They apply id("com.android.library") without a version.
-        classpath("com.android.tools.build:gradle:9.2.1")
+        classpath("com.android.tools.build:gradle:9.3.1")
         // Compose Multiplatform for the wasmJs todo sample. The Compose gradle plugin (libs/DSL)
         // plus the Kotlin Compose compiler plugin (decoupled from the gradle plugin since Kotlin
         // 2.0, versioned with Kotlin). The sample applies both without a version.
         classpath("org.jetbrains.compose:compose-gradle-plugin:1.11.1")
-        classpath("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.4.0")
+        classpath("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.4.10")
     }
 }
 

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -147,6 +147,19 @@ SQLite notes:
 - `poolSize` defaults to `1` because SQLite allows one writer.
 - File databases are opened in WAL mode.
 - Foreign keys are enabled with `PRAGMA foreign_keys=ON`.
+- Every `createSqliteDatabase(":memory:")` call opens its **own** in-memory database, private to
+  that driver and shared only across its own pooled connections. It lives as long as the driver:
+  `close()` frees it.
+- To put several drivers on one in-memory database, name it with a SQLite URI (JVM and native —
+  Android rejects `file:` paths, androidx.sqlite opens without `SQLITE_OPEN_URI`):
+
+  ```kotlin
+  val a = createSqliteDatabase("file:shared?mode=memory&cache=shared")
+  val b = createSqliteDatabase("file:shared?mode=memory&cache=shared") // same database as `a`
+  ```
+
+- `journal_mode`, `foreign_keys` and `busy_timeout` spelled out in a path are honoured; Kormium
+  appends only the defaults you left out.
 - `UUID`, `Decimal`, `Json` and temporal values are stored as text and parsed back.
 
 ### Browser SQLite (`kormium-sqlite-wasm`)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-version = 0.11.1
+version = 0.12.0
 group = io.github.kormium
 
 # The full multi-target build (jvm + native + iOS + js + wasm across all modules) exhausts the

--- a/kormium-core/build.gradle.kts
+++ b/kormium-core/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("multiplatform")
-    kotlin("plugin.serialization") version "2.4.0"
+    kotlin("plugin.serialization") version "2.4.10"
     id("com.android.kotlin.multiplatform.library")
 }
 
@@ -60,8 +60,8 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 // Public suspend API (suspendTransaction/suspendAutocommit) is coroutine-based.
-                api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
                 // LocalDate/LocalTime/LocalDateTime appear in the public API (ColumnType,
                 // ResultSet), so consumers need the types on their compile classpath.
                 api("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
@@ -70,7 +70,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
             }
         }
         // Logging is reached through the internal KormiumLogger facade. Every target EXCEPT
@@ -80,7 +80,7 @@ kotlin {
         val loggingMain by creating {
             dependsOn(commonMain)
             dependencies {
-                implementation("io.github.oshai:kotlin-logging:7.0.3")
+                implementation("io.github.oshai:kotlin-logging:8.0.4")
             }
         }
         val jvmMain by getting {
@@ -88,14 +88,14 @@ kotlin {
             dependencies {
                 // kotlin-logging delegates to SLF4J on the JVM; core needs the API on the
                 // runtime classpath (previously pulled in transitively via the drivers).
-                implementation("org.slf4j:slf4j-api:2.0.16")
+                implementation("org.slf4j:slf4j-api:2.0.18")
             }
         }
         val androidMain by getting {
             dependsOn(loggingMain)
             dependencies {
                 // Android is JVM-flavoured: kotlin-logging delegates to SLF4J here too.
-                implementation("org.slf4j:slf4j-api:2.0.16")
+                implementation("org.slf4j:slf4j-api:2.0.18")
             }
         }
         // Native + JS + Wasm/JS all have kotlin-logging artifacts -> share loggingMain.

--- a/kormium-decimal/build.gradle.kts
+++ b/kormium-decimal/build.gradle.kts
@@ -52,7 +52,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
             }
         }
         // JVM-flavoured targets bind java.math.BigDecimal so JDBC/r2dbc drivers declare the

--- a/kormium-jdbc/build.gradle.kts
+++ b/kormium-jdbc/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
                 // SqlParameterSource, so :kormium-core is part of the public API.
                 api(project(":kormium-core"))
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
-                implementation("com.zaxxer:HikariCP:6.2.1")
+                implementation("com.zaxxer:HikariCP:7.1.0")
             }
         }
         val jvmTest by getting {

--- a/kormium-ktor-di/build.gradle.kts
+++ b/kormium-ktor-di/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
     }
 }
 
-val ktorVersion = "3.5.0"
+val ktorVersion = "3.5.2"
 
 kotlin {
     explicitApi()

--- a/kormium-ktor-koin/build.gradle.kts
+++ b/kormium-ktor-koin/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
     }
 }
 
-val koinVersion = "4.1.0"
+val koinVersion = "4.2.2"
 
 kotlin {
     explicitApi()

--- a/kormium-ktor/build.gradle.kts
+++ b/kormium-ktor/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
     }
 }
 
-val ktorVersion = "3.5.0"
+val ktorVersion = "3.5.2"
 
 kotlin {
     explicitApi()

--- a/kormium-mysql-node/build.gradle.kts
+++ b/kormium-mysql-node/build.gradle.kts
@@ -29,7 +29,7 @@ kotlin {
                 implementation(project(":kormium-mysql-dialect"))
                 // Shared Wasm driver layer: named-param parser, text ResultSet, binding helper.
                 implementation(project(":kormium-wasm-driver"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
                 // mysql2: pure-JS MySQL/MariaDB client with a promise API. https://sidorares.github.io/node-mysql2
                 implementation(npm("mysql2", "3.22.5"))
@@ -38,7 +38,7 @@ kotlin {
         val wasmJsTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
             }
         }
     }

--- a/kormium-mysql/build.gradle.kts
+++ b/kormium-mysql/build.gradle.kts
@@ -53,7 +53,7 @@ kotlin {
                 api(project(":kormium-mysql-dialect"))
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
                 // MySqlJvmTypeMapper binds a JsonElement as its text form into a JSON column.
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
             }
         }
         val commonTest by getting {
@@ -75,23 +75,23 @@ kotlin {
             dependencies {
                 // End-to-end tests of the JVM driver against a real MySQL in Docker.
                 implementation(project(":kormium-migrate"))
-                implementation("org.testcontainers:mysql:1.20.4")
+                implementation("org.testcontainers:mysql:1.21.4")
                 implementation("com.mysql:mysql-connector-j:8.4.0")
                 // For the all-column-types round-trip test (Instant / Json columns).
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
             }
         }
         val nativeMain by getting {
             dependencies {
                 // The native libmysqlclient driver.
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
             }
         }
         val nativeTest by getting {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
             }
         }
     }

--- a/kormium-observe/build.gradle.kts
+++ b/kormium-observe/build.gradle.kts
@@ -57,7 +57,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
             }
         }
     }

--- a/kormium-postgres-dialect/build.gradle.kts
+++ b/kormium-postgres-dialect/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
                 // Only the Dialect SPI comes from core; core stays unaware of concrete dialects.
                 api(project(":kormium-core"))
                 // PostgresDialect casts a JsonElement bind to ::jsonb, so it needs the type.
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
             }
         }
         val commonTest by getting {

--- a/kormium-postgres-node/build.gradle.kts
+++ b/kormium-postgres-node/build.gradle.kts
@@ -29,7 +29,7 @@ kotlin {
                 implementation(project(":kormium-postgres-dialect"))
                 // Shared Wasm driver layer: named-param parser, text ResultSet, binding helper.
                 implementation(project(":kormium-wasm-driver"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
                 // node-postgres: pure-JS Postgres client. https://node-postgres.com
                 implementation(npm("pg", "8.13.1"))
@@ -38,7 +38,7 @@ kotlin {
         val wasmJsTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
             }
         }
     }

--- a/kormium-postgres/build.gradle.kts
+++ b/kormium-postgres/build.gradle.kts
@@ -93,8 +93,8 @@ kotlin {
                 // existing consumers exactly as before.
                 api(project(":kormium-postgres-dialect"))
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
-                implementation("io.github.oshai:kotlin-logging:7.0.3")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
+                implementation("io.github.oshai:kotlin-logging:8.0.4")
             }
         }
         val commonTest by getting {
@@ -108,7 +108,7 @@ kotlin {
                 // The JVM Postgres driver is the shared JDBC driver wired with the
                 // pgjdbc URL + PgResultSetWrapper (which uses kotlinx-datetime).
                 implementation(project(":kormium-jdbc"))
-                implementation("org.postgresql:postgresql:42.7.4")
+                implementation("org.postgresql:postgresql:42.7.13")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
             }
         }
@@ -116,19 +116,19 @@ kotlin {
             dependencies {
                 // End-to-end tests of the JVM driver against a real Postgres in Docker.
                 implementation(project(":kormium-migrate"))
-                implementation("org.testcontainers:postgresql:1.20.4")
-                implementation("org.postgresql:postgresql:42.7.4")
+                implementation("org.testcontainers:postgresql:1.21.4")
+                implementation("org.postgresql:postgresql:42.7.13")
                 // For the all-column-types round-trip test (Instant / Json columns).
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
             }
         }
         val nativeMain by getting {
             dependencies {
                 // The native libpq driver (formerly :pgkn).
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
-                implementation("io.github.oshai:kotlin-logging:7.0.3")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
+                implementation("io.github.oshai:kotlin-logging:8.0.4")
             }
         }
         // The async socket reactor's syscalls differ by OS: poll/pipe/fcntl on Unix

--- a/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/Log.kt
+++ b/kormium-postgres/src/nativeMain/kotlin/io/github/kormium/postgres/Log.kt
@@ -11,7 +11,7 @@ internal object PgknMarker : Marker {
 internal class KLogger(private val actualKLogger: ActualKLogger) : ActualKLogger by actualKLogger {
     constructor(name: String) : this(KotlinLogging.logger(name))
 
-    override fun trace(message: () -> Any?) = trace(null as Throwable?, PgknMarker, message)
+    override fun trace(message: () -> Any?) = trace(PgknMarker, message)
 
 // Might want to override this to give the ability to turn on/off logs for PGKN
 // override fun isLoggingEnabledFor(level: Level, marker: Marker?) = level.isLoggingEnabled() && ?

--- a/kormium-r2dbc/build.gradle.kts
+++ b/kormium-r2dbc/build.gradle.kts
@@ -27,10 +27,14 @@ kotlin {
                 api(project(":kormium-postgres"))
                 // MySqlDialect + MySqlJvmTypeMapper for the MySQL r2dbc factory.
                 api(project(":kormium-mysql"))
-                implementation("org.postgresql:r2dbc-postgresql:1.0.7.RELEASE")
-                implementation("io.asyncer:r2dbc-mysql:1.3.0")
+                implementation("org.postgresql:r2dbc-postgresql:1.1.2.RELEASE")
+                // r2dbc-postgresql 1.1 annotates its API with JSpecify and ships the annotations
+                // as `provided`, so Kotlin needs them on the compile classpath to read the
+                // nullability off signatures like PostgresqlConnection.notifications.
+                compileOnly("org.jspecify:jspecify:1.0.0")
+                implementation("io.asyncer:r2dbc-mysql:1.4.3")
                 implementation("io.r2dbc:r2dbc-pool:1.0.2.RELEASE")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:1.11.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
             }
         }
@@ -40,9 +44,9 @@ kotlin {
                 // Decimal + Instant round-trips over r2dbc (the two types the JDBC/native
                 // suites cover but this backend otherwise would not).
                 implementation(project(":kormium-decimal"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
-                implementation("org.testcontainers:postgresql:1.20.4")
-                implementation("org.testcontainers:mysql:1.20.4")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
+                implementation("org.testcontainers:postgresql:1.21.4")
+                implementation("org.testcontainers:mysql:1.21.4")
             }
         }
     }

--- a/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/NumericAsTextCodec.kt
+++ b/kormium-r2dbc/src/jvmMain/kotlin/io/github/kormium/r2dbc/NumericAsTextCodec.kt
@@ -48,10 +48,13 @@ internal object NumericAsTextCodec : Codec<String> {
     override fun canDecode(dataType: Int, format: Format, type: Class<*>): Boolean =
         dataType == NUMERIC_OID && type == String::class.java
 
-    override fun decode(buffer: ByteBuf, dataType: Int, format: Format, type: Class<out String>): String =
-        when (format) {
-            Format.FORMAT_TEXT -> buffer.toString(StandardCharsets.US_ASCII)
-            Format.FORMAT_BINARY -> decodeBinaryNumeric(buffer)
+    // The driver passes a null buffer for a SQL NULL (r2dbc-postgresql 1.1 spells that out with
+    // JSpecify annotations, so the parameter and the result are nullable here).
+    override fun decode(buffer: ByteBuf?, dataType: Int, format: Format, type: Class<out String>): String? =
+        when {
+            buffer == null -> null
+            format == Format.FORMAT_TEXT -> buffer.toString(StandardCharsets.US_ASCII)
+            else -> decodeBinaryNumeric(buffer)
         }
 
     override fun canEncode(value: Any): Boolean = false

--- a/kormium-sqlite-js/build.gradle.kts
+++ b/kormium-sqlite-js/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
                 api(project(":kormium-core"))
                 // Reuse the shared, pure SqliteDialect (no duplication) — see ADR 0001.
                 implementation(project(":kormium-sqlite-dialect"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
                 // wa-sqlite: SQLite in WASM with async VFS (IndexedDB-capable). https://github.com/rhashimoto/wa-sqlite
                 implementation(npm("wa-sqlite", "1.0.0"))
@@ -41,7 +41,7 @@ kotlin {
         val jsTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
             }
         }
     }

--- a/kormium-sqlite-node/build.gradle.kts
+++ b/kormium-sqlite-node/build.gradle.kts
@@ -29,7 +29,7 @@ kotlin {
                 implementation(project(":kormium-sqlite-dialect"))
                 // Shared Wasm driver layer: named-param parser, text ResultSet, binding helper.
                 implementation(project(":kormium-wasm-driver"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
                 // better-sqlite3: the de-facto synchronous SQLite for Node. https://github.com/WiseLibs/better-sqlite3
                 implementation(npm("better-sqlite3", "12.11.1"))
@@ -38,7 +38,7 @@ kotlin {
         val wasmJsTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
             }
         }
     }

--- a/kormium-sqlite-wasm/build.gradle.kts
+++ b/kormium-sqlite-wasm/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
                 implementation(project(":kormium-sqlite-dialect"))
                 // Shared Wasm driver layer: named-param parser, text ResultSet, binding helper.
                 implementation(project(":kormium-wasm-driver"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
                 // wa-sqlite: SQLite in WASM with async VFS (IndexedDB-capable). https://github.com/rhashimoto/wa-sqlite
                 implementation(npm("wa-sqlite", "1.0.0"))
@@ -49,7 +49,7 @@ kotlin {
         val wasmJsTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
             }
         }
     }

--- a/kormium-sqlite/README.md
+++ b/kormium-sqlite/README.md
@@ -48,8 +48,20 @@ val db = createSqliteDatabase("app.db") {
 }
 ```
 
+Two `createSqliteDatabase()` calls never share an in-memory database. To put several drivers on
+one, name it with a SQLite URI (JVM and native only):
+
+```kotlin
+val a = createSqliteDatabase("file:shared?mode=memory&cache=shared")
+val b = createSqliteDatabase("file:shared?mode=memory&cache=shared") // same database as `a`
+```
+
+`journal_mode`, `foreign_keys` and `busy_timeout` written into such a path are honoured as-is;
+Kormium only fills in the ones you left out.
+
 > On Android an in-memory database is private per connection, so `poolSize` must be `1`; use a
-> file path for a shared pool.
+> file path for a shared pool. Android also rejects `file:` URIs — androidx.sqlite opens without
+> `SQLITE_OPEN_URI`, so the URI would become a file of that name.
 
 ## Platforms
 

--- a/kormium-sqlite/README.md
+++ b/kormium-sqlite/README.md
@@ -29,7 +29,7 @@ macOS, iOS and Android need nothing extra.
 ## Example
 
 ```kotlin
-// In-memory (shared-cache on JVM/Native, lives only while the driver is open).
+// In-memory: private to this driver (its pool shares it), lives only while the driver is open.
 val db: Database<App> = createSqliteDatabase()
 
 // File-backed, opened in WAL mode. SQLite has a single writer, so poolSize defaults to 1;

--- a/kormium-sqlite/build.gradle.kts
+++ b/kormium-sqlite/build.gradle.kts
@@ -40,7 +40,7 @@ kotlin {
     // version lazily (it may still be downloading at configuration time).
     val konanDataDir = System.getenv("KONAN_DATA_DIR")?.let(::File)
         ?: File(System.getProperty("user.home"), ".konan")
-    val konanVersion = "2.4.0"
+    val konanVersion = "2.4.10"
     // On Windows the distribution ships run_konan.bat, which has to go through cmd /c.
     fun runKonan(): List<String> {
         val dist = (konanDataDir.listFiles { f ->
@@ -149,8 +149,8 @@ kotlin {
                 implementation(project(":kormium-observe"))
                 implementation(project(":kormium-decimal"))
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
             }
         }
         val jvmMain by getting {
@@ -158,22 +158,22 @@ kotlin {
                 // The JVM SQLite driver is the shared JDBC driver wired with the
                 // sqlite-jdbc URL + SqliteResultSetWrapper.
                 implementation(project(":kormium-jdbc"))
-                implementation("org.xerial:sqlite-jdbc:3.47.1.0")
+                implementation("org.xerial:sqlite-jdbc:3.53.2.1")
             }
         }
         val androidMain by getting {
             dependencies {
                 // androidx.sqlite's bundled SQLite ships its own native library for Android,
                 // so the driver works on-device without relying on the framework's sqlite.
-                implementation("androidx.sqlite:sqlite:2.6.2")
-                implementation("androidx.sqlite:sqlite-bundled:2.6.2")
+                implementation("androidx.sqlite:sqlite:2.7.0")
+                implementation("androidx.sqlite:sqlite-bundled:2.7.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
             }
         }
         val jvmTest by getting {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
             }
         }
     }

--- a/kormium-sqlite/src/androidMain/kotlin/CreateSqliteDatabase.android.kt
+++ b/kormium-sqlite/src/androidMain/kotlin/CreateSqliteDatabase.android.kt
@@ -47,6 +47,15 @@ private class SqliteAndroidDriver(
                 "(a larger pool would give each caller a separate empty database). " +
                 "Use a file path for a shared pooled database."
         }
+        // JVM and native hand a "file:…" path to SQLite as a URI (SQLITE_OPEN_URI), which is how
+        // several drivers share one in-memory database. androidx.sqlite opens without that flag,
+        // so the URI would be taken literally and quietly create a file named
+        // "file:shared?mode=memory&cache=shared" — say so instead.
+        require(!path.startsWith("file:")) {
+            "Android does not support SQLite URI filenames (androidx.sqlite opens without " +
+                "SQLITE_OPEN_URI, so \"$path\" would become a file of that name); use a plain " +
+                "file path or \":memory:\"."
+        }
     }
 
     // A bounded borrow: a saturated pool fails with a clear, catchable error instead of

--- a/kormium-sqlite/src/commonMain/kotlin/CreateSqliteDatabase.kt
+++ b/kormium-sqlite/src/commonMain/kotlin/CreateSqliteDatabase.kt
@@ -15,8 +15,12 @@ import kotlin.time.Duration.Companion.seconds
  *   (androidx.sqlite) an in-memory database is private per connection, so there [poolSize]
  *   must be 1 — a larger pool is rejected; use a file path for a shared pool. A file-backed
  *   database is opened in WAL (write-ahead logging) mode for better read/write concurrency.
- *   To share one in-memory database between drivers on JVM/native, pass an explicit SQLite
- *   URI instead: `createSqliteDatabase("file:shared?mode=memory&cache=shared")`.
+ *
+ *   A `"file:…"` path is handed to SQLite as a URI (JVM and native only — Android rejects it,
+ *   androidx.sqlite opens without `SQLITE_OPEN_URI`). That is how to share one in-memory
+ *   database between drivers: `createSqliteDatabase("file:shared?mode=memory&cache=shared")`.
+ *   Kormium adds `journal_mode`, `foreign_keys` and `busy_timeout` to a URI only when the
+ *   caller has not spelled them out, so its defaults never override an explicit choice.
  * @param poolSize how many connections to keep. SQLite allows a single writer, so the
  *   default is 1 (everything serialised, no `database is locked`); raise it for
  *   concurrent reads (WAL permits many readers alongside one writer).
@@ -60,3 +64,34 @@ internal fun newInMemoryDatabaseName(): String = "kormium-mem-${inMemoryDatabase
 
 @OptIn(ExperimentalAtomicApi::class)
 private val inMemoryDatabaseCounter = AtomicLong(0)
+
+/**
+ * Whether [path] names an in-memory database rather than a file — `":memory:"`, the
+ * `file:<name>?mode=memory` URI built above, or a caller's own `file::memory:` spelling.
+ *
+ * Two decisions hang on it: WAL is meaningless without a file, and an in-memory database exists
+ * only while some connection to it is open, so the JVM driver has to hold one open itself.
+ */
+internal fun isInMemorySqlitePath(path: String): Boolean =
+    ":memory:" in path || sqlitePathParams(path)["mode"] == "memory"
+
+/**
+ * The query parameters of a SQLite path — `file:app.db?busy_timeout=60000` yields
+ * `{busy_timeout=60000}`; a path without a `?` yields an empty map.
+ *
+ * Kormium applies three pragmas of its own (`journal_mode`, `foreign_keys`, `busy_timeout`).
+ * A caller who writes one of them into the path means it, so both drivers consult this map
+ * first and fall back to the default only for what is missing — on the JVM by not appending
+ * the parameter (sqlite-jdbc applies the caller's), on native by issuing the caller's value as
+ * the `PRAGMA`. Values are restricted to word characters: they are interpolated into a `PRAGMA`
+ * statement on native, and nothing legitimate here is more than a keyword or a number.
+ */
+internal fun sqlitePathParams(path: String): Map<String, String> {
+    val query = path.substringAfter('?', "")
+    if (query.isEmpty()) return emptyMap()
+    return query.split('&').mapNotNull { part ->
+        val key = part.substringBefore('=', "")
+        val value = part.substringAfter('=', "")
+        if (key.isEmpty() || value.isEmpty() || !value.all { it == '_' || it.isLetterOrDigit() }) null else key to value
+    }.toMap()
+}

--- a/kormium-sqlite/src/commonMain/kotlin/CreateSqliteDatabase.kt
+++ b/kormium-sqlite/src/commonMain/kotlin/CreateSqliteDatabase.kt
@@ -1,5 +1,7 @@
 package io.github.kormium
 
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -7,14 +9,14 @@ import kotlin.time.Duration.Companion.seconds
  * Opens a SQLite database and returns a [SqliteDriver].
  *
  * @param path the database file path, or `":memory:"` (the default) for an in-memory
- *   database. On JVM/native, with the default `poolSize = 1` an in-memory database is private
- *   to that one connection, so separate `createSqliteDatabase()` calls never see each other's
- *   data; with `poolSize > 1` it is opened in shared-cache mode instead, so the pool's
- *   connections all see the same database — it lives only while the driver is open. On
- *   Android (androidx.sqlite) an in-memory database is private per connection, so there
- *   [poolSize] must be 1 — a larger pool is rejected; use a file path for a shared pool.
- *   A file-backed database is opened in WAL (write-ahead logging) mode for better
- *   read/write concurrency.
+ *   database. On JVM/native each `":memory:"` call gets its own private database — two
+ *   `createSqliteDatabase()` calls never see each other's data — shared across that one
+ *   driver's [poolSize] connections; it lives only while the driver is open. On Android
+ *   (androidx.sqlite) an in-memory database is private per connection, so there [poolSize]
+ *   must be 1 — a larger pool is rejected; use a file path for a shared pool. A file-backed
+ *   database is opened in WAL (write-ahead logging) mode for better read/write concurrency.
+ *   To share one in-memory database between drivers on JVM/native, pass an explicit SQLite
+ *   URI instead: `createSqliteDatabase("file:shared?mode=memory&cache=shared")`.
  * @param poolSize how many connections to keep. SQLite allows a single writer, so the
  *   default is 1 (everything serialised, no `database is locked`); raise it for
  *   concurrent reads (WAL permits many readers alongside one writer).
@@ -41,3 +43,20 @@ public fun createSqliteDatabase(
     acquireTimeout: Duration = 30.seconds,
     block: KormiumBuilder.() -> Unit,
 ): SqliteDriver = KormiumBuilder().apply(block).finish { createSqliteDatabase(path, poolSize, acquireTimeout, it) }
+
+/**
+ * A process-unique name for an in-memory database, used by the JVM and native drivers to build
+ * a `file:<name>?mode=memory&cache=shared` URI.
+ *
+ * Shared cache is what lets a driver's `poolSize` connections see one database, but the plain
+ * `file::memory:?cache=shared` URI is identical for every caller, so unrelated
+ * `createSqliteDatabase()` calls in one process silently landed on the same physical database
+ * (https://github.com/kormium/kormium/issues/131). Naming each one keeps the pool sharing while
+ * isolating drivers from each other. A counter is enough: shared-cache in-memory databases are
+ * per-process, so uniqueness within this process is uniqueness everywhere it matters.
+ */
+@OptIn(ExperimentalAtomicApi::class)
+internal fun newInMemoryDatabaseName(): String = "kormium-mem-${inMemoryDatabaseCounter.fetchAndAdd(1)}"
+
+@OptIn(ExperimentalAtomicApi::class)
+private val inMemoryDatabaseCounter = AtomicLong(0)

--- a/kormium-sqlite/src/commonMain/kotlin/CreateSqliteDatabase.kt
+++ b/kormium-sqlite/src/commonMain/kotlin/CreateSqliteDatabase.kt
@@ -7,8 +7,10 @@ import kotlin.time.Duration.Companion.seconds
  * Opens a SQLite database and returns a [SqliteDriver].
  *
  * @param path the database file path, or `":memory:"` (the default) for an in-memory
- *   database. On JVM/native an in-memory database is opened in shared-cache mode so a pool
- *   of connections all see the same database; it lives only while the driver is open. On
+ *   database. On JVM/native, with the default `poolSize = 1` an in-memory database is private
+ *   to that one connection, so separate `createSqliteDatabase()` calls never see each other's
+ *   data; with `poolSize > 1` it is opened in shared-cache mode instead, so the pool's
+ *   connections all see the same database — it lives only while the driver is open. On
  *   Android (androidx.sqlite) an in-memory database is private per connection, so there
  *   [poolSize] must be 1 — a larger pool is rejected; use a file path for a shared pool.
  *   A file-backed database is opened in WAL (write-ahead logging) mode for better

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteIntegrationTest.kt
@@ -57,7 +57,7 @@ import kotlin.uuid.Uuid
  */
 class SqliteIntegrationTest {
 
-    // One shared in-memory database (shared-cache) for the whole class. Tables are
+    // One in-memory database, private to this class, for all of its tests. Tables are
     // created with IF NOT EXISTS; every test uses fresh random ids.
     private val db: Database<SqCatalog> = createSqliteDatabase(":memory:")
 

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteMemoryIsolationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteMemoryIsolationTest.kt
@@ -1,0 +1,34 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
+import io.github.kormium.autocommit
+import io.github.kormium.createSqliteDatabase
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * Regression test for the default `:memory:` + `poolSize = 1` case sharing state process-wide
+ * (https://github.com/kormium/kormium/issues/131): two independent [createSqliteDatabase] calls
+ * must not see each other's data, even though both use the same default `":memory:"` path.
+ */
+class SqliteMemoryIsolationTest {
+
+    @Test
+    fun independentInstancesDoNotShareState() {
+        val a = createSqliteDatabase()
+        val b = createSqliteDatabase()
+        try {
+            a.autocommit {
+                executeUpdate("CREATE TABLE t(x INTEGER)", params = emptyMap(), invalidates = emptyList())
+            }
+
+            // b never saw a's CREATE TABLE, so querying it here must fail with "no such table"
+            // rather than see a's (nonexistent) rows.
+            assertFailsWith<Exception> {
+                b.autocommit { executeUpdate("SELECT * FROM t", params = emptyMap(), invalidates = emptyList()) }
+            }
+        } finally {
+            a.close()
+            b.close()
+        }
+    }
+}

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteMemoryIsolationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteMemoryIsolationTest.kt
@@ -1,13 +1,11 @@
 @file:OptIn(io.github.kormium.DelicateKormiumApi::class)
 
-import io.github.kormium.QueryException
 import io.github.kormium.SqliteDriver
 import io.github.kormium.autocommit
 import io.github.kormium.createSqliteDatabase
 import io.github.kormium.transaction
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 /**
  * `:memory:` isolation on JVM/native (https://github.com/kormium/kormium/issues/131). Both
@@ -16,11 +14,18 @@ import kotlin.test.assertFailsWith
  * test database showing a neighbour's rows. Each call now gets its own name, which has to hold
  * three ways at once: separate drivers are isolated, one driver's pool still shares a database
  * across its connections, and an explicit URI can still opt back into sharing.
+ *
+ * Isolation is asserted positively — the same table exists in both databases and only one of
+ * them holds the row — rather than by expecting a failure in the second database, which would
+ * also "pass" if that driver were broken in some entirely different way.
  */
 class SqliteMemoryIsolationTest {
 
     private fun createTable(db: SqliteDriver, name: String) = db.autocommit {
         executeUpdate("CREATE TABLE $name(x INTEGER)", params = emptyMap(), invalidates = emptyList())
+    }
+
+    private fun insertRow(db: SqliteDriver, name: String) = db.autocommit {
         executeUpdate("INSERT INTO $name(x) VALUES (1)", params = emptyMap(), invalidates = emptyList())
     }
 
@@ -35,8 +40,10 @@ class SqliteMemoryIsolationTest {
         val b = createSqliteDatabase()
         try {
             createTable(a, "iso_default")
-            // b never saw a's CREATE TABLE, so the table simply does not exist there.
-            assertFailsWith<QueryException> { countIn(b, "iso_default") }
+            createTable(b, "iso_default")
+            insertRow(a, "iso_default")
+            assertEquals(1, countIn(a, "iso_default"))
+            assertEquals(0, countIn(b, "iso_default"), "b must not see a's row")
         } finally {
             a.close()
             b.close()
@@ -49,7 +56,10 @@ class SqliteMemoryIsolationTest {
         val b = createSqliteDatabase(poolSize = 2)
         try {
             createTable(a, "iso_pooled")
-            assertFailsWith<QueryException> { countIn(b, "iso_pooled") }
+            createTable(b, "iso_pooled")
+            insertRow(a, "iso_pooled")
+            assertEquals(1, countIn(a, "iso_pooled"))
+            assertEquals(0, countIn(b, "iso_pooled"), "b must not see a's row")
         } finally {
             a.close()
             b.close()
@@ -61,6 +71,7 @@ class SqliteMemoryIsolationTest {
         val db = createSqliteDatabase(poolSize = 2)
         try {
             createTable(db, "iso_pool_shared")
+            insertRow(db, "iso_pool_shared")
             // The outer transaction pins one connection for its whole body, so the nested
             // autocommit is forced onto the pool's *other* connection — which must see the
             // database the first one created (a read, so no shared-cache table lock is held).
@@ -83,10 +94,45 @@ class SqliteMemoryIsolationTest {
         val b = createSqliteDatabase(uri)
         try {
             createTable(a, "iso_shared_uri")
+            insertRow(a, "iso_shared_uri")
             assertEquals(1, countIn(b, "iso_shared_uri"))
         } finally {
             a.close()
             b.close()
+        }
+    }
+
+    @Test
+    fun pragmasInThePathWinOverKormiumsDefaults() {
+        // busy_timeout is Kormium's to set (5000) unless the caller says otherwise in the path.
+        // Both backends have to honour it, by different routes: sqlite-jdbc parses the parameter
+        // on the JVM, while native reads it back out of the URI and issues the PRAGMA itself.
+        val db = createSqliteDatabase("file:kormium-pragma-test?mode=memory&cache=shared&busy_timeout=1234")
+        try {
+            val timeout = db.autocommit {
+                execute("PRAGMA busy_timeout", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) }
+            }.single()
+            assertEquals(1234, timeout)
+        } finally {
+            db.close()
+        }
+    }
+
+    @Test
+    fun kormiumsDefaultPragmasStillApply() {
+        val db = createSqliteDatabase()
+        try {
+            val (foreignKeys, timeout) = db.autocommit {
+                val fk = execute("PRAGMA foreign_keys", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) }
+                    .single()
+                val bt = execute("PRAGMA busy_timeout", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) }
+                    .single()
+                fk to bt
+            }
+            assertEquals(1, foreignKeys)
+            assertEquals(5000, timeout)
+        } finally {
+            db.close()
         }
     }
 }

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteMemoryIsolationTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteMemoryIsolationTest.kt
@@ -1,31 +1,89 @@
 @file:OptIn(io.github.kormium.DelicateKormiumApi::class)
 
+import io.github.kormium.QueryException
+import io.github.kormium.SqliteDriver
 import io.github.kormium.autocommit
 import io.github.kormium.createSqliteDatabase
+import io.github.kormium.transaction
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 /**
- * Regression test for the default `:memory:` + `poolSize = 1` case sharing state process-wide
- * (https://github.com/kormium/kormium/issues/131): two independent [createSqliteDatabase] calls
- * must not see each other's data, even though both use the same default `":memory:"` path.
+ * `:memory:` isolation on JVM/native (https://github.com/kormium/kormium/issues/131). Both
+ * drivers used to open the same `file::memory:?cache=shared` URI, so unrelated
+ * [createSqliteDatabase] calls in one process silently shared one physical database — a "fresh"
+ * test database showing a neighbour's rows. Each call now gets its own name, which has to hold
+ * three ways at once: separate drivers are isolated, one driver's pool still shares a database
+ * across its connections, and an explicit URI can still opt back into sharing.
  */
 class SqliteMemoryIsolationTest {
 
+    private fun createTable(db: SqliteDriver, name: String) = db.autocommit {
+        executeUpdate("CREATE TABLE $name(x INTEGER)", params = emptyMap(), invalidates = emptyList())
+        executeUpdate("INSERT INTO $name(x) VALUES (1)", params = emptyMap(), invalidates = emptyList())
+    }
+
+    private fun countIn(db: SqliteDriver, name: String): Int =
+        db.autocommit {
+            execute("SELECT count(*) FROM $name", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) ?: 0 }
+        }.single()
+
     @Test
-    fun independentInstancesDoNotShareState() {
+    fun separateDriversDoNotShareState() {
         val a = createSqliteDatabase()
         val b = createSqliteDatabase()
         try {
-            a.autocommit {
-                executeUpdate("CREATE TABLE t(x INTEGER)", params = emptyMap(), invalidates = emptyList())
-            }
+            createTable(a, "iso_default")
+            // b never saw a's CREATE TABLE, so the table simply does not exist there.
+            assertFailsWith<QueryException> { countIn(b, "iso_default") }
+        } finally {
+            a.close()
+            b.close()
+        }
+    }
 
-            // b never saw a's CREATE TABLE, so querying it here must fail with "no such table"
-            // rather than see a's (nonexistent) rows.
-            assertFailsWith<Exception> {
-                b.autocommit { executeUpdate("SELECT * FROM t", params = emptyMap(), invalidates = emptyList()) }
+    @Test
+    fun separatePooledDriversDoNotShareState() {
+        val a = createSqliteDatabase(poolSize = 2)
+        val b = createSqliteDatabase(poolSize = 2)
+        try {
+            createTable(a, "iso_pooled")
+            assertFailsWith<QueryException> { countIn(b, "iso_pooled") }
+        } finally {
+            a.close()
+            b.close()
+        }
+    }
+
+    @Test
+    fun oneDriversPoolSharesOneDatabase() {
+        val db = createSqliteDatabase(poolSize = 2)
+        try {
+            createTable(db, "iso_pool_shared")
+            // The outer transaction pins one connection for its whole body, so the nested
+            // autocommit is forced onto the pool's *other* connection — which must see the
+            // database the first one created (a read, so no shared-cache table lock is held).
+            val seen = db.transaction {
+                execute("SELECT 1", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) }
+                countIn(db, "iso_pool_shared")
             }
+            assertEquals(1, seen)
+        } finally {
+            db.close()
+        }
+    }
+
+    @Test
+    fun explicitSharedUriOptsBackIntoSharing() {
+        // The documented escape hatch for callers who *want* one in-memory database behind
+        // several drivers. It lives as long as one of them is open.
+        val uri = "file:kormium-isolation-test?mode=memory&cache=shared"
+        val a = createSqliteDatabase(uri)
+        val b = createSqliteDatabase(uri)
+        try {
+            createTable(a, "iso_shared_uri")
+            assertEquals(1, countIn(b, "iso_shared_uri"))
         } finally {
             a.close()
             b.close()

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteObserveTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteObserveTest.kt
@@ -22,8 +22,8 @@ import kotlin.uuid.Uuid
  * to re-query and emit the new state. This exercises the whole chain — Scope dirty-table
  * tracking → WriteListeners.fire on commit → the flow's re-fetch.
  *
- * The query is filtered to a unique id so it is robust against the shared-cache `:memory:`
- * database other tests also use.
+ * The query is filtered to a unique id, matching the convention used across the SQLite test
+ * suite (each test class opens its own private in-memory database).
  */
 class SqliteObserveTest {
 

--- a/kormium-sqlite/src/commonTest/kotlin/SqliteSuspendTest.kt
+++ b/kormium-sqlite/src/commonTest/kotlin/SqliteSuspendTest.kt
@@ -16,7 +16,8 @@ import kotlin.uuid.Uuid
  * End-to-end test of the suspend path on a real backend (SQLite, JVM + Native). It
  * exercises [suspendTransaction] / [suspendAutocommit] → SuspendDatabase.useConnection
  * → the offload runner (SuspendExecutorAdapter on the IO dispatcher). Reuses the
- * top-level SqCatalog/Products/Product from SqliteIntegrationTest (shared-cache :memory:).
+ * top-level SqCatalog/Products/Product from SqliteIntegrationTest, but against its own
+ * private in-memory database.
  */
 class SqliteSuspendTest {
 

--- a/kormium-sqlite/src/jvmMain/kotlin/CreateSqliteDatabase.jvm.kt
+++ b/kormium-sqlite/src/jvmMain/kotlin/CreateSqliteDatabase.jvm.kt
@@ -2,6 +2,8 @@ package io.github.kormium
 
 import io.github.kormium.jdbc.JdbcDatabase
 import io.github.kormium.jdbc.SqlExceptionTranslator
+import java.sql.Connection
+import java.sql.DriverManager
 import java.sql.SQLException
 import kotlin.time.Duration
 
@@ -14,28 +16,35 @@ private val sqliteTranslator: SqlExceptionTranslator = { e: SQLException ->
 // (foreign_keys, busy_timeout, journal_mode) and unknown parameters, which it leaves on the
 // filename — so `mode`/`cache` still reach SQLite as URI parameters, and a `file:` filename
 // makes it open with SQLITE_OPEN_URI.
-private fun sqliteJdbcUrl(path: String): String = when {
-    // Shared cache so this driver's pool all sees one database, under a process-unique name so
-    // unrelated createSqliteDatabase() calls do not (issue #131). WAL is meaningless without a
-    // file, so it is omitted here.
-    path == ":memory:" ->
-        "jdbc:sqlite:file:${newInMemoryDatabaseName()}?mode=memory&cache=shared&foreign_keys=on&busy_timeout=5000"
-
-    // A caller-supplied SQLite URI — the way to opt back into one in-memory database shared by
-    // several drivers ("file:shared?mode=memory&cache=shared"). It carries its own parameters,
-    // so ours are appended instead of replacing the `?`; the pragmas are the same as for a
-    // plain path (journal_mode=WAL is simply a no-op on an in-memory database).
-    path.startsWith("file:") ->
-        "jdbc:sqlite:$path${if ('?' in path) "&" else "?"}journal_mode=WAL&foreign_keys=on&busy_timeout=5000"
-
-    // WAL gives concurrent readers alongside one writer; foreign_keys are OFF by
-    // default in SQLite, so enable them to surface ForeignKeyViolationException.
-    else -> "jdbc:sqlite:$path?journal_mode=WAL&foreign_keys=on&busy_timeout=5000"
+//
+// `:memory:` becomes a process-unique shared-cache URI: shared cache is what lets this driver's
+// pool see one database, but the plain `file::memory:?cache=shared` URI is identical for every
+// caller, so unrelated createSqliteDatabase() calls used to land on the same physical database
+// (issue #131). A caller's own `file:` URI is otherwise left as written — that is the way to opt
+// back into one in-memory database behind several drivers — and only the pragmas it does not
+// already set are appended.
+private fun sqliteJdbcUrl(path: String): String {
+    val filename = if (path == ":memory:") "file:${newInMemoryDatabaseName()}?mode=memory&cache=shared" else path
+    val callerParams = sqlitePathParams(filename)
+    // WAL gives concurrent readers alongside one writer (and is meaningless without a file);
+    // foreign keys are OFF by default in SQLite, so enable them to surface
+    // ForeignKeyViolationException. Anything the caller spelled out in the path wins.
+    val defaults = buildList {
+        if (!isInMemorySqlitePath(filename)) add("journal_mode" to "WAL")
+        add("foreign_keys" to "on")
+        add("busy_timeout" to "5000")
+    }.filterNot { (key, _) -> key in callerParams }
+    val appended = if (defaults.isEmpty()) {
+        ""
+    } else {
+        defaults.joinToString("&", prefix = if ('?' in filename) "&" else "?") { (key, value) -> "$key=$value" }
+    }
+    return "jdbc:sqlite:$filename$appended"
 }
 
-private class SqliteJdbcDriver(path: String, poolSize: Int, acquireTimeout: Duration, config: KormiumConfig) :
+private class SqliteJdbcDriver(jdbcUrl: String, poolSize: Int, acquireTimeout: Duration, config: KormiumConfig) :
     JdbcDatabase(
-        jdbcUrl = sqliteJdbcUrl(path),
+        jdbcUrl = jdbcUrl,
         poolSize = poolSize,
         acquireTimeout = acquireTimeout,
         dialect = SqliteDialect,
@@ -44,11 +53,39 @@ private class SqliteJdbcDriver(path: String, poolSize: Int, acquireTimeout: Dura
         translate = sqliteTranslator,
         config = config,
     ),
-    SqliteDriver
+    SqliteDriver {
+
+    // An in-memory database exists only while at least one connection to it is open, and HikariCP
+    // retires pooled connections behind our back (maxLifetime, 30 minutes by default; also on any
+    // fatal error). At the default poolSize = 1 that leaves an instant with no connection at all,
+    // which drops the database — the next caller silently gets an empty one. This connection is
+    // never pooled and never handed out; it exists to outlive that churn.
+    private val keepAlive: Connection? = openKeepAlive(jdbcUrl)
+
+    private fun openKeepAlive(jdbcUrl: String): Connection? {
+        if (!isInMemorySqlitePath(jdbcUrl)) return null
+        return try {
+            DriverManager.getConnection(jdbcUrl)
+        } catch (e: SQLException) {
+            super.close() // the pool is already up at this point; don't leak it
+            throw sqliteException(e.message ?: "SQL error", e.errorCode.takeIf { it != 0 }, e)
+        }
+    }
+
+    // The pool closes first: while it drains, the database must still exist. Closing the
+    // keep-alive last is what finally frees an in-memory database.
+    override fun close() {
+        try {
+            super.close()
+        } finally {
+            keepAlive?.close()
+        }
+    }
+}
 
 public actual fun createSqliteDatabase(
     path: String,
     poolSize: Int,
     acquireTimeout: Duration,
     config: KormiumConfig,
-): SqliteDriver = SqliteJdbcDriver(path, poolSize, acquireTimeout, config)
+): SqliteDriver = SqliteJdbcDriver(sqliteJdbcUrl(path), poolSize, acquireTimeout, config)

--- a/kormium-sqlite/src/jvmMain/kotlin/CreateSqliteDatabase.jvm.kt
+++ b/kormium-sqlite/src/jvmMain/kotlin/CreateSqliteDatabase.jvm.kt
@@ -10,27 +10,32 @@ private val sqliteTranslator: SqlExceptionTranslator = { e: SQLException ->
     sqliteException(e.message ?: "SQL error", e.errorCode.takeIf { it != 0 }, e)
 }
 
-private fun sqliteJdbcUrl(path: String, poolSize: Int): String =
-    if (path == ":memory:") {
-        // A single connection (the common case, e.g. tests) gets SQLite's default: a private
-        // in-memory database, so unrelated createSqliteDatabase() calls don't see each other's
-        // data. A pool needs cache=shared so its connections all see the same database — but
-        // that URI is identical across instances, so it would also leak across instances if
-        // poolSize were 1. WAL is meaningless without a file, so it is omitted here.
-        if (poolSize > 1) {
-            "jdbc:sqlite:file::memory:?cache=shared&foreign_keys=on&busy_timeout=5000"
-        } else {
-            "jdbc:sqlite::memory:?foreign_keys=on&busy_timeout=5000"
-        }
-    } else {
-        // WAL gives concurrent readers alongside one writer; foreign_keys are OFF by
-        // default in SQLite, so enable them to surface ForeignKeyViolationException.
-        "jdbc:sqlite:$path?journal_mode=WAL&foreign_keys=on&busy_timeout=5000"
-    }
+// sqlite-jdbc splits everything after the first `?` into pragmas it applies itself
+// (foreign_keys, busy_timeout, journal_mode) and unknown parameters, which it leaves on the
+// filename — so `mode`/`cache` still reach SQLite as URI parameters, and a `file:` filename
+// makes it open with SQLITE_OPEN_URI.
+private fun sqliteJdbcUrl(path: String): String = when {
+    // Shared cache so this driver's pool all sees one database, under a process-unique name so
+    // unrelated createSqliteDatabase() calls do not (issue #131). WAL is meaningless without a
+    // file, so it is omitted here.
+    path == ":memory:" ->
+        "jdbc:sqlite:file:${newInMemoryDatabaseName()}?mode=memory&cache=shared&foreign_keys=on&busy_timeout=5000"
+
+    // A caller-supplied SQLite URI — the way to opt back into one in-memory database shared by
+    // several drivers ("file:shared?mode=memory&cache=shared"). It carries its own parameters,
+    // so ours are appended instead of replacing the `?`; the pragmas are the same as for a
+    // plain path (journal_mode=WAL is simply a no-op on an in-memory database).
+    path.startsWith("file:") ->
+        "jdbc:sqlite:$path${if ('?' in path) "&" else "?"}journal_mode=WAL&foreign_keys=on&busy_timeout=5000"
+
+    // WAL gives concurrent readers alongside one writer; foreign_keys are OFF by
+    // default in SQLite, so enable them to surface ForeignKeyViolationException.
+    else -> "jdbc:sqlite:$path?journal_mode=WAL&foreign_keys=on&busy_timeout=5000"
+}
 
 private class SqliteJdbcDriver(path: String, poolSize: Int, acquireTimeout: Duration, config: KormiumConfig) :
     JdbcDatabase(
-        jdbcUrl = sqliteJdbcUrl(path, poolSize),
+        jdbcUrl = sqliteJdbcUrl(path),
         poolSize = poolSize,
         acquireTimeout = acquireTimeout,
         dialect = SqliteDialect,

--- a/kormium-sqlite/src/jvmMain/kotlin/CreateSqliteDatabase.jvm.kt
+++ b/kormium-sqlite/src/jvmMain/kotlin/CreateSqliteDatabase.jvm.kt
@@ -10,11 +10,18 @@ private val sqliteTranslator: SqlExceptionTranslator = { e: SQLException ->
     sqliteException(e.message ?: "SQL error", e.errorCode.takeIf { it != 0 }, e)
 }
 
-private fun sqliteJdbcUrl(path: String): String =
+private fun sqliteJdbcUrl(path: String, poolSize: Int): String =
     if (path == ":memory:") {
-        // Shared cache so a pool of connections all see the same in-memory database.
-        // WAL is meaningless without a file, so it is omitted here.
-        "jdbc:sqlite:file::memory:?cache=shared&foreign_keys=on&busy_timeout=5000"
+        // A single connection (the common case, e.g. tests) gets SQLite's default: a private
+        // in-memory database, so unrelated createSqliteDatabase() calls don't see each other's
+        // data. A pool needs cache=shared so its connections all see the same database — but
+        // that URI is identical across instances, so it would also leak across instances if
+        // poolSize were 1. WAL is meaningless without a file, so it is omitted here.
+        if (poolSize > 1) {
+            "jdbc:sqlite:file::memory:?cache=shared&foreign_keys=on&busy_timeout=5000"
+        } else {
+            "jdbc:sqlite::memory:?foreign_keys=on&busy_timeout=5000"
+        }
     } else {
         // WAL gives concurrent readers alongside one writer; foreign_keys are OFF by
         // default in SQLite, so enable them to surface ForeignKeyViolationException.
@@ -23,7 +30,7 @@ private fun sqliteJdbcUrl(path: String): String =
 
 private class SqliteJdbcDriver(path: String, poolSize: Int, acquireTimeout: Duration, config: KormiumConfig) :
     JdbcDatabase(
-        jdbcUrl = sqliteJdbcUrl(path),
+        jdbcUrl = sqliteJdbcUrl(path, poolSize),
         poolSize = poolSize,
         acquireTimeout = acquireTimeout,
         dialect = SqliteDialect,

--- a/kormium-sqlite/src/jvmTest/kotlin/SqliteInMemoryKeepAliveTest.kt
+++ b/kormium-sqlite/src/jvmTest/kotlin/SqliteInMemoryKeepAliveTest.kt
@@ -1,0 +1,72 @@
+@file:OptIn(io.github.kormium.DelicateKormiumApi::class)
+
+import io.github.kormium.SqliteDriver
+import io.github.kormium.autocommit
+import io.github.kormium.createSqliteDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * An in-memory SQLite database exists only while some connection to it is open, and HikariCP
+ * recycles pooled connections on its own schedule — `maxLifetime`, 30 minutes by default, plus
+ * eviction after a fatal error. At the default `poolSize = 1` that leaves an instant with no
+ * connection at all, which drops the database: a long-running process would silently find its
+ * cache empty half an hour in. The JVM driver therefore holds one unpooled connection open for
+ * its whole life.
+ *
+ * Waiting out `maxLifetime` is not a test, so this reaches into HikariCP and asks for the same
+ * eviction directly. Reflection keeps the pool internals out of Kormium's API — the alternative
+ * would be exposing a knob that exists only for this test.
+ */
+class SqliteInMemoryKeepAliveTest {
+
+    private fun softEvictPooledConnections(db: SqliteDriver) {
+        val dataSource = db.javaClass.superclass.getDeclaredField("ds")
+            .apply { isAccessible = true }
+            .get(db)
+        val poolBean = dataSource.javaClass.getMethod("getHikariPoolMXBean").invoke(dataSource)
+        Class.forName("com.zaxxer.hikari.HikariPoolMXBean")
+            .getMethod("softEvictConnections")
+            .invoke(poolBean)
+    }
+
+    private fun countIn(db: SqliteDriver, name: String): Int =
+        db.autocommit {
+            execute("SELECT count(*) FROM $name", params = emptyMap(), invalidates = emptyList()) { it.getInt(0) ?: 0 }
+        }.single()
+
+    @Test
+    fun inMemoryDatabaseSurvivesConnectionRecycling() {
+        val db = createSqliteDatabase()
+        try {
+            db.autocommit {
+                executeUpdate("CREATE TABLE keep_alive(x INTEGER)", params = emptyMap(), invalidates = emptyList())
+                executeUpdate("INSERT INTO keep_alive(x) VALUES (1)", params = emptyMap(), invalidates = emptyList())
+            }
+            softEvictPooledConnections(db)
+            assertEquals(1, countIn(db, "keep_alive"), "the database must outlive the pooled connection")
+        } finally {
+            db.close()
+        }
+    }
+
+    @Test
+    fun explicitlySharedInMemoryUriAlsoSurvives() {
+        val uri = "file:kormium-keep-alive-test?mode=memory&cache=shared"
+        val db = createSqliteDatabase(uri)
+        try {
+            db.autocommit {
+                executeUpdate("CREATE TABLE keep_alive_uri(x INTEGER)", params = emptyMap(), invalidates = emptyList())
+                executeUpdate(
+                    "INSERT INTO keep_alive_uri(x) VALUES (1)",
+                    params = emptyMap(),
+                    invalidates = emptyList(),
+                )
+            }
+            softEvictPooledConnections(db)
+            assertEquals(1, countIn(db, "keep_alive_uri"))
+        } finally {
+            db.close()
+        }
+    }
+}

--- a/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
+++ b/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
@@ -66,18 +66,17 @@ private class SqliteNativeDriver(
 
     private val isMemory = path == ":memory:"
 
-    // A single connection (the common case, e.g. tests) gets SQLite's default: a private
-    // in-memory database, so unrelated createSqliteDatabase() calls don't see each other's
-    // data. A pool needs cache=shared so its connections all see the same database — but that
-    // URI is identical across instances, so it would also leak across instances if poolSize
-    // were 1. A shared-cache URI filename then requires SQLITE_OPEN_URI.
-    private val useSharedCache = isMemory && poolSize > 1
-    private val filename = if (useSharedCache) "file::memory:?cache=shared" else path
+    // Shared cache so this driver's pool all sees one database, under a process-unique name so
+    // unrelated createSqliteDatabase() calls do not (issue #131). A caller may also pass their
+    // own "file:…" URI — the way to opt back into one in-memory database shared by several
+    // drivers. Either way a URI filename requires SQLITE_OPEN_URI.
+    private val isUri = isMemory || path.startsWith("file:")
+    private val filename = if (isMemory) "file:${newInMemoryDatabaseName()}?mode=memory&cache=shared" else path
 
     // A SQLite connection is handed to exactly one caller at a time via a Channel that
     // doubles as a blocking "free connection" queue — mirroring the libpq driver.
     private val connections: List<CPointer<sqlite3>> = List(poolSize) {
-        openConnection(filename, uri = useSharedCache).also { initPragmas(it, file = !isMemory) }
+        openConnection(filename, uri = isUri).also { initPragmas(it, file = !isMemory) }
     }
 
     private val pool = Channel<CPointer<sqlite3>>(poolSize).also { channel ->

--- a/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
+++ b/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
@@ -66,14 +66,18 @@ private class SqliteNativeDriver(
 
     private val isMemory = path == ":memory:"
 
-    // Shared cache so a pool of connections all see the same in-memory database; a URI
-    // filename then requires SQLITE_OPEN_URI.
-    private val filename = if (isMemory) "file::memory:?cache=shared" else path
+    // A single connection (the common case, e.g. tests) gets SQLite's default: a private
+    // in-memory database, so unrelated createSqliteDatabase() calls don't see each other's
+    // data. A pool needs cache=shared so its connections all see the same database — but that
+    // URI is identical across instances, so it would also leak across instances if poolSize
+    // were 1. A shared-cache URI filename then requires SQLITE_OPEN_URI.
+    private val useSharedCache = isMemory && poolSize > 1
+    private val filename = if (useSharedCache) "file::memory:?cache=shared" else path
 
     // A SQLite connection is handed to exactly one caller at a time via a Channel that
     // doubles as a blocking "free connection" queue — mirroring the libpq driver.
     private val connections: List<CPointer<sqlite3>> = List(poolSize) {
-        openConnection(filename, uri = isMemory).also { initPragmas(it, file = !isMemory) }
+        openConnection(filename, uri = useSharedCache).also { initPragmas(it, file = !isMemory) }
     }
 
     private val pool = Channel<CPointer<sqlite3>>(poolSize).also { channel ->

--- a/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
+++ b/kormium-sqlite/src/nativeMain/kotlin/CreateSqliteDatabase.native.kt
@@ -64,19 +64,23 @@ private class SqliteNativeDriver(
     private val typeMapper: TypeMapper = StandardTypeMapper
     override val writeListeners: WriteListeners = WriteListeners()
 
-    private val isMemory = path == ":memory:"
-
     // Shared cache so this driver's pool all sees one database, under a process-unique name so
     // unrelated createSqliteDatabase() calls do not (issue #131). A caller may also pass their
     // own "file:…" URI — the way to opt back into one in-memory database shared by several
     // drivers. Either way a URI filename requires SQLITE_OPEN_URI.
-    private val isUri = isMemory || path.startsWith("file:")
-    private val filename = if (isMemory) "file:${newInMemoryDatabaseName()}?mode=memory&cache=shared" else path
+    private val isUri = path == ":memory:" || path.startsWith("file:")
+    private val filename =
+        if (path == ":memory:") "file:${newInMemoryDatabaseName()}?mode=memory&cache=shared" else path
+
+    // Covers a caller's own in-memory URI too ("file:shared?mode=memory"), which has no more use
+    // for WAL than ":memory:" does. Pragmas the caller wrote into the path win over our defaults.
+    private val isMemory = isInMemorySqlitePath(filename)
+    private val pathParams = sqlitePathParams(filename)
 
     // A SQLite connection is handed to exactly one caller at a time via a Channel that
     // doubles as a blocking "free connection" queue — mirroring the libpq driver.
     private val connections: List<CPointer<sqlite3>> = List(poolSize) {
-        openConnection(filename, uri = isUri).also { initPragmas(it, file = !isMemory) }
+        openConnection(filename, uri = isUri).also { initPragmas(it, file = !isMemory, params = pathParams) }
     }
 
     private val pool = Channel<CPointer<sqlite3>>(poolSize).also { channel ->
@@ -328,8 +332,12 @@ private fun openConnection(filename: String, uri: Boolean): CPointer<sqlite3> = 
 // foreign_keys are OFF by default in SQLite; WAL only applies to a real file. busy_timeout
 // lets a blocked writer wait instead of failing immediately with SQLITE_BUSY.
 @OptIn(ExperimentalForeignApi::class)
-private fun initPragmas(conn: CPointer<sqlite3>, file: Boolean) {
-    if (file) sqlite3_exec(conn, "PRAGMA journal_mode=WAL", null, null, null)
-    sqlite3_exec(conn, "PRAGMA foreign_keys=ON", null, null, null)
-    sqlite3_exec(conn, "PRAGMA busy_timeout=5000", null, null, null)
+private fun initPragmas(conn: CPointer<sqlite3>, file: Boolean, params: Map<String, String>) {
+    // SQLite itself ignores unknown URI parameters, so journal_mode/foreign_keys/busy_timeout in
+    // a caller's "file:…" path only take effect because we read them back out here — which is
+    // also what sqlite-jdbc does with them on the JVM, keeping the two backends in step.
+    val journalMode = params["journal_mode"] ?: "WAL".takeIf { file }
+    if (journalMode != null) sqlite3_exec(conn, "PRAGMA journal_mode=$journalMode", null, null, null)
+    sqlite3_exec(conn, "PRAGMA foreign_keys=${params["foreign_keys"] ?: "ON"}", null, null, null)
+    sqlite3_exec(conn, "PRAGMA busy_timeout=${params["busy_timeout"] ?: "5000"}", null, null, null)
 }

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/kormium/kormium/actions/workflows/ci.yml/badge.svg)](https://github.com/kormium/kormium/actions/workflows/ci.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.kormium/kormium-core.svg)](https://central.sonatype.com/search?q=g%3Aio.github.kormium)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.4.0-blue.svg?logo=kotlin)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.4.10-blue.svg?logo=kotlin)](https://kotlinlang.org)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 Type-safe ORM and SQL DSL for Kotlin Multiplatform.

--- a/samples/cross-instance-cache/build.gradle.kts
+++ b/samples/cross-instance-cache/build.gradle.kts
@@ -47,7 +47,7 @@ kotlin {
                 implementation(project(":kormium-postgres"))
                 // rethis: a Kotlin Multiplatform Redis client (JVM + Native), so the Redis
                 // NotificationTransport runs on the same targets as kormium itself.
-                implementation("eu.vendeli:rethis:0.4.3")
+                implementation("eu.vendeli:rethis:0.4.4")
             }
         }
         val commonTest by getting {
@@ -55,9 +55,9 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
-                implementation("org.testcontainers:postgresql:1.20.4")
-                implementation("org.testcontainers:testcontainers:1.20.4")
-                implementation("org.postgresql:postgresql:42.7.4")
+                implementation("org.testcontainers:postgresql:1.21.4")
+                implementation("org.testcontainers:testcontainers:1.21.4")
+                implementation("org.postgresql:postgresql:42.7.13")
             }
         }
     }

--- a/samples/ktor-di/build.gradle.kts
+++ b/samples/ktor-di/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     kotlin("multiplatform")
-    kotlin("plugin.serialization") version "2.4.0"
+    kotlin("plugin.serialization") version "2.4.10"
 }
 
 group = "io.github.kormium.samples.ktordi"
@@ -15,7 +15,7 @@ repositories {
     }
 }
 
-val ktorVersion = "3.5.0"
+val ktorVersion = "3.5.2"
 
 kotlin {
     val hostOs = System.getProperty("os.name")
@@ -53,7 +53,7 @@ kotlin {
                 implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
                 implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
                 implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 
                 implementation(project(":kormium-postgres"))
                 // Reified call.transaction(Catalog){} resolving Database<G> from Ktor's built-in DI.
@@ -66,14 +66,14 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-server-netty:$ktorVersion")
-                implementation("org.slf4j:slf4j-simple:2.0.16")
+                implementation("org.slf4j:slf4j-simple:2.0.18")
             }
         }
         val jvmTest by getting {
             dependencies {
                 implementation("io.ktor:ktor-server-test-host:$ktorVersion")
-                implementation("org.testcontainers:postgresql:1.20.4")
-                implementation("org.postgresql:postgresql:42.7.4")
+                implementation("org.testcontainers:postgresql:1.21.4")
+                implementation("org.postgresql:postgresql:42.7.13")
             }
         }
         if (!hostOs.contains("windows", ignoreCase = true)) {

--- a/samples/ktor-koin/build.gradle.kts
+++ b/samples/ktor-koin/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     kotlin("multiplatform")
-    kotlin("plugin.serialization") version "2.4.0"
+    kotlin("plugin.serialization") version "2.4.10"
 }
 
 group = "io.github.kormium.samples.ktorkoin"
@@ -15,7 +15,7 @@ repositories {
     }
 }
 
-val ktorVersion = "3.5.0"
+val ktorVersion = "3.5.2"
 
 kotlin {
     val hostOs = System.getProperty("os.name")
@@ -53,7 +53,7 @@ kotlin {
                 implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
                 implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
                 implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 
                 implementation(project(":kormium-postgres"))
                 // Reified call.transaction(Catalog){} resolving Database<G> from Koin.
@@ -66,14 +66,14 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-server-netty:$ktorVersion")
-                implementation("org.slf4j:slf4j-simple:2.0.16")
+                implementation("org.slf4j:slf4j-simple:2.0.18")
             }
         }
         val jvmTest by getting {
             dependencies {
                 implementation("io.ktor:ktor-server-test-host:$ktorVersion")
-                implementation("org.testcontainers:postgresql:1.20.4")
-                implementation("org.postgresql:postgresql:42.7.4")
+                implementation("org.testcontainers:postgresql:1.21.4")
+                implementation("org.postgresql:postgresql:42.7.13")
             }
         }
         if (!hostOs.contains("windows", ignoreCase = true)) {

--- a/samples/r2dbc/build.gradle.kts
+++ b/samples/r2dbc/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("multiplatform")
-    kotlin("plugin.serialization") version "2.4.0"
+    kotlin("plugin.serialization") version "2.4.10"
 }
 
 group = "io.github.kormium.samples.r2dbc"
@@ -13,7 +13,7 @@ repositories {
     }
 }
 
-val ktorVersion = "3.5.0"
+val ktorVersion = "3.5.2"
 
 // JVM-only: r2dbc (and kormium-r2dbc) are JVM-only, so this sample has no native target.
 kotlin {
@@ -35,8 +35,8 @@ kotlin {
                 implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
                 implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
                 implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
-                implementation("org.slf4j:slf4j-simple:2.0.16")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
+                implementation("org.slf4j:slf4j-simple:2.0.18")
 
                 // The async (non-blocking) Postgres backend...
                 implementation(project(":kormium-r2dbc"))
@@ -49,7 +49,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation("io.ktor:ktor-server-test-host:$ktorVersion")
-                implementation("org.testcontainers:postgresql:1.20.4")
+                implementation("org.testcontainers:postgresql:1.21.4")
             }
         }
     }

--- a/samples/repository/build.gradle.kts
+++ b/samples/repository/build.gradle.kts
@@ -51,7 +51,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
             }
         }
     }

--- a/samples/repository/src/commonTest/kotlin/RepositoryTest.kt
+++ b/samples/repository/src/commonTest/kotlin/RepositoryTest.kt
@@ -17,14 +17,11 @@ import kotlin.test.assertEquals
 /** Runs on JVM and native (SQLite is self-contained). */
 class RepositoryTest {
 
-    // The default :memory: database is shared across this module's test run, so each test
-    // sets up the schema and clears the tables to stay independent.
+    // Every createSqliteDatabase() call opens its own private in-memory database, so a test only
+    // has to create the schema — there is nothing left over from the previous one to clear.
     private suspend fun freshDb(): SuspendDatabase<Shop> {
         val db: SuspendDatabase<Shop> = createSqliteDatabase()
-        db.suspendTransaction {
-            Users.execSql(usersDdl); Orders.execSql(ordersDdl)
-            Users.deleteWhere { }; Orders.deleteWhere { }
-        }
+        db.suspendTransaction { Users.execSql(usersDdl); Orders.execSql(ordersDdl) }
         return db
     }
 
@@ -43,6 +40,7 @@ class RepositoryTest {
         ShopService(db, users, orders).register(user(4, "Dave", 22), order(100, userId = 4, total = 50))
         assertEquals(listOf(100), orders.all().map { it.id })           // cross-repo tx committed
         assertEquals(setOf("Alice", "Dave"), users.adults().map { it.name }.toSet())
+        db.close()
     }
 
     @Test

--- a/samples/sharding/README.md
+++ b/samples/sharding/README.md
@@ -8,9 +8,9 @@ A standalone console app (over **SQLite**, no external database) showing two thi
 - **Sharding** — one catalog (`AccountsCatalog`) spread across several `Database` instances,
   routed by key (`id % shards`).
 
-Each shard is its own SQLite **file** in the system temp dir: Kormium opens `:memory:` in
-shared-cache mode, so two `:memory:` handles would be the *same* database, not two shards. The
-files (and their WAL sidecars) are cleaned up on exit.
+Each shard is its own in-memory SQLite database: every `createSqliteDatabase()` call opens a
+fresh one, so no two shards share storage. Pass a file path instead to make a shard outlive the
+process.
 
 ## Run
 

--- a/samples/sharding/build.gradle.kts
+++ b/samples/sharding/build.gradle.kts
@@ -45,7 +45,7 @@ kotlin {
             dependencies {
                 implementation(project(":kormium-sqlite"))
                 // For a temp dir + file cleanup that works on both JVM and native.
-                implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.9.1")
             }
         }
         val commonTest by getting {

--- a/samples/sharding/src/commonMain/kotlin/Main.kt
+++ b/samples/sharding/src/commonMain/kotlin/Main.kt
@@ -11,9 +11,6 @@ import io.github.kormium.createSqliteDatabase
 import io.github.kormium.database.Database
 import io.github.kormium.eq
 import io.github.kormium.transaction
-import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
-import kotlinx.io.files.SystemTemporaryDirectory
 
 // --- Two independent catalogs -------------------------------------------------
 // A Catalog is a marker type. A Table is tagged with its catalog, and so is the
@@ -64,11 +61,10 @@ class ShardedAccounts(private val shards: List<Database<AccountsCatalog>>) {
 private fun account(id: Int, owner: String) = Account().apply { this.id = id; this.owner = owner }
 
 fun main() {
-    // Two shards for AccountsCatalog, each its OWN database. They must be distinct files:
-    // Kormium opens ":memory:" in shared-cache mode, so two ":memory:" handles would be the same
-    // database — not two shards. AuditCatalog is a separate (in-memory) database.
-    val shardPaths = List(2) { Path(SystemTemporaryDirectory, "kormium-shard-$it.db") }
-    val shards: List<Database<AccountsCatalog>> = shardPaths.map { createSqliteDatabase(it.toString()) }
+    // Two shards for AccountsCatalog, each its OWN database: every createSqliteDatabase() call
+    // opens a fresh in-memory database, so the shards never share storage (use file paths to
+    // make them outlive the process). AuditCatalog is a third, independent database.
+    val shards: List<Database<AccountsCatalog>> = List(2) { createSqliteDatabase() }
     val auditDb: Database<AuditCatalog> = createSqliteDatabase()
 
     try {
@@ -90,12 +86,6 @@ fun main() {
     } finally {
         shards.forEach { it.close() }
         auditDb.close()
-        // Best-effort cleanup of the shard files (WAL also leaves -wal / -shm sidecars).
-        shardPaths.forEach { p ->
-            listOf(p.toString(), "${p}-wal", "${p}-shm").forEach { f ->
-                runCatching { SystemFileSystem.delete(Path(f), mustExist = false) }
-            }
-        }
     }
 }
 

--- a/samples/sharding/src/commonTest/kotlin/ShardingTest.kt
+++ b/samples/sharding/src/commonTest/kotlin/ShardingTest.kt
@@ -6,21 +6,15 @@ import io.github.kormium.autocommit
 import io.github.kormium.createSqliteDatabase
 import io.github.kormium.database.Database
 import io.github.kormium.transaction
-import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
-import kotlinx.io.files.SystemTemporaryDirectory
-import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-/** Runs on both JVM and native; shards are distinct SQLite files in the temp dir. */
+/** Runs on both JVM and native; each shard is its own in-memory SQLite database. */
 class ShardingTest {
 
     @Test
     fun shardingAndCatalogs() {
-        val tag = Random.nextInt(0, Int.MAX_VALUE)
-        val shardPaths = List(2) { Path(SystemTemporaryDirectory, "kormium-shard-test-$tag-$it.db") }
-        val shards: List<Database<AccountsCatalog>> = shardPaths.map { createSqliteDatabase(it.toString()) }
+        val shards: List<Database<AccountsCatalog>> = List(2) { createSqliteDatabase() }
         val auditDb: Database<AuditCatalog> = createSqliteDatabase()
 
         try {
@@ -40,11 +34,6 @@ class ShardingTest {
         } finally {
             shards.forEach { it.close() }
             auditDb.close()
-            shardPaths.forEach { p ->
-                listOf(p.toString(), "$p-wal", "$p-shm").forEach { f ->
-                    runCatching { SystemFileSystem.delete(Path(f), mustExist = false) }
-                }
-            }
         }
     }
 }

--- a/samples/sqlite-cache/build.gradle.kts
+++ b/samples/sqlite-cache/build.gradle.kts
@@ -53,8 +53,8 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
-                implementation("org.testcontainers:postgresql:1.20.4")
-                implementation("org.postgresql:postgresql:42.7.4")
+                implementation("org.testcontainers:postgresql:1.21.4")
+                implementation("org.postgresql:postgresql:42.7.13")
             }
         }
         // The native Postgres driver now ships inside :kormium-postgres (nativeMain).

--- a/samples/wasm-todo/build.gradle.kts
+++ b/samples/wasm-todo/build.gradle.kts
@@ -30,9 +30,9 @@ kotlin {
                 implementation(compose.material3)
                 implementation(compose.ui)
 
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-browser:0.3")
+                implementation("org.jetbrains.kotlinx:kotlinx-browser:0.5.0")
             }
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "kormium"


### PR DESCRIPTION
Builds on @Beutlin's #139 — their commit is kept as the first one here, with the fix carried the rest of the way.

## The bug

Both JVM and Native opened `":memory:"` as `file::memory:?cache=shared`. That URI is identical for every caller, so unrelated `createSqliteDatabase()` calls in one process — two test fixtures, two shards — silently read and wrote the same physical database. Fixes #131.

## The fix

#139 keyed the shared cache off `poolSize`: private database at `poolSize = 1`, shared cache above it. That fixes the common case but leaves the identical bug at `poolSize > 1`, where the URI is still the same for everyone — two pooled drivers keep sharing state.

Naming each database instead fixes both at once and needs no branch on `poolSize`:

```
file:kormium-mem-<N>?mode=memory&cache=shared
```

Shared cache still does its real job — one driver's pool all sees one database — while different drivers land on different names. The counter is process-local, which is exactly the scope that matters: shared-cache in-memory databases never cross a process.

## An in-memory database no longer vanishes after 30 minutes

The follow-up this PR originally deferred is fixed here too, because it is the same seam. SQLite frees an in-memory database as soon as its last connection closes, and HikariCP recycles pooled connections on its own schedule (`maxLifetime`, 30 minutes by default; also after a fatal error). At the default `poolSize = 1` that leaves an instant with no connection at all, so a long-running JVM process silently found every table empty half an hour in — before this branch as much as after it.

Reproduced against the real stack (HikariCP 6.2.1 + sqlite-jdbc, `maxLifetime` lowered to its 30 s minimum):

```
10s: rows = 1
20s: rows = 1
30s: LOST -> [SQLITE_ERROR] no such table: t
40s..90s: LOST
```

The JVM driver now holds one unpooled connection open for as long as the driver is open, closed after the pool drains. Native was never affected — its connections live as long as the driver.

## Pragmas written into the path are honoured

`file:` paths pass through to SQLite as URIs (`SQLITE_OPEN_URI` on Native, a `file:` filename on JVM) — that is the escape hatch for deliberately sharing one in-memory database between drivers:

```kotlin
createSqliteDatabase("file:shared?mode=memory&cache=shared")
```

Kormium's own `journal_mode` / `foreign_keys` / `busy_timeout` were appended last and so silently overrode a caller who spelled them out. Now the caller's value wins on both backends: the JVM simply does not append the parameter (sqlite-jdbc applies the caller's), Native reads it back out of the URI and issues it as the `PRAGMA` — SQLite itself ignores these as URI parameters, so that read-back is what makes them work at all.

Android rejects `file:` paths outright: androidx.sqlite opens without `SQLITE_OPEN_URI`, so the URI would have quietly created a *file* named `file:shared?mode=memory&cache=shared`.

## Tests

`SqliteMemoryIsolationTest` covers the properties that have to hold together, asserted positively — the same table in both databases, the row in only one — rather than by expecting a failure in the second database, which would also "pass" if that driver were broken some other way:

- separate drivers are isolated (default, and at `poolSize = 2`);
- one driver's pool still shares a database across its connections — checked by pinning one connection in a `transaction { }` so the nested read is forced onto the other;
- an explicit shared URI still shares;
- a caller's `busy_timeout` survives to `PRAGMA busy_timeout`, and Kormium's defaults still apply when the caller says nothing.

`SqliteInMemoryKeepAliveTest` (JVM) asks HikariCP for the eviction directly instead of waiting out `maxLifetime`; both of its cases fail with the keep-alive removed.

## Also in this PR

- **Version bumped to 0.12.0.** Two `createSqliteDatabase()` calls no longer sharing a database is a behaviour change to a released API, so this cycle is a minor release, not a patch. The CHANGELOG carries a Migration section with the one-line fix.
- **Toolchain and dependency updates.** Kotlin 2.4.0 → 2.4.10 (Kotlin/Native, the Compose compiler and serialization plugins, and the CI konan cache keys follow), AGP 9.3.1, coroutines 1.11.0, serialization 1.11.0, kotlinx-io 0.9.1, kotlinx-browser 0.5.0, Ktor 3.5.2, Koin 4.2.2, androidx.sqlite 2.7.0, sqlite-jdbc 3.53.2.1, HikariCP 7.1.0, pgjdbc 42.7.13, r2dbc-postgresql 1.1.2, r2dbc-mysql 1.4.3, SLF4J 2.0.18, kotlin-logging 8.0.4, Testcontainers 1.21.4, plus the publishing and foojay Gradle plugins. Benchmarks only: Exposed 1.4.0, Hibernate 7.4.6. HikariCP and pgjdbc had drifted to two different versions across modules; both are single-valued again.

  Two of those needed the code to follow, neither visible to callers: r2dbc-postgresql 1.1 declares its API with JSpecify, so `NumericAsTextCodec.decode` is explicitly nullable and the annotations are on the compile classpath (the driver ships them `provided`); the comparison benchmark follows Exposed's move to `kotlin.uuid.Uuid` and top-level expression builders.

  Left alone deliberately: MySQL Connector/J and Testcontainers 2.x (majors whose tests need Docker), and the npm dependencies (a version change there needs `kotlin-js-store/wasm/yarn.lock` regenerated, and Kotlin 2.4.10's managed Node 25 has no better-sqlite3 prebuild, so it builds from source — worth watching in the wasm/node job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
