### PR TITLE
Move the tested PostgreSQL baseline to 18, clean up libpq.def

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:18
         env:
           POSTGRES_PASSWORD: password
           POSTGRES_DB: postgres

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to Kormium are documented here. The format is based on
 
 ## [Unreleased]
 
+### Changed
+- **The tested PostgreSQL baseline moves from 16 to 18.** CI's service container, every
+  Testcontainers fixture, the benchmark harness and the sample `docker-compose.yml` files now run
+  `postgres:18` (`pgvector/pgvector:pg18` for the vector suite). The benchmark containers pin
+  `PGDATA=/var/lib/postgresql/data` explicitly, because the PostgreSQL 18 image moved its default
+  data directory and the tmpfs mount the benchmarks rely on would otherwise go unused. No driver
+  code changed: `libpq` itself is not vendored or version-pinned — the cinterop links whatever the
+  platform's package manager provides, and every libpq entry point the native driver calls has
+  been available since PostgreSQL 9.
+- **`libpq.def` path cleanup.** Dropped the dead `/usr/lib/postgresql/13/lib` search path
+  (PostgreSQL 13 went EOL in November 2025), fixed a malformed linuxbrew `-L` path, removed a
+  stray `-lpq` from `compilerOpts` (it is a linker flag), and extended the Windows include search
+  to `C:\Program Files\PostgreSQL\14..18` so it matches the range
+  `kormium-postgres/build.gradle.kts` scans for the link-time artifact.
+
 ## [0.12.0] — In-memory SQLite databases are private per driver
 
 > Behaviour change to a released API: two `createSqliteDatabase()` calls no longer land on the

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -100,7 +100,7 @@ come from a single timed run without an error estimate — treat them as coarser
 ## Methodology and stability
 
 - JMH 1.37; per benchmark: 2 forks, 5×2s warmup + 5×2s measurement, fixed 2 GiB heap.
-- PostgreSQL (`postgres:16-alpine`) keeps its data directory on tmpfs and runs with
+- PostgreSQL (`postgres:18-alpine`) keeps its data directory on tmpfs and runs with
   `fsync`, `synchronous_commit` and `full_page_writes` off. The benchmarks measure
   ORM/driver overhead, not disk latency — disk is by far the noisiest component,
   especially under Docker on macOS. All ORMs get the same database.

--- a/benchmarks/run.bat
+++ b/benchmarks/run.bat
@@ -36,7 +36,7 @@ if not exist "%RESULTS_DIR%" mkdir "%RESULTS_DIR%"
 
 echo ==^> Starting PostgreSQL (tmpfs, durability off) on port %PORT%
 docker rm -f %CONTAINER% >nul 2>&1
-docker run -d --name %CONTAINER% -e POSTGRES_PASSWORD=password -p %PORT%:5432 --tmpfs /var/lib/postgresql/data postgres:16-alpine postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off >nul
+docker run -d --name %CONTAINER% -e POSTGRES_PASSWORD=password -e PGDATA=/var/lib/postgresql/data -p %PORT%:5432 --tmpfs /var/lib/postgresql/data postgres:18-alpine postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off >nul
 if errorlevel 1 (
   echo ERROR: failed to start the PostgreSQL container - is Docker Desktop running? 1>&2
   exit /b 1

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -29,8 +29,9 @@ docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
 docker run -d --name "$CONTAINER" \
   -e POSTGRES_PASSWORD=password \
   -p "$PORT:5432" \
+  -e PGDATA=/var/lib/postgresql/data \
   --tmpfs /var/lib/postgresql/data \
-  postgres:16-alpine \
+  postgres:18-alpine \
   postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off >/dev/null
 trap 'docker rm -f "$CONTAINER" >/dev/null 2>&1 || true' EXIT
 until docker exec "$CONTAINER" pg_isready -U postgres >/dev/null 2>&1; do sleep 0.5; done

--- a/benchmarks/src/jmh/kotlin/ComparisonBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/ComparisonBenchmark.kt
@@ -140,7 +140,11 @@ open class ComparisonBenchmark {
             // tmpfs data dir + durability off: these benchmarks measure ORM/driver overhead,
             // not disk fsync latency, and disk is by far the noisiest component (especially
             // Docker on macOS). All three ORMs get the same treatment.
-            container = PostgreSQLContainer("postgres:16-alpine").apply {
+            container = PostgreSQLContainer("postgres:18-alpine").apply {
+                // PostgreSQL 18's image moved the default PGDATA out of
+                // /var/lib/postgresql/data; pin it back so the tmpfs mount below actually
+                // holds the data directory.
+                withEnv("PGDATA", "/var/lib/postgresql/data")
                 withTmpFs(mapOf("/var/lib/postgresql/data" to "rw"))
                 withCommand("postgres", "-c", "fsync=off", "-c", "synchronous_commit=off", "-c", "full_page_writes=off")
                 start()

--- a/benchmarks/src/jmh/kotlin/KormiumBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/KormiumBenchmark.kt
@@ -67,7 +67,10 @@ open class KormiumBenchmark {
         Class.forName("org.postgresql.Driver")
         // Same stability setup as ComparisonBenchmark: tmpfs data dir and durability off, so
         // we measure ORM/driver overhead rather than disk fsync latency.
-        container = PostgreSQLContainer("postgres:16-alpine").apply {
+        container = PostgreSQLContainer("postgres:18-alpine").apply {
+            // PostgreSQL 18's image moved the default PGDATA out of /var/lib/postgresql/data;
+            // pin it back so the tmpfs mount below actually holds the data directory.
+            withEnv("PGDATA", "/var/lib/postgresql/data")
             withTmpFs(mapOf("/var/lib/postgresql/data" to "rw"))
             withCommand("postgres", "-c", "fsync=off", "-c", "synchronous_commit=off", "-c", "full_page_writes=off")
             start()

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -15,7 +15,7 @@ avoid unnecessary churn and document breaking changes in [CHANGELOG.md](../CHANG
 | JDK | 21+ |
 | Kotlin | 2.4.x project line |
 | Gradle | Gradle wrapper in the repository |
-| PostgreSQL | Tested with PostgreSQL 16 in CI/sample infrastructure |
+| PostgreSQL | Tested with PostgreSQL 18 in CI/sample infrastructure |
 | MySQL / MariaDB | JDBC (`mysql-connector-j`), native (`libmariadb`) and r2dbc; driver versions pinned in Gradle files |
 | SQLite | Driver versions pinned in Gradle files |
 | Ktor | Version pinned in Ktor module Gradle files |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,7 +71,7 @@ sudo apt-get install libpq-dev
 Windows Native (mingwX64) is experimental: CI runs the JVM and native test suites on a
 Windows runner. Install a Windows libpq via MSYS2
 (`pacman -S mingw-w64-x86_64-postgresql`) or an EDB PostgreSQL distribution; the cinterop
-searches `C:/msys64/mingw64` and `C:\Program Files\PostgreSQL\15..17`. For other
+searches `C:/msys64/mingw64` and `C:\Program Files\PostgreSQL\14..18`. For other
 layouts pass `-Plibpq.include=<dir>` and `-Plibpq.lib=<dir>` to Gradle.
 
 ### SQLite Native

--- a/docs/tables-and-entities.md
+++ b/docs/tables-and-entities.md
@@ -155,7 +155,7 @@ CREATE TABLE docs (id uuid PRIMARY KEY, embedding vector(1536) NOT NULL);
 ```
 
 > **pgvector is a third-party extension, not part of core PostgreSQL** — it ships with no standard
-> distribution. Install the binary first (an OS package like `postgresql-16-pgvector`, the
+> distribution. Install the binary first (an OS package like `postgresql-18-pgvector`, the
 > `pgvector/pgvector` Docker image, or enabling it on a managed service such as RDS/Cloud SQL/Supabase),
 > then run `CREATE EXTENSION vector`. Without the installed binary that statement fails with
 > "could not open extension control file".

--- a/kormium-postgres/build.gradle.kts
+++ b/kormium-postgres/build.gradle.kts
@@ -24,7 +24,8 @@ kotlin {
     // The libpq artifact Windows test binaries link against, preferring the dynamic
     // library: import lib, then the DLL itself (lld links DLLs directly), then the MSVC
     // import lib. -Plibpq.lib=<dir> (set by benchmarks/run.bat) takes precedence over
-    // the known MSYS2 / EDB install locations.
+    // the known MSYS2 / EDB install locations. The 18..14 range mirrors the include paths
+    // in src/nativeInterop/cinterop/libpq.def — keep the two in sync.
     val windowsLibpqArtifact: String? by lazy {
         val roots = listOfNotNull((findProperty("libpq.lib") as String?)?.let { file(it).parentFile }) +
             listOf(file("C:/msys64/mingw64")) +

--- a/kormium-postgres/src/jvmTest/kotlin/PgNotificationIntegrationTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/PgNotificationIntegrationTest.kt
@@ -38,7 +38,7 @@ class PgNotificationIntegrationTest {
     @Test
     fun commitOnOneInstanceNotifiesAnother() {
         assumeTrue(DockerClientFactory.instance().isDockerAvailable, "Docker is not available")
-        val container = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+        val container = PostgreSQLContainer("postgres:18-alpine").apply { start() }
         try {
             fun connect() = createDatabase(
                 host = container.host,

--- a/kormium-postgres/src/jvmTest/kotlin/PgVectorIntegrationTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/PgVectorIntegrationTest.kt
@@ -100,7 +100,7 @@ private class Doc : Entity() {
 /** A JDBC driver against a pgvector container started once for this suite, with the schema created. */
 private object VecDb : io.github.kormium.database.Database<VecCatalog> {
     private val container =
-        PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg16").asCompatibleSubstituteFor("postgres"))
+        PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18").asCompatibleSubstituteFor("postgres"))
             .apply { start() }
 
     private val driver = createDatabase(

--- a/kormium-postgres/src/jvmTest/kotlin/StabilityTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/StabilityTest.kt
@@ -57,7 +57,7 @@ class StabilityTest {
     @Test
     fun poolRecoversAfterDatabaseRestart() {
         assumeDocker()
-        val container = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+        val container = PostgreSQLContainer("postgres:18-alpine").apply { start() }
         try {
             createDatabase(
                 host = container.host,

--- a/kormium-postgres/src/jvmTest/kotlin/TableIntegrationTest.kt
+++ b/kormium-postgres/src/jvmTest/kotlin/TableIntegrationTest.kt
@@ -586,7 +586,7 @@ object ItProducts : Table<ItCatalog, ItProduct>("it_products", ::ItProduct) {
  * backed by a Postgres container started once for the test run.
  */
 object ItDatabase : Database<ItCatalog> {
-    private val container = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+    private val container = PostgreSQLContainer("postgres:18-alpine").apply { start() }
 
     private val driver = createDatabase(
         host = container.host,

--- a/kormium-postgres/src/nativeInterop/cinterop/libpq.def
+++ b/kormium-postgres/src/nativeInterop/cinterop/libpq.def
@@ -4,14 +4,16 @@ package = libpq
 #staticLibraries = libpq.a
 #libraryPaths = /opt/homebrew/opt/libpq/lib
 
-compilerOpts.osx = -I/opt/homebrew/opt/libpq/include -I/usr/local/opt/libpq/include -lpq
+compilerOpts.osx = -I/opt/homebrew/opt/libpq/include -I/usr/local/opt/libpq/include
 linkerOpts.osx = -L/opt/homebrew/opt/libpq/lib -L/usr/local/opt/libpq/lib -lpq
 
-compilerOpts.linux = -I/usr/include/postgresql/ -I/home/linuxbrew/.linuxbrew/opt/libpq/include -I/opt/homebrew/opt/libpq/include -I/usr/local/opt/libpq/include -lpq
-linkerOpts.linux = -L/usr/lib/x86_64-linux-gnu -L/usr/lib/postgresql/13/lib -L/home/linuxbrew/.linuxbrew/opt/libpq/libpkg-config -L/opt/homebrew/opt/libpq/lib -L/usr/local/opt/libpq/lib -lpq
+compilerOpts.linux = -I/usr/include/postgresql/ -I/home/linuxbrew/.linuxbrew/opt/libpq/include -I/opt/homebrew/opt/libpq/include -I/usr/local/opt/libpq/include
+linkerOpts.linux = -L/usr/lib/x86_64-linux-gnu -L/home/linuxbrew/.linuxbrew/opt/libpq/lib -L/opt/homebrew/opt/libpq/lib -L/usr/local/opt/libpq/lib -lpq
 
 # Windows: MSYS2 mingw64 libpq (pacman -S mingw-w64-x86_64-postgresql) or an EDB
-# PostgreSQL install. The unix paths at the end let the klib cross-compile from
+# PostgreSQL install. The version range here mirrors the one kormium-postgres/build.gradle.kts
+# scans for the link-time artifact (18 down to 14 — PostgreSQL 13 went EOL in November 2025);
+# keep the two in sync. The unix paths at the end let the klib cross-compile from
 # macOS/Linux CI hosts — libpq-fe.h is platform-neutral, and only the final link of a
 # Windows executable needs the real Windows libpq.
 #
@@ -20,5 +22,5 @@ linkerOpts.linux = -L/usr/lib/x86_64-linux-gnu -L/usr/lib/postgresql/13/lib -L/h
 # time (duplicate pthread_* symbols). kormium-postgres/build.gradle.kts picks the
 # dynamic artifact (libpq.dll.a / libpq.dll / libpq.lib) explicitly on Windows hosts.
 compilerOpts.mingw = -IC:/msys64/mingw64/include \
-    -I"C:\Program Files\PostgreSQL\18\include" -I"C:\Program Files\PostgreSQL\17\include" -I"C:\Program Files\PostgreSQL\16\include" -I"C:\Program Files\PostgreSQL\15\include" \
+    -I"C:\Program Files\PostgreSQL\18\include" -I"C:\Program Files\PostgreSQL\17\include" -I"C:\Program Files\PostgreSQL\16\include" -I"C:\Program Files\PostgreSQL\15\include" -I"C:\Program Files\PostgreSQL\14\include" \
     -I/opt/homebrew/opt/libpq/include -I/usr/local/opt/libpq/include -I/usr/include/postgresql/

--- a/kormium-r2dbc/src/jvmTest/kotlin/R2dbcNotificationIntegrationTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/R2dbcNotificationIntegrationTest.kt
@@ -38,7 +38,7 @@ class R2dbcNotificationIntegrationTest {
     @Test
     fun commitOnOneInstanceNotifiesAnother() {
         assumeTrue(DockerClientFactory.instance().isDockerAvailable, "Docker is not available")
-        val container = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+        val container = PostgreSQLContainer("postgres:18-alpine").apply { start() }
         try {
             fun connect() = createR2dbcDatabase(
                 host = container.host,

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcCancellationTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcCancellationTest.kt
@@ -36,7 +36,7 @@ class R2dbcCancellationTest {
     @BeforeTest
     fun setUp() {
         if (!dockerAvailable) return
-        val pg = PostgreSQLContainer("postgres:16-alpine")
+        val pg = PostgreSQLContainer("postgres:18-alpine")
         pg.start()
         container = pg
         db = createR2dbcDatabase(

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcDecimalInstantTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcDecimalInstantTest.kt
@@ -37,7 +37,7 @@ class R2dbcDecimalInstantTest {
     @BeforeTest
     fun setUp() {
         if (!dockerAvailable) return
-        val pg = PostgreSQLContainer("postgres:16-alpine")
+        val pg = PostgreSQLContainer("postgres:18-alpine")
         pg.start()
         container = pg
         db = createR2dbcDatabase(

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcEdgeCaseTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcEdgeCaseTest.kt
@@ -45,7 +45,7 @@ class R2dbcEdgeCaseTest {
     @BeforeTest
     fun setUp() {
         if (!dockerAvailable) return
-        val pg = PostgreSQLContainer("postgres:16-alpine")
+        val pg = PostgreSQLContainer("postgres:18-alpine")
         pg.start()
         container = pg
         db = createR2dbcDatabase(

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcIntegrationTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcIntegrationTest.kt
@@ -40,7 +40,7 @@ class R2dbcIntegrationTest {
     @BeforeTest
     fun setUp() {
         if (!dockerAvailable) return
-        val pg = PostgreSQLContainer("postgres:16-alpine")
+        val pg = PostgreSQLContainer("postgres:18-alpine")
         pg.start()
         container = pg
         db = createR2dbcDatabase(

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcLifecycleTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcLifecycleTest.kt
@@ -22,7 +22,7 @@ class R2dbcLifecycleTest {
     private val dockerAvailable = DockerClientFactory.instance().isDockerAvailable
 
     private fun withDb(block: (db: io.github.kormium.database.SuspendDatabase<R2Catalog>) -> Unit) {
-        val pg = PostgreSQLContainer("postgres:16-alpine")
+        val pg = PostgreSQLContainer("postgres:18-alpine")
         pg.start()
         try {
             val db = createR2dbcDatabase(

--- a/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcTransactionOptionsTest.kt
+++ b/kormium-r2dbc/src/jvmTest/kotlin/io/github/kormium/r2dbc/R2dbcTransactionOptionsTest.kt
@@ -29,7 +29,7 @@ class R2dbcTransactionOptionsTest {
     @BeforeTest
     fun setUp() {
         if (!dockerAvailable) return
-        val pg = PostgreSQLContainer("postgres:16-alpine")
+        val pg = PostgreSQLContainer("postgres:18-alpine")
         pg.start()
         container = pg
         db = createR2dbcDatabase(

--- a/readme.md
+++ b/readme.md
@@ -111,9 +111,9 @@ against a genuine SQLite library (in-memory) on every target.
 **Kotlin/Native, against live servers.** Testcontainers is a JVM library, so the
 native path takes a different route: the `linuxX64` and `mingwX64` test
 executables link the real `libpq` / `libsqlite3` / `libmariadb` and connect to a
-**PostgreSQL 16** and **MariaDB 11** server provisioned by CI (service containers
-on Linux, the preinstalled PostgreSQL service on Windows). The native drivers are
-validated end-to-end, not just compiled.
+**PostgreSQL 18** and **MariaDB 11** server provisioned by CI as service containers
+on Linux; on Windows the runner image's own preinstalled PostgreSQL service backs the
+libpq tests. The native drivers are validated end-to-end, not just compiled.
 
 **Platform matrix (CI).**
 

--- a/samples/cross-instance-cache/docker-compose.yml
+++ b/samples/cross-instance-cache/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     environment:
       POSTGRES_PASSWORD: password
     ports:

--- a/samples/ktor-di/docker-compose.yml
+++ b/samples/ktor-di/docker-compose.yml
@@ -4,7 +4,7 @@
 # (localhost:5432, user/db "postgres", password "password").
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     container_name: kormium-ktor-di-postgres
     environment:
       POSTGRES_PASSWORD: password

--- a/samples/ktor-di/src/jvmTest/kotlin/KtorDiTest.kt
+++ b/samples/ktor-di/src/jvmTest/kotlin/KtorDiTest.kt
@@ -29,7 +29,7 @@ class KtorDiTest {
     fun createThenList() {
         if (!DockerClientFactory.instance().isDockerAvailable) return // skip without Docker
 
-        val pg = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+        val pg = PostgreSQLContainer("postgres:18-alpine").apply { start() }
         try {
             val db: SuspendDatabase<AppCatalog> = createDatabase(
                 host = pg.host,

--- a/samples/ktor-koin/docker-compose.yml
+++ b/samples/ktor-koin/docker-compose.yml
@@ -4,7 +4,7 @@
 # (localhost:5432, user/db "postgres", password "password").
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     container_name: kormium-ktor-koin-postgres
     environment:
       POSTGRES_PASSWORD: password

--- a/samples/ktor-koin/src/jvmTest/kotlin/KtorKoinTest.kt
+++ b/samples/ktor-koin/src/jvmTest/kotlin/KtorKoinTest.kt
@@ -37,7 +37,7 @@ class KtorKoinTest {
     fun createThenList() {
         if (!DockerClientFactory.instance().isDockerAvailable) return // skip without Docker
 
-        val pg = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+        val pg = PostgreSQLContainer("postgres:18-alpine").apply { start() }
         try {
             val db: SuspendDatabase<AppCatalog> = createDatabase(
                 host = pg.host,

--- a/samples/r2dbc/docker-compose.yml
+++ b/samples/r2dbc/docker-compose.yml
@@ -4,7 +4,7 @@
 # (localhost:5432, user/db "postgres", password "password").
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     container_name: kormium-r2dbc-postgres
     environment:
       POSTGRES_PASSWORD: password

--- a/samples/r2dbc/src/jvmTest/kotlin/R2dbcSampleTest.kt
+++ b/samples/r2dbc/src/jvmTest/kotlin/R2dbcSampleTest.kt
@@ -29,7 +29,7 @@ class R2dbcSampleTest {
     fun createThenList() {
         if (!DockerClientFactory.instance().isDockerAvailable) return // skip without Docker
 
-        val pg = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+        val pg = PostgreSQLContainer("postgres:18-alpine").apply { start() }
         try {
             val db: SuspendDatabase<AppCatalog> = createR2dbcDatabase(
                 host = pg.host,

--- a/samples/sqlite-cache/docker-compose.yml
+++ b/samples/sqlite-cache/docker-compose.yml
@@ -4,7 +4,7 @@
 # (localhost:5432, user/db "postgres", password "password"). The SQLite cache is in-memory.
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     container_name: kormium-sqlite-cache-postgres
     environment:
       POSTGRES_PASSWORD: password

--- a/samples/sqlite-cache/src/jvmTest/kotlin/SqliteCacheTest.kt
+++ b/samples/sqlite-cache/src/jvmTest/kotlin/SqliteCacheTest.kt
@@ -20,7 +20,7 @@ class SqliteCacheTest {
     fun readThroughHitMissPopulate() {
         if (!DockerClientFactory.instance().isDockerAvailable) return // skip without Docker
 
-        val pg = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+        val pg = PostgreSQLContainer("postgres:18-alpine").apply { start() }
         try {
             val pgDb: Database<PgCatalog> = createDatabase(
                 host = pg.host,


### PR DESCRIPTION
## What this is

An answer to "should we update libpq?" — with the finding that **there is no libpq version to update**. It is neither vendored nor pinned: `kormium-postgres` cinterops against the system library, and CI installs it unversioned (`apt-get install libpq-dev`, `brew install libpq`, `pacman -S mingw-w64-x86_64-postgresql`), so it already tracks whatever the platform ships. Every libpq entry point the native driver calls — `PQconnectdbParams`, `PQsendQueryParams`, `PQsetnonblocking`, `PQisBusy`, `PQsocket`, `PQnotifies`, `PQresultErrorField` — has been available since PostgreSQL 9.

So what actually needed attention was the *tested* baseline and some rotted paths. No driver code changes here.

## Server baseline: 16 → 18

- `.github/workflows/ci.yml` service container → `postgres:18`
- Every Testcontainers fixture in `kormium-postgres`, `kormium-r2dbc`, `samples/*` and `benchmarks` → `postgres:18-alpine`
- `PgVectorIntegrationTest` → `pgvector/pgvector:pg18`
- All five sample `docker-compose.yml` files
- Docs that quote the baseline: `docs/compatibility.md`, `readme.md`, `benchmarks/README.md`, `docs/tables-and-entities.md` (`postgresql-18-pgvector`)

### The one non-obvious part

PostgreSQL 18's official image **moved its default `PGDATA`** out of `/var/lib/postgresql/data` — which is precisely where the benchmark harness mounts its tmpfs. A plain tag bump would have left that mount unused and quietly relocated the benchmarks onto overlayfs, i.e. a silent measurement regression with no error anywhere. All four call sites (`run.sh`, `run.bat`, and the two JMH classes' `withTmpFs`) now pin `PGDATA=/var/lib/postgresql/data` explicitly, so behaviour is identical to before.

## libpq.def cleanup

- Dropped the dead `-L/usr/lib/postgresql/13/lib` (PostgreSQL 13 went EOL in November 2025)
- Fixed a malformed linuxbrew path: `.../opt/libpq/libpkg-config` → `.../opt/libpq/lib` (looks like a truncated `pkg-config` that got glued onto `lib`)
- Removed a stray `-lpq` from `compilerOpts.linux` / `.osx`, where a linker flag does nothing — it is already in `linkerOpts`
- Extended the Windows include search to `C:\Program Files\PostgreSQL\14..18` so it matches the `18 downTo 14` range `kormium-postgres/build.gradle.kts` scans for the link-time artifact, and `docs/installation.md`, which claimed a third range (`15..17`). Both code sites now carry a comment pointing at the other.

Also corrected `readme.md`: it read as though CI provisions the quoted PostgreSQL version on both Linux and Windows, but the Windows native tests run against the runner image's own preinstalled service, whose version we do not control.

## Verification

- `:benchmarks:compileJmhKotlin` and `:kormium-postgres:compileTestKotlinJvm` compile clean
- All changed YAML parses; `pgvector/pgvector:pg18` and `postgres:18-alpine` tags confirmed to exist
- `benchmarks/run.bat` keeps its CRLF endings (`.gitattributes` marks `*.bat eol=crlf` because cmd.exe misparses LF-only batch files)
- The native cinterop path can only be validated by CI — this machine has no `libpq-dev`
- `reports/08-jvm-vs-native.md` deliberately still says PostgreSQL 16: it records an actual measurement run
- pgjdbc (42.7.13) and testcontainers (1.21.4) are already at their latest releases — nothing to bump

`## [Unreleased]` in the changelog is updated, as `docs/compatibility.md` requires for baseline changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjDe4hFmVHTCUZeux9NXc7
