### PR TITLE
feat(sqlite-wasm): load extensions at runtime in the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Kormium are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Browser extensions actually load.** `loadLibrary` on the wa-sqlite engines (`kormium-sqlite-wasm`
+  and `kormium-sqlite-js`) fetches the extension as an Emscripten side module, writes it into the
+  virtual filesystem and has SQLite `dlopen` it — the mechanism proven in
+  [sqlite-wasm-engines](https://github.com/kormium/sqlite-wasm-engines), now reachable from
+  `sqlite { extension(...) }`. It needs an engine built with dynamic linking, so the capability is
+  probed and the failure names the build that can do it
+  (`@kormium/wa-sqlite-loadable`) rather than surfacing as a missing symbol. Extension loading is
+  armed only for the duration of the call: leaving `load_extension()` enabled would let any SQL in
+  the page load code. The Worker-hosted engines still refuse — they expose neither the module nor
+  the database handle.
+
 ## [0.13.0] — SQLite extensions
 
 ### Added

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -198,7 +198,8 @@ Every engine applies `pragma(...)`. Loading an extension differs:
 | Native / iOS | yes | the package links its own static library and registers it before the pool opens |
 | Node (better-sqlite3) | yes | `loadExtension()` when the connection is opened |
 | Android (androidx) | yes | registered process-wide via `sqlite3_auto_extension`, through Kormium's JNI shim (`kormium-sqlite-android-ext`); the package ships only its `.so` per ABI |
-| Browser (wa-sqlite, sqlite-wasm) | with the loadable build | an extension is a *different* WASM build; pass it via the `engine` parameter (`SqliteWasmEngine` / `SqliteJsEngine`). The default is upstream's, compiled with `SQLITE_OMIT_LOAD_EXTENSION`; [sqlite-wasm-engines](https://github.com/kormium/sqlite-wasm-engines) publishes an extension-capable one |
+| Browser (wa-sqlite) | with the loadable build | the extension is fetched as an Emscripten side module, written into the virtual filesystem and `dlopen`ed. Needs an engine built for it — pass `@kormium/wa-sqlite-loadable` via the `engine` parameter; the default is upstream's, compiled with `SQLITE_OMIT_LOAD_EXTENSION` |
+| Browser (Worker engines) | no | SQLite runs in a Worker, which exposes neither the module nor the database handle; use a build with the extension compiled in |
 
 An extension declares the engines it supports, and a driver rejects one it was not built for while
 opening the database — by name, rather than leaving it to surface as `no such module` later. The

--- a/kormium-sqlite-js/src/jsMain/kotlin/io/github/kormium/sqlite/js/JsExtensionLoader.kt
+++ b/kormium-sqlite-js/src/jsMain/kotlin/io/github/kormium/sqlite/js/JsExtensionLoader.kt
@@ -1,0 +1,78 @@
+package io.github.kormium.sqlite.js
+
+import io.github.kormium.SqliteEngine
+import io.github.kormium.SqliteExtensionUnsupportedException
+import kotlinx.coroutines.await
+import kotlin.js.Promise
+
+/** Whether the Emscripten module exports [name] — how a build's capabilities are discovered. */
+private fun moduleHasExport(module: Any, name: String): Boolean =
+    js("typeof module[name] === 'function'") as Boolean
+
+/** Fetches the side module. A browser cannot read it off disk, so it arrives over the network. */
+private fun fetchArrayBuffer(url: String): Promise<Any> =
+    js("fetch(url).then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status + ' for ' + url); return r.arrayBuffer(); })") as Promise<Any>
+
+/** Places the side module in Emscripten's virtual filesystem, which is where dlopen looks. */
+private fun writeToFs(module: Any, path: String, bytes: Any) {
+    js("module.FS.writeFile(path, new Uint8Array(bytes))")
+}
+
+private fun enableLoadExtension(module: Any, db: Int, on: Int) {
+    js("module.ccall('sqlite3_enable_load_extension', 'number', ['number', 'number'], [db, on])")
+}
+
+/**
+ * Loads a SQLite extension into the Kotlin/JS wa-sqlite engine — the sibling of
+ * `kormium-sqlite-wasm`'s loader, and the same mechanism: an extension in the browser is an
+ * Emscripten side module, fetched, written into the virtual filesystem and `dlopen`ed.
+ *
+ * Only an engine built with dynamic linking can do it; Kormium's default is upstream's build,
+ * compiled with `SQLITE_OMIT_LOAD_EXTENSION`, so the capability is probed and the failure names the
+ * fix rather than surfacing as a missing symbol.
+ */
+internal suspend fun loadSideModule(
+    module: Any,
+    db: Int,
+    path: String,
+    entryPoint: String?,
+    exec: suspend (String) -> Unit,
+) {
+    if (!moduleHasExport(module, "_sqlite3_enable_load_extension")) {
+        throw SqliteExtensionUnsupportedException(
+            extension = path,
+            engine = SqliteEngine.WaSqlite,
+            message = "this WASM build cannot load extensions at runtime — it comes from upstream, " +
+                "compiled with SQLITE_OMIT_LOAD_EXTENSION. Pass an extension-capable engine, e.g. " +
+                "@kormium/wa-sqlite-loadable, via the `engine` parameter of createSqliteJsDatabase.",
+        )
+    }
+
+    // SQLite derives the entry point from the file name (vec.so -> sqlite3_vec_init), so the name
+    // is preserved from the URL. It is interpolated into SQL, hence the restriction.
+    val name = path.substringAfterLast('/')
+    require(name.isNotEmpty() && name.all { it == '.' || it == '-' || it == '_' || it.isLetterOrDigit() }) {
+        "the extension file name must be word characters, '.', '-' or '_', was '$name'"
+    }
+    entryPoint?.let {
+        require(it.isNotEmpty() && it.all { c -> c == '_' || c.isLetterOrDigit() }) {
+            "the entry point must be word characters, was '$it'"
+        }
+    }
+
+    writeToFs(module, "/$name", fetchArrayBuffer(path).await())
+
+    // Armed only for this call: leaving load_extension() enabled would let any SQL in the page
+    // load code.
+    enableLoadExtension(module, db, 1)
+    try {
+        val call = if (entryPoint == null) {
+            "select load_extension('/$name')"
+        } else {
+            "select load_extension('/$name', '$entryPoint')"
+        }
+        exec(call)
+    } finally {
+        enableLoadExtension(module, db, 0)
+    }
+}

--- a/kormium-sqlite-js/src/jsMain/kotlin/io/github/kormium/sqlite/js/JsSqliteConnectionScope.kt
+++ b/kormium-sqlite-js/src/jsMain/kotlin/io/github/kormium/sqlite/js/JsSqliteConnectionScope.kt
@@ -1,7 +1,6 @@
 package io.github.kormium.sqlite.js
 
 import io.github.kormium.SqliteEngine
-import io.github.kormium.SqliteExtensionUnsupportedException
 import io.github.kormium.SuspendSqliteConnectionScope
 
 /**
@@ -9,12 +8,13 @@ import io.github.kormium.SuspendSqliteConnectionScope
  * `kormium-sqlite-wasm`'s scope. Suspend because wa-sqlite's IndexedDB VFS is asynchronous
  * (Asyncify), so there is no blocking call to build a [io.github.kormium.SqliteConnectionScope] on.
  *
- * `loadLibrary` is not available: the upstream WASM build is compiled with
- * `SQLITE_OMIT_LOAD_EXTENSION` (ADR 0013, decision 7). Pragmas and probes work today.
+ * `loadLibrary` goes through the engine that owns the Emscripten module and the database handle;
+ * whether the build can actually load anything is probed there.
  */
 internal class JsSqliteConnectionScope(
     private val runStatement: suspend (String) -> Unit,
     private val readScalar: suspend (String) -> String?,
+    private val loader: suspend (String, String?) -> Unit,
 ) : SuspendSqliteConnectionScope {
 
     override val engine: SqliteEngine get() = SqliteEngine.WaSqlite
@@ -25,12 +25,7 @@ internal class JsSqliteConnectionScope(
 
     override suspend fun queryScalar(sql: String): String? = runCatching { readScalar(sql) }.getOrNull()
 
-    override suspend fun loadLibrary(path: String, entryPoint: String?): Nothing =
-        throw SqliteExtensionUnsupportedException(
-            extension = path,
-            engine = engine,
-            message = "loading a SQLite extension at runtime is not available on the $engine " +
-                "engine: its WASM build comes from upstream and is compiled with " +
-                "SQLITE_OMIT_LOAD_EXTENSION. An extension compiled into the engine still works.",
-        )
+    override suspend fun loadLibrary(path: String, entryPoint: String?) {
+        loader(path, entryPoint)
+    }
 }

--- a/kormium-sqlite-js/src/jsMain/kotlin/io/github/kormium/sqlite/js/SqliteJsDatabase.kt
+++ b/kormium-sqlite-js/src/jsMain/kotlin/io/github/kormium/sqlite/js/SqliteJsDatabase.kt
@@ -43,11 +43,13 @@ public class SqliteJsDatabase internal constructor(
     private val executor = WaSqliteExecutor(api, db, SqliteDialect, StandardTypeMapper)
 
     /** Applies the caller's [SqliteOptions] to this connection; see the factory below. */
-    internal suspend fun applyOptions(options: SqliteOptions) {
+    internal suspend fun applyOptions(options: SqliteOptions, module: Any) {
+        val exec: suspend (String) -> Unit = { sql -> executor.execute(sql, emptyMap()) }
         options.suspendApplyTo(
             JsSqliteConnectionScope(
-                runStatement = { sql -> executor.execute(sql, emptyMap()) },
+                runStatement = exec,
                 readScalar = { sql -> executor.execute(sql, emptyMap()) { it.getString(0) }.firstOrNull() },
+                loader = { path, entryPoint -> loadSideModule(module, db, path, entryPoint, exec) },
             ),
         )
     }
@@ -114,7 +116,7 @@ public suspend fun createSqliteJsDatabase(
     check(db != 0) { "wa-sqlite open_v2 returned a null database handle (dataDir=$dataDir)" }
     val database = SqliteJsDatabase(api, db, config)
     try {
-        database.applyOptions(options)
+        database.applyOptions(options, module)
     } catch (e: Throwable) {
         runCatching { database.close() }
         throw e

--- a/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/SqliteWasmDatabase.kt
+++ b/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/SqliteWasmDatabase.kt
@@ -42,13 +42,21 @@ public class SqliteWasmDatabase internal constructor(
 
     private val executor = WaSqliteExecutor(api, db, SqliteDialect, StandardTypeMapper)
 
-    /** Applies the caller's [SqliteOptions] to this connection; see the factory below. */
-    internal suspend fun applyOptions(options: SqliteOptions) {
+    /**
+     * Applies the caller's [SqliteOptions] to this connection; see the factory below. [module] is
+     * the Emscripten module behind [api] — an extension is a side module written into its virtual
+     * filesystem, so loading one needs the module itself, not just the SQLite API over it.
+     */
+    internal suspend fun applyOptions(options: SqliteOptions, module: JsAny) {
+        val exec: suspend (String) -> Unit = { sql -> executor.execute(sql, emptyMap()) }
         options.suspendApplyTo(
             WasmSqliteConnectionScope(
                 engine = SqliteEngine.WaSqlite,
-                runStatement = { sql -> executor.execute(sql, emptyMap()) },
+                runStatement = exec,
                 readScalar = { sql -> executor.execute(sql, emptyMap()) { it.getString(0) }.firstOrNull() },
+                loader = { path, entryPoint ->
+                    loadSideModule(module, db, SqliteEngine.WaSqlite, path, entryPoint, exec)
+                },
             ),
         )
     }
@@ -122,7 +130,7 @@ public suspend fun createSqliteWasmDatabase(
     // A connection that cannot be prepared must not be handed out: close it and let the failure
     // surface here rather than at the first query.
     try {
-        database.applyOptions(options)
+        database.applyOptions(options, module)
     } catch (e: Throwable) {
         runCatching { database.close() }
         throw e

--- a/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/WasmExtensionLoader.kt
+++ b/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/WasmExtensionLoader.kt
@@ -1,0 +1,81 @@
+package io.github.kormium.sqlite.wasm
+
+import io.github.kormium.SqliteEngine
+import io.github.kormium.SqliteExtensionUnsupportedException
+import kotlinx.coroutines.await
+import kotlin.js.Promise
+
+/** Whether the Emscripten module exports [name] — how a build's capabilities are discovered. */
+private fun moduleHasExport(module: JsAny, name: String): Boolean =
+    js("typeof module[name] === 'function'")
+
+/** Fetches the side module. A browser cannot read it off disk, so it arrives over the network. */
+private fun fetchArrayBuffer(url: String): Promise<JsAny> =
+    js("fetch(url).then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status + ' for ' + url); return r.arrayBuffer(); })")
+
+/** Places the side module in Emscripten's virtual filesystem, which is where dlopen looks. */
+private fun writeToFs(module: JsAny, path: String, bytes: JsAny) {
+    js("module.FS.writeFile(path, new Uint8Array(bytes))")
+}
+
+private fun enableLoadExtension(module: JsAny, db: JsNumber, on: Int): Int =
+    js("module.ccall('sqlite3_enable_load_extension', 'number', ['number', 'number'], [db, on])")
+
+/**
+ * Loads a SQLite extension into a wa-sqlite engine at runtime.
+ *
+ * In the browser an extension is an Emscripten **side module**: it is fetched, written into the
+ * virtual filesystem and `dlopen`ed by SQLite. That only works on an engine built with dynamic
+ * linking — Kormium's default is upstream's build, compiled with `SQLITE_OMIT_LOAD_EXTENSION`, so
+ * the capability is probed rather than assumed and the failure names the fix.
+ *
+ * SQLite derives the entry point from the file name (`vec.so` looks up `sqlite3_vec_init`), so the
+ * name is preserved from [path] rather than invented here.
+ */
+internal suspend fun loadSideModule(
+    module: JsAny,
+    db: JsNumber,
+    engine: SqliteEngine,
+    path: String,
+    entryPoint: String?,
+    exec: suspend (String) -> Unit,
+) {
+    if (!moduleHasExport(module, "_sqlite3_enable_load_extension")) {
+        throw SqliteExtensionUnsupportedException(
+            extension = path,
+            engine = engine,
+            message = "this WASM build cannot load extensions at runtime — it comes from upstream, " +
+                "compiled with SQLITE_OMIT_LOAD_EXTENSION. Pass an extension-capable engine, e.g. " +
+                "@kormium/wa-sqlite-loadable, via the `engine` parameter of createSqliteWasmDatabase.",
+        )
+    }
+
+    val name = path.substringAfterLast('/')
+    // The name is interpolated into SQL, and it comes from a URL. Nothing legitimate here is more
+    // than a file name.
+    require(name.isNotEmpty() && name.all { it == '.' || it == '-' || it == '_' || it.isLetterOrDigit() }) {
+        "the extension file name must be word characters, '.', '-' or '_', was '$name'"
+    }
+    entryPoint?.let {
+        require(it.isNotEmpty() && it.all { c -> c == '_' || c.isLetterOrDigit() }) {
+            "the entry point must be word characters, was '$it'"
+        }
+    }
+
+    writeToFs(module, "/$name", fetchArrayBuffer(path).await<JsAny>())
+
+    // Armed only for this call: leaving load_extension() enabled would let any SQL in the page
+    // load code. There is no db_config equivalent reachable from JS here, so this is the C API's
+    // coarser switch, turned straight back off.
+    enableLoadExtension(module, db, 1)
+    try {
+        val call = if (entryPoint == null) {
+            "select load_extension('/$name')"
+        } else {
+            "select load_extension('/$name', '$entryPoint')"
+        }
+        exec(call)
+    } finally {
+        enableLoadExtension(module, db, 0)
+    }
+}

--- a/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/WasmSqliteConnectionScope.kt
+++ b/kormium-sqlite-wasm/src/wasmJsMain/kotlin/io/github/kormium/sqlite/wasm/WasmSqliteConnectionScope.kt
@@ -14,15 +14,15 @@ import io.github.kormium.SuspendSqliteConnectionScope
  * SQLite differently (a `WaSqliteExecutor` here, a `WorkerConnection` there) and all this scope
  * needs from them is "run a statement" and "read one value".
  *
- * `loadLibrary` is not available yet: the WASM builds Kormium currently consumes come from upstream
- * compiled with `SQLITE_OMIT_LOAD_EXTENSION`, so there is nothing to load into. Reaching it needs
- * Kormium's own Emscripten build with dynamic linking (ADR 0013, decision 7). Pragmas and probes
- * work today.
+ * `loadLibrary` is supplied by the engine that has something to load into — today the wa-sqlite
+ * one, which owns the Emscripten module and the database handle. The Worker-hosted engines run
+ * SQLite in another thread and hand out neither, so they leave it null and refuse.
  */
 internal class WasmSqliteConnectionScope(
     override val engine: SqliteEngine,
     private val runStatement: suspend (String) -> Unit,
     private val readScalar: suspend (String) -> String?,
+    private val loader: (suspend (String, String?) -> Unit)? = null,
 ) : SuspendSqliteConnectionScope {
 
     override suspend fun exec(sql: String) {
@@ -31,12 +31,14 @@ internal class WasmSqliteConnectionScope(
 
     override suspend fun queryScalar(sql: String): String? = runCatching { readScalar(sql) }.getOrNull()
 
-    override suspend fun loadLibrary(path: String, entryPoint: String?): Nothing =
-        throw SqliteExtensionUnsupportedException(
+    override suspend fun loadLibrary(path: String, entryPoint: String?) {
+        val load = loader ?: throw SqliteExtensionUnsupportedException(
             extension = path,
             engine = engine,
-            message = "loading a SQLite extension at runtime is not available on the $engine " +
-                "engine: its WASM build comes from upstream and is compiled with " +
-                "SQLITE_OMIT_LOAD_EXTENSION. An extension compiled into the engine still works.",
+            message = "the $engine engine runs SQLite in a Worker and exposes neither the module " +
+                "nor the database handle, so an extension cannot be loaded into it at runtime. " +
+                "Use an engine build with the extension compiled in.",
         )
+        load(path, entryPoint)
+    }
 }

--- a/kormium-sqlite-wasm/src/wasmJsTest/kotlin/io/github/kormium/sqlite/wasm/SqliteWasmOptionsTest.kt
+++ b/kormium-sqlite-wasm/src/wasmJsTest/kotlin/io/github/kormium/sqlite/wasm/SqliteWasmOptionsTest.kt
@@ -24,6 +24,15 @@ private class ServerOnlyExtension : SqliteExtension {
     override val supportedEngines: Set<SqliteEngine> = setOf(SqliteEngine.Xerial, SqliteEngine.Native)
 }
 
+/** Asks the engine to load a side module — which only an extension-capable build can do. */
+private class LoadingExtension : SqliteExtension {
+    override val name: String = "loading"
+    override val supportedEngines: Set<SqliteEngine> = setOf(SqliteEngine.WaSqlite)
+    override suspend fun suspendInstall(connection: SuspendSqliteConnectionScope) {
+        connection.loadLibrary("https://example.invalid/vec.so")
+    }
+}
+
 private class BrowserExtension : SqliteExtension {
     override val name: String = "browser-ok"
     override val supportedEngines: Set<SqliteEngine> = setOf(SqliteEngine.WaSqlite)
@@ -67,6 +76,27 @@ class SqliteWasmOptionsTest {
         } finally {
             db.close()
         }
+    }
+
+    /**
+     * The default engine is upstream's build, compiled with `SQLITE_OMIT_LOAD_EXTENSION`, so it
+     * cannot load anything and must say so by name. The successful path needs the loadable build
+     * and a real fetch, which Node cannot do for a local file — it is covered end to end by
+     * kormium/sqlite-wasm-engines' own smoke tests instead.
+     */
+    @Test
+    fun loadingIntoTheDefaultEngineFailsWithTheFix() = runTest {
+        var failure: SqliteExtensionUnsupportedException? = null
+        try {
+            createSqliteWasmDatabase(moduleConfig = wasmConfig(), options = SqliteOptions(LoadingExtension()))
+        } catch (e: SqliteExtensionUnsupportedException) {
+            failure = e
+        }
+        assertEquals(SqliteEngine.WaSqlite, failure?.engine)
+        assertTrue(
+            failure!!.message!!.contains("wa-sqlite-loadable"),
+            "the message should name the engine that can do it, was: ${failure.message}",
+        )
     }
 
     @Test


### PR DESCRIPTION
`loadLibrary` on the wa-sqlite engines now does what it says: the extension is fetched as an
Emscripten side module, written into the virtual filesystem and `dlopen`ed by SQLite — the mechanism
proven in [sqlite-wasm-engines](https://github.com/kormium/sqlite-wasm-engines), now reachable
through the ordinary `sqlite { extension(...) }` block. Closes the browser half of
[ADR 0013](docs/adr/0013-sqlite-extensions.md).

Applies to both `kormium-sqlite-wasm` and `kormium-sqlite-js`.

## Three deliberate details

- **The capability is probed, not assumed.** Kormium's default engine is upstream's build, compiled
  with `SQLITE_OMIT_LOAD_EXTENSION`. Asking it to load something fails naming the build that can
  (`@kormium/wa-sqlite-loadable`), rather than surfacing later as a missing symbol.
- **Loading is armed only for the duration of the call.** Leaving `load_extension()` enabled would
  let any SQL in the page load code.
- **The file name is preserved from the URL**, because SQLite derives the entry point from it
  (`vec.so` → `sqlite3_vec_init`). Name and entry point reach SQL, so both are restricted to word
  characters.

The Worker-hosted engines still refuse, now with the real reason: SQLite runs in another thread and
neither the module nor the database handle is exposed.

## No API change

The loader and both connection scopes are `internal`, and no api dump moves — this is a behaviour
addition, not a surface change.

## Test coverage, stated plainly

Under Node the test covers the default path: the stock engine refuses and names the fix. The
successful load needs a `fetch`, which Node will not do for a local file, so it stays covered end to
end by `sqlite-wasm-engines`' own smoke tests. That is said in the test's KDoc rather than implying
fuller coverage here.

## Noticed while working

`SqliteJsIntegrationTest.crudRoundTrip` is flaky: it failed once on mocha's 2000 ms timeout, then
passed three runs in a row. Cold WASM instantiation looks like the cause. Not touched here, but it
will redden CI at random and wants a longer timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKQgxJYdJuokocwHqWKWXH