### PR TITLE
0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ All notable changes to Kormium are documented here. The format is based on
 
 ## [Unreleased]
 
-> The SQLite in-memory change below alters the behaviour of a released API, so the next release
-> is **0.12.0**, not a patch. See *Migration* at the end of this section.
+## [0.12.0] — In-memory SQLite databases are private per driver
+
+> Behaviour change to a released API: two `createSqliteDatabase()` calls no longer land on the
+> same in-memory database. See *Migration* at the end of this section.
 
 ### Fixed
 - **`createSqliteDatabase(":memory:")` is no longer shared process-wide.** JVM and Native opened


### PR DESCRIPTION
Cuts the changelog for **0.12.0**. The version itself was bumped in #140, so this is the changelog heading and nothing else.

Release contents:

- `createSqliteDatabase(":memory:")` is private per driver again (#131) — the headline behaviour change, with a Migration section for anyone who relied on the accidental process-wide sharing.
- An in-memory database on the JVM no longer disappears when HikariCP recycles the pooled connection (`maxLifetime`, 30 min by default).
- Pragmas written into a `file:` path win over Kormium's defaults; Android rejects `file:` URIs instead of creating a file by that name.
- Toolchain and dependency refresh: Kotlin 2.4.10, AGP 9.3.1, coroutines 1.11.0, Ktor 3.5.2, Koin 4.2.2, HikariCP 7.1.0, sqlite-jdbc 3.53.2.1, pgjdbc 42.7.13, r2dbc-postgresql 1.1.2, kotlin-logging 8.0.4 and friends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)